### PR TITLE
fix: correct Google OAuth config key in token refresh

### DIFF
--- a/app/Services/Social/ConnectionVerifier.php
+++ b/app/Services/Social/ConnectionVerifier.php
@@ -182,8 +182,8 @@ class ConnectionVerifier
         $response = Http::asForm()->post('https://oauth2.googleapis.com/token', [
             'grant_type' => 'refresh_token',
             'refresh_token' => $account->refresh_token,
-            'client_id' => config('services.youtube.client_id'),
-            'client_secret' => config('services.youtube.client_secret'),
+            'client_id' => config('services.google.client_id'),
+            'client_secret' => config('services.google.client_secret'),
         ]);
 
         if ($response->failed()) {


### PR DESCRIPTION
Fix Google OAuth config key in service file

Replaced `services.youtube` with `services.google` for client_id and client_secret.
Daily verify command was failing due to incorrect config key.