### PR TITLE
feat: add multipart media upload endpoint and split URL flow

### DIFF
--- a/app/Http/Controllers/Api/PostController.php
+++ b/app/Http/Controllers/Api/PostController.php
@@ -7,8 +7,10 @@ namespace App\Http\Controllers\Api;
 use App\Actions\Post\CreatePost;
 use App\Actions\Post\DeletePost;
 use App\Actions\Post\UpdatePost;
+use App\Enums\Media\Type as MediaType;
 use App\Enums\Post\Action as PostAction;
-use App\Http\Requests\Api\Post\AttachMediaRequest;
+use App\Http\Requests\Api\Post\AttachMediaFromUrlRequest;
+use App\Http\Requests\Api\Post\StoreMediaRequest;
 use App\Http\Requests\Api\Post\StorePostRequest;
 use App\Http\Requests\Api\Post\UpdatePostRequest;
 use App\Http\Resources\Api\PostMediaAttachResource;
@@ -20,6 +22,7 @@ use App\Services\Post\MediaAttacher;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Http\Resources\Json\AnonymousResourceCollection;
+use Illuminate\Validation\ValidationException;
 use Symfony\Component\HttpFoundation\Response;
 
 class PostController extends Controller
@@ -83,7 +86,42 @@ class PostController extends Controller
         return response()->json(null, Response::HTTP_NO_CONTENT);
     }
 
-    public function attachMedia(AttachMediaRequest $request, Post $post): PostMediaAttachResource
+    public function storeMedia(StoreMediaRequest $request, Post $post): PostResource
+    {
+        $this->authorize('update', $post);
+
+        $file = $request->file('media');
+        $type = MediaType::fromMime((string) $file->getMimeType());
+
+        if ($type === null || ! in_array($type, $post->allowedMediaTypes(), true)) {
+            throw ValidationException::withMessages([
+                'media' => 'This file type is not supported by the platforms enabled on the post.',
+            ]);
+        }
+
+        if ($file->getSize() > $type->maxSizeInBytes()) {
+            throw ValidationException::withMessages([
+                'media' => 'File size exceeds the maximum allowed for this media type.',
+            ]);
+        }
+
+        $media = $post->workspace->addMedia($file, 'assets');
+
+        $post->appendMedia([[
+            'id' => $media->id,
+            'path' => $media->path,
+            'url' => $media->url,
+            'type' => $media->type,
+            'mime_type' => $media->mime_type,
+            'original_filename' => $media->original_filename,
+        ]]);
+
+        $post->refresh()->load(['postPlatforms.socialAccount', 'labels']);
+
+        return new PostResource($post);
+    }
+
+    public function attachMediaFromUrl(AttachMediaFromUrlRequest $request, Post $post): PostMediaAttachResource
     {
         $this->authorize('update', $post);
 

--- a/app/Http/Requests/Api/Post/AttachMediaFromUrlRequest.php
+++ b/app/Http/Requests/Api/Post/AttachMediaFromUrlRequest.php
@@ -6,7 +6,7 @@ namespace App\Http\Requests\Api\Post;
 
 use Illuminate\Foundation\Http\FormRequest;
 
-class AttachMediaRequest extends FormRequest
+class AttachMediaFromUrlRequest extends FormRequest
 {
     public function authorize(): bool
     {

--- a/app/Http/Requests/Api/Post/StoreMediaRequest.php
+++ b/app/Http/Requests/Api/Post/StoreMediaRequest.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Requests\Api\Post;
+
+use App\Enums\Media\Type as MediaType;
+use Illuminate\Foundation\Http\FormRequest;
+
+class StoreMediaRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * @return array<string, array<int, string>>
+     */
+    public function rules(): array
+    {
+        $allowedMimes = [
+            ...MediaType::Image->allowedMimeTypes(),
+            ...MediaType::Video->allowedMimeTypes(),
+        ];
+
+        return [
+            // Use the largest per-type cap as the upper bound; per-type
+            // and per-post enforcement happens in the controller.
+            'media' => [
+                'required',
+                'file',
+                'max:'.MediaType::Video->maxSizeInKb(),
+                'mimetypes:'.implode(',', $allowedMimes),
+            ],
+        ];
+    }
+}

--- a/app/Http/Resources/Api/PostMediaAttachResource.php
+++ b/app/Http/Resources/Api/PostMediaAttachResource.php
@@ -9,7 +9,7 @@ use Illuminate\Http\Request;
 use Illuminate\Http\Resources\Json\JsonResource;
 
 /**
- * Wraps a Post with the result of an attach-media operation
+ * Wraps a Post with the result of an attach-media-from-url operation
  * (counts + list of failed URLs).
  */
 class PostMediaAttachResource extends JsonResource

--- a/app/Services/Post/MediaAttacher.php
+++ b/app/Services/Post/MediaAttacher.php
@@ -11,7 +11,8 @@ use RuntimeException;
 
 /**
  * Downloads public URLs and attaches them as media to a post — used by
- * the MCP `AttachMediaFromUrlTool` and the REST attach-media endpoint.
+ * the MCP `AttachMediaFromUrlTool` and the REST `attach-media-from-url`
+ * endpoint.
  *
  * URL syntax + DNS resolvability are validated at the request layer
  * (`url:http,https`, `active_url`). Locking, intersection of accepted

--- a/routes/api.php
+++ b/routes/api.php
@@ -18,7 +18,8 @@ Route::middleware(['auth:api', 'workspace.token', 'throttle:api'])->group(functi
     Route::get('/posts/{post}', [PostController::class, 'show'])->name('api.posts.show');
     Route::put('/posts/{post}', [PostController::class, 'update'])->name('api.posts.update');
     Route::delete('/posts/{post}', [PostController::class, 'destroy'])->name('api.posts.destroy');
-    Route::post('/posts/{post}/media', [PostController::class, 'attachMedia'])->name('api.posts.attach-media');
+    Route::post('/posts/{post}/media', [PostController::class, 'storeMedia'])->name('api.posts.store-media');
+    Route::post('/posts/{post}/media/from-url', [PostController::class, 'attachMediaFromUrl'])->name('api.posts.attach-media-from-url');
     Route::get('/posts/{post}/metrics', [PostController::class, 'metrics'])->name('api.posts.metrics');
     Route::get('/posts/{post}/preview', [PostController::class, 'preview'])->name('api.posts.preview');
 

--- a/tests/Feature/Api/PostMediaApiTest.php
+++ b/tests/Feature/Api/PostMediaApiTest.php
@@ -8,6 +8,7 @@ use App\Models\Post;
 use App\Models\PostPlatform;
 use App\Models\SocialAccount;
 use App\Models\Workspace;
+use Illuminate\Http\UploadedFile;
 use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Storage;
 
@@ -46,7 +47,7 @@ it('attaches media from url', function () {
     ]);
 
     $this->withHeaders(['Authorization' => 'Bearer '.$this->plainToken])
-        ->postJson(route('api.posts.attach-media', $this->post), [
+        ->postJson(route('api.posts.attach-media-from-url', $this->post), [
             'urls' => ['https://example.com/photo.png'],
         ])
         ->assertOk()
@@ -63,7 +64,7 @@ it('reports failures for unreachable urls', function () {
     ]);
 
     $this->withHeaders(['Authorization' => 'Bearer '.$this->plainToken])
-        ->postJson(route('api.posts.attach-media', $this->post), [
+        ->postJson(route('api.posts.attach-media-from-url', $this->post), [
             'urls' => ['https://example.com/missing.png'],
         ])
         ->assertOk()
@@ -76,7 +77,7 @@ it('cannot attach media to a post from another workspace', function () {
     $post = Post::factory()->create(['workspace_id' => $other->id, 'user_id' => $this->user->id]);
 
     $this->withHeaders(['Authorization' => 'Bearer '.$this->plainToken])
-        ->postJson(route('api.posts.attach-media', $post), [
+        ->postJson(route('api.posts.attach-media-from-url', $post), [
             'urls' => ['https://example.com/photo.png'],
         ])
         ->assertNotFound();
@@ -143,7 +144,78 @@ it('cannot get metrics from another workspace post', function () {
 
 it('rejects attach media payload without urls', function () {
     $this->withHeaders(['Authorization' => 'Bearer '.$this->plainToken])
-        ->postJson(route('api.posts.attach-media', $this->post), [])
+        ->postJson(route('api.posts.attach-media-from-url', $this->post), [])
         ->assertUnprocessable()
         ->assertJsonValidationErrors(['urls']);
+});
+
+it('uploads a media file and attaches it to the post', function () {
+    $file = UploadedFile::fake()->createWithContent(
+        'photo.png',
+        file_get_contents(__DIR__.'/../../fixtures/1x1.png'),
+    );
+
+    $this->withHeaders(['Authorization' => 'Bearer '.$this->plainToken, 'Accept' => 'application/json'])
+        ->post(route('api.posts.store-media', $this->post), ['media' => $file])
+        ->assertOk();
+
+    expect(Media::where('mediable_id', $this->workspace->id)->count())->toBe(1);
+    expect($this->post->fresh()->media)->toHaveCount(1);
+});
+
+it('rejects upload of an unsupported mime type', function () {
+    $file = UploadedFile::fake()->createWithContent('doc.txt', 'plain text content');
+
+    $this->withHeaders(['Authorization' => 'Bearer '.$this->plainToken, 'Accept' => 'application/json'])
+        ->post(route('api.posts.store-media', $this->post), ['media' => $file])
+        ->assertUnprocessable()
+        ->assertJsonValidationErrors(['media']);
+});
+
+it('rejects upload when the file type is not supported by enabled platforms', function () {
+    $tiktokAccount = SocialAccount::factory()->tiktok()->create([
+        'workspace_id' => $this->workspace->id,
+    ]);
+
+    $tiktokOnlyPost = Post::factory()->create([
+        'workspace_id' => $this->workspace->id,
+        'user_id' => $this->user->id,
+    ]);
+
+    PostPlatform::factory()->tiktok()->create([
+        'post_id' => $tiktokOnlyPost->id,
+        'social_account_id' => $tiktokAccount->id,
+        'enabled' => true,
+    ]);
+
+    $file = UploadedFile::fake()->createWithContent(
+        'photo.png',
+        file_get_contents(__DIR__.'/../../fixtures/1x1.png'),
+    );
+
+    $this->withHeaders(['Authorization' => 'Bearer '.$this->plainToken, 'Accept' => 'application/json'])
+        ->post(route('api.posts.store-media', $tiktokOnlyPost), ['media' => $file])
+        ->assertUnprocessable()
+        ->assertJsonValidationErrors(['media']);
+});
+
+it('cannot upload media to a post from another workspace', function () {
+    $other = Workspace::factory()->create();
+    $post = Post::factory()->create(['workspace_id' => $other->id, 'user_id' => $this->user->id]);
+
+    $file = UploadedFile::fake()->createWithContent(
+        'photo.png',
+        file_get_contents(__DIR__.'/../../fixtures/1x1.png'),
+    );
+
+    $this->withHeaders(['Authorization' => 'Bearer '.$this->plainToken, 'Accept' => 'application/json'])
+        ->post(route('api.posts.store-media', $post), ['media' => $file])
+        ->assertNotFound();
+});
+
+it('rejects upload without a media file', function () {
+    $this->withHeaders(['Authorization' => 'Bearer '.$this->plainToken])
+        ->postJson(route('api.posts.store-media', $this->post), [])
+        ->assertUnprocessable()
+        ->assertJsonValidationErrors(['media']);
 });


### PR DESCRIPTION
## Summary

- Adds `POST /api/posts/{post}/media` for direct file (multipart) upload — closes the bytes-upload gap previously only the web app had.
- Renames the existing URL-based attach endpoint to `POST /api/posts/{post}/media/from-url` (route name `api.posts.attach-media-from-url`, controller method `attachMediaFromUrl`) so the path matches HTTP semantics — `POST <resource>/media` is expected to take a file body, not JSON URLs.

## Why

Until now, attaching media via REST/MCP was URL-only (`MediaAttacher::attachFromUrls`). For SDK/curl callers that have local bytes (no public URL), there was no way in. ChatGPT's MCP integration can't pass binary either, but custom apps and direct-API users now have a proper multipart path.

Mirrors Postiz's split (`/upload` vs `/upload-from-url`), with one difference of design choice: ours stays post-scoped (one round-trip = upload + attach) instead of workspace-scoped media library. Can revisit later if a media-library use case shows up.

## Validation flow on `storeMedia`

1. `StoreMediaRequest`: `mimetypes` allow-list (image/jpeg, png, gif, webp, video/mp4, quicktime) + global `max` (video cap).
2. Controller: `MediaType::fromMime()` → check intersection with `$post->allowedMediaTypes()` (e.g. TikTok-only post + image upload → 422).
3. Controller: per-type `maxSizeInBytes()` cap.
4. Reuses `Workspace::addMedia` (PNG/WEBP → JPEG normalization) + `Post::appendMedia` (lockForUpdate JSON merge).

## MCP

No changes. `AttachMediaFromUrlTool` was already named correctly. Binary upload via MCP isn't supported by any MCP server (Postiz included) — it's a protocol limitation: tool inputs are JSON, no binary type. SDK/custom clients use the new REST endpoint.

## Test plan

- [x] `tests/Feature/Api/PostMediaApiTest.php` — 12 tests pass (5 new for multipart: success, unsupported MIME, type-platform mismatch, cross-workspace 404, missing field; 4 existing renamed for `attach-media-from-url`).
- [x] Full Feature/Api suite: 89 pass.
- [x] Full Feature/Mcp suite: 75 pass.
- [x] Full suite (parallel): 1368 pass / 2 skipped.
- [x] Pint clean.
- [x] Wayfinder regenerated (`storeMedia`, `attachMediaFromUrl`).

## Breaking change

Route name `api.posts.attach-media` → `api.posts.attach-media-from-url`. URL `/api/posts/{post}/media` (JSON urls[]) → `/api/posts/{post}/media/from-url`. The REST API is fresh (PR #14 merged yesterday), impact should be near zero.