### PR TITLE
fix: let authenticated users connect Google/GitHub from Settings

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -123,7 +123,10 @@ THREADS_CLIENT_SECRET=
 THREADS_CLIENT_REDIRECT="${APP_URL}/accounts/threads/callback"
 
 # Google (https://console.cloud.google.com)
-# Used for YouTube social account connection AND Google login/signup
+# Used for YouTube social account connection AND Google login/signup.
+# Register BOTH callback URLs in the OAuth app's authorized redirect URIs:
+#   - ${APP_URL}/auth/google/callback                                   (signup/login)
+#   - ${APP_URL}/settings/authentication/providers/google/callback      (link from Settings)
 GOOGLE_AUTH_ENABLED=false
 GOOGLE_CLIENT_ID=
 GOOGLE_CLIENT_SECRET=
@@ -131,7 +134,10 @@ GOOGLE_CLIENT_REDIRECT="${APP_URL}/accounts/youtube/callback"
 GOOGLE_AUTH_CALLBACK="${APP_URL}/auth/google/callback"
 
 # GitHub (https://github.com/settings/developers)
-# Used for GitHub login/signup
+# Used for GitHub login/signup.
+# Register BOTH callback URLs in the OAuth app's authorized redirect URIs:
+#   - ${APP_URL}/auth/github/callback                                   (signup/login)
+#   - ${APP_URL}/settings/authentication/providers/github/callback      (link from Settings)
 GITHUB_AUTH_ENABLED=false
 GITHUB_CLIENT_ID=
 GITHUB_CLIENT_SECRET=

--- a/.env.example
+++ b/.env.example
@@ -123,10 +123,7 @@ THREADS_CLIENT_SECRET=
 THREADS_CLIENT_REDIRECT="${APP_URL}/accounts/threads/callback"
 
 # Google (https://console.cloud.google.com)
-# Used for YouTube social account connection AND Google login/signup.
-# Register BOTH callback URLs in the OAuth app's authorized redirect URIs:
-#   - ${APP_URL}/auth/google/callback                                   (signup/login)
-#   - ${APP_URL}/settings/authentication/providers/google/callback      (link from Settings)
+# Used for YouTube social account connection AND Google login/signup
 GOOGLE_AUTH_ENABLED=false
 GOOGLE_CLIENT_ID=
 GOOGLE_CLIENT_SECRET=
@@ -134,10 +131,7 @@ GOOGLE_CLIENT_REDIRECT="${APP_URL}/accounts/youtube/callback"
 GOOGLE_AUTH_CALLBACK="${APP_URL}/auth/google/callback"
 
 # GitHub (https://github.com/settings/developers)
-# Used for GitHub login/signup.
-# Register BOTH callback URLs in the OAuth app's authorized redirect URIs:
-#   - ${APP_URL}/auth/github/callback                                   (signup/login)
-#   - ${APP_URL}/settings/authentication/providers/github/callback      (link from Settings)
+# Used for GitHub login/signup
 GITHUB_AUTH_ENABLED=false
 GITHUB_CLIENT_ID=
 GITHUB_CLIENT_SECRET=

--- a/app/Http/Controllers/App/Settings/AuthenticationController.php
+++ b/app/Http/Controllers/App/Settings/AuthenticationController.php
@@ -15,6 +15,7 @@ use Illuminate\Validation\Rule;
 use Inertia\Inertia;
 use Inertia\Response;
 use Laravel\Socialite\Facades\Socialite;
+use Laravel\Socialite\Two\AbstractProvider;
 
 class AuthenticationController extends Controller
 {
@@ -68,9 +69,54 @@ class AuthenticationController extends Controller
     {
         abort_unless(in_array($provider, self::PROVIDERS, true), 404);
 
+        return $this->driver($provider)->redirect();
+    }
+
+    public function connectProviderCallback(Request $request, string $provider): RedirectResponse
+    {
+        abort_unless(in_array($provider, self::PROVIDERS, true), 404);
+
+        try {
+            $providerUser = $this->driver($provider)->user();
+        } catch (\Exception) {
+            return redirect()->route('app.authentication.edit')
+                ->with('flash.error', __('settings.authentication.providers.flash_already_linked', ['provider' => ucfirst($provider)]));
+        }
+
+        $user = $request->user();
+        $column = "{$provider}_id";
+        $providerId = (string) $providerUser->getId();
+
+        $existing = User::where($column, $providerId)
+            ->where('id', '!=', $user->id)
+            ->first();
+
+        if ($existing) {
+            return redirect()->route('app.authentication.edit')
+                ->with('flash.error', __('settings.authentication.providers.flash_already_linked', ['provider' => ucfirst($provider)]));
+        }
+
+        if ($user->{$column} !== $providerId) {
+            $user->update([$column => $providerId]);
+        }
+
+        return redirect()->route('app.authentication.edit')
+            ->with('flash.success', __('settings.authentication.providers.flash_connected', ['provider' => ucfirst($provider)]));
+    }
+
+    /**
+     * Build a Socialite driver for the connect flow with its dedicated
+     * callback URL. The signup/login flow uses the driver's default
+     * redirect URL configured in `config/services.php`; here we override
+     * so each flow round-trips through its own route.
+     */
+    private function driver(string $provider): AbstractProvider
+    {
+        $callback = route('app.authentication.connect-provider.callback', $provider);
+
         return match ($provider) {
-            'google' => Socialite::driver('google-auth')->redirect(),
-            'github' => Socialite::driver('github')->scopes(['read:user', 'user:email'])->redirect(),
+            'google' => Socialite::driver('google-auth')->redirectUrl($callback),
+            'github' => Socialite::driver('github')->scopes(['read:user', 'user:email'])->redirectUrl($callback),
         };
     }
 

--- a/app/Http/Controllers/App/Settings/AuthenticationController.php
+++ b/app/Http/Controllers/App/Settings/AuthenticationController.php
@@ -14,6 +14,7 @@ use Illuminate\Support\Facades\DB;
 use Illuminate\Validation\Rule;
 use Inertia\Inertia;
 use Inertia\Response;
+use Laravel\Socialite\Facades\Socialite;
 
 class AuthenticationController extends Controller
 {
@@ -61,6 +62,16 @@ class AuthenticationController extends Controller
             ->delete();
 
         return back()->with('flash.success', __('settings.authentication.sessions.flash_logged_out'));
+    }
+
+    public function connectProvider(string $provider): RedirectResponse
+    {
+        abort_unless(in_array($provider, self::PROVIDERS, true), 404);
+
+        return match ($provider) {
+            'google' => Socialite::driver('google-auth')->redirect(),
+            'github' => Socialite::driver('github')->scopes(['read:user', 'user:email'])->redirect(),
+        };
     }
 
     public function disconnectProvider(Request $request, string $provider): RedirectResponse

--- a/app/Http/Controllers/App/Settings/AuthenticationController.php
+++ b/app/Http/Controllers/App/Settings/AuthenticationController.php
@@ -15,7 +15,6 @@ use Illuminate\Validation\Rule;
 use Inertia\Inertia;
 use Inertia\Response;
 use Laravel\Socialite\Facades\Socialite;
-use Laravel\Socialite\Two\AbstractProvider;
 
 class AuthenticationController extends Controller
 {
@@ -69,54 +68,9 @@ class AuthenticationController extends Controller
     {
         abort_unless(in_array($provider, self::PROVIDERS, true), 404);
 
-        return $this->driver($provider)->redirect();
-    }
-
-    public function connectProviderCallback(Request $request, string $provider): RedirectResponse
-    {
-        abort_unless(in_array($provider, self::PROVIDERS, true), 404);
-
-        try {
-            $providerUser = $this->driver($provider)->user();
-        } catch (\Exception) {
-            return redirect()->route('app.authentication.edit')
-                ->with('flash.error', __('settings.authentication.providers.flash_already_linked', ['provider' => ucfirst($provider)]));
-        }
-
-        $user = $request->user();
-        $column = "{$provider}_id";
-        $providerId = (string) $providerUser->getId();
-
-        $existing = User::where($column, $providerId)
-            ->where('id', '!=', $user->id)
-            ->first();
-
-        if ($existing) {
-            return redirect()->route('app.authentication.edit')
-                ->with('flash.error', __('settings.authentication.providers.flash_already_linked', ['provider' => ucfirst($provider)]));
-        }
-
-        if ($user->{$column} !== $providerId) {
-            $user->update([$column => $providerId]);
-        }
-
-        return redirect()->route('app.authentication.edit')
-            ->with('flash.success', __('settings.authentication.providers.flash_connected', ['provider' => ucfirst($provider)]));
-    }
-
-    /**
-     * Build a Socialite driver for the connect flow with its dedicated
-     * callback URL. The signup/login flow uses the driver's default
-     * redirect URL configured in `config/services.php`; here we override
-     * so each flow round-trips through its own route.
-     */
-    private function driver(string $provider): AbstractProvider
-    {
-        $callback = route('app.authentication.connect-provider.callback', $provider);
-
         return match ($provider) {
-            'google' => Socialite::driver('google-auth')->redirectUrl($callback),
-            'github' => Socialite::driver('github')->scopes(['read:user', 'user:email'])->redirectUrl($callback),
+            'google' => Socialite::driver('google-auth')->redirect(),
+            'github' => Socialite::driver('github')->scopes(['read:user', 'user:email'])->redirect(),
         };
     }
 

--- a/app/Http/Controllers/Auth/GitHubController.php
+++ b/app/Http/Controllers/Auth/GitHubController.php
@@ -35,10 +35,6 @@ class GitHubController extends Controller
             return redirect()->route('login');
         }
 
-        if (Auth::check()) {
-            return $this->connectToCurrentUser(Auth::user(), (string) $githubUser->getId());
-        }
-
         $user = User::where('github_id', (string) $githubUser->getId())
             ->when($githubUser->getEmail(), fn ($query, $email) => $query->orWhere('email', $email))
             ->first();
@@ -54,25 +50,6 @@ class GitHubController extends Controller
         }
 
         return $this->registerNewUser($githubUser);
-    }
-
-    private function connectToCurrentUser(User $user, string $githubId): RedirectResponse
-    {
-        $existing = User::where('github_id', $githubId)
-            ->where('id', '!=', $user->id)
-            ->first();
-
-        if ($existing) {
-            return redirect()->route('app.authentication.edit')
-                ->with('flash.error', __('settings.authentication.providers.flash_already_linked', ['provider' => 'GitHub']));
-        }
-
-        if ($user->github_id !== $githubId) {
-            $user->update(['github_id' => $githubId]);
-        }
-
-        return redirect()->route('app.authentication.edit')
-            ->with('flash.success', __('settings.authentication.providers.flash_connected', ['provider' => 'GitHub']));
     }
 
     private function loginExistingUser(User $user, string $githubId): RedirectResponse

--- a/app/Http/Controllers/Auth/GitHubController.php
+++ b/app/Http/Controllers/Auth/GitHubController.php
@@ -35,6 +35,10 @@ class GitHubController extends Controller
             return redirect()->route('login');
         }
 
+        if (Auth::check()) {
+            return $this->connectToCurrentUser(Auth::user(), (string) $githubUser->getId());
+        }
+
         $user = User::where('github_id', (string) $githubUser->getId())
             ->when($githubUser->getEmail(), fn ($query, $email) => $query->orWhere('email', $email))
             ->first();
@@ -50,6 +54,25 @@ class GitHubController extends Controller
         }
 
         return $this->registerNewUser($githubUser);
+    }
+
+    private function connectToCurrentUser(User $user, string $githubId): RedirectResponse
+    {
+        $existing = User::where('github_id', $githubId)
+            ->where('id', '!=', $user->id)
+            ->first();
+
+        if ($existing) {
+            return redirect()->route('app.authentication.edit')
+                ->with('flash.error', __('settings.authentication.providers.flash_already_linked', ['provider' => 'GitHub']));
+        }
+
+        if ($user->github_id !== $githubId) {
+            $user->update(['github_id' => $githubId]);
+        }
+
+        return redirect()->route('app.authentication.edit')
+            ->with('flash.success', __('settings.authentication.providers.flash_connected', ['provider' => 'GitHub']));
     }
 
     private function loginExistingUser(User $user, string $githubId): RedirectResponse

--- a/app/Http/Controllers/Auth/GitHubController.php
+++ b/app/Http/Controllers/Auth/GitHubController.php
@@ -35,6 +35,13 @@ class GitHubController extends Controller
             return redirect()->route('login');
         }
 
+        // The signup/login redirect is gated by the `guest` middleware and
+        // the connect-from-settings redirect by `auth`, so this is a safe
+        // signal for which flow we came from.
+        if (Auth::check()) {
+            return $this->connectToCurrentUser(Auth::user(), (string) $githubUser->getId());
+        }
+
         $user = User::where('github_id', (string) $githubUser->getId())
             ->when($githubUser->getEmail(), fn ($query, $email) => $query->orWhere('email', $email))
             ->first();
@@ -50,6 +57,25 @@ class GitHubController extends Controller
         }
 
         return $this->registerNewUser($githubUser);
+    }
+
+    private function connectToCurrentUser(User $user, string $githubId): RedirectResponse
+    {
+        $existing = User::where('github_id', $githubId)
+            ->where('id', '!=', $user->id)
+            ->first();
+
+        if ($existing) {
+            return redirect()->route('app.authentication.edit')
+                ->with('flash.error', __('settings.authentication.providers.flash_already_linked', ['provider' => 'GitHub']));
+        }
+
+        if ($user->github_id !== $githubId) {
+            $user->update(['github_id' => $githubId]);
+        }
+
+        return redirect()->route('app.authentication.edit')
+            ->with('flash.success', __('settings.authentication.providers.flash_connected', ['provider' => 'GitHub']));
     }
 
     private function loginExistingUser(User $user, string $githubId): RedirectResponse

--- a/app/Http/Controllers/Auth/GoogleController.php
+++ b/app/Http/Controllers/Auth/GoogleController.php
@@ -33,10 +33,6 @@ class GoogleController extends Controller
             return redirect()->route('login');
         }
 
-        if (Auth::check()) {
-            return $this->connectToCurrentUser(Auth::user(), $googleUser->getId());
-        }
-
         $user = User::where('google_id', $googleUser->getId())
             ->orWhere('email', $googleUser->getEmail())
             ->first();
@@ -46,25 +42,6 @@ class GoogleController extends Controller
         }
 
         return $this->registerNewUser($googleUser);
-    }
-
-    private function connectToCurrentUser(User $user, string $googleId): RedirectResponse
-    {
-        $existing = User::where('google_id', $googleId)
-            ->where('id', '!=', $user->id)
-            ->first();
-
-        if ($existing) {
-            return redirect()->route('app.authentication.edit')
-                ->with('flash.error', __('settings.authentication.providers.flash_already_linked', ['provider' => 'Google']));
-        }
-
-        if ($user->google_id !== $googleId) {
-            $user->update(['google_id' => $googleId]);
-        }
-
-        return redirect()->route('app.authentication.edit')
-            ->with('flash.success', __('settings.authentication.providers.flash_connected', ['provider' => 'Google']));
     }
 
     private function loginExistingUser(User $user, string $googleId): RedirectResponse

--- a/app/Http/Controllers/Auth/GoogleController.php
+++ b/app/Http/Controllers/Auth/GoogleController.php
@@ -33,6 +33,13 @@ class GoogleController extends Controller
             return redirect()->route('login');
         }
 
+        // The signup/login redirect is gated by the `guest` middleware and
+        // the connect-from-settings redirect by `auth`, so this is a safe
+        // signal for which flow we came from.
+        if (Auth::check()) {
+            return $this->connectToCurrentUser(Auth::user(), $googleUser->getId());
+        }
+
         $user = User::where('google_id', $googleUser->getId())
             ->orWhere('email', $googleUser->getEmail())
             ->first();
@@ -42,6 +49,25 @@ class GoogleController extends Controller
         }
 
         return $this->registerNewUser($googleUser);
+    }
+
+    private function connectToCurrentUser(User $user, string $googleId): RedirectResponse
+    {
+        $existing = User::where('google_id', $googleId)
+            ->where('id', '!=', $user->id)
+            ->first();
+
+        if ($existing) {
+            return redirect()->route('app.authentication.edit')
+                ->with('flash.error', __('settings.authentication.providers.flash_already_linked', ['provider' => 'Google']));
+        }
+
+        if ($user->google_id !== $googleId) {
+            $user->update(['google_id' => $googleId]);
+        }
+
+        return redirect()->route('app.authentication.edit')
+            ->with('flash.success', __('settings.authentication.providers.flash_connected', ['provider' => 'Google']));
     }
 
     private function loginExistingUser(User $user, string $googleId): RedirectResponse

--- a/app/Http/Controllers/Auth/GoogleController.php
+++ b/app/Http/Controllers/Auth/GoogleController.php
@@ -33,6 +33,10 @@ class GoogleController extends Controller
             return redirect()->route('login');
         }
 
+        if (Auth::check()) {
+            return $this->connectToCurrentUser(Auth::user(), $googleUser->getId());
+        }
+
         $user = User::where('google_id', $googleUser->getId())
             ->orWhere('email', $googleUser->getEmail())
             ->first();
@@ -42,6 +46,25 @@ class GoogleController extends Controller
         }
 
         return $this->registerNewUser($googleUser);
+    }
+
+    private function connectToCurrentUser(User $user, string $googleId): RedirectResponse
+    {
+        $existing = User::where('google_id', $googleId)
+            ->where('id', '!=', $user->id)
+            ->first();
+
+        if ($existing) {
+            return redirect()->route('app.authentication.edit')
+                ->with('flash.error', __('settings.authentication.providers.flash_already_linked', ['provider' => 'Google']));
+        }
+
+        if ($user->google_id !== $googleId) {
+            $user->update(['google_id' => $googleId]);
+        }
+
+        return redirect()->route('app.authentication.edit')
+            ->with('flash.success', __('settings.authentication.providers.flash_connected', ['provider' => 'Google']));
     }
 
     private function loginExistingUser(User $user, string $googleId): RedirectResponse

--- a/lang/en/settings.php
+++ b/lang/en/settings.php
@@ -100,6 +100,8 @@ return [
             'connect' => 'Connect',
             'disconnect' => 'Disconnect',
             'flash_disconnected' => ':provider disconnected successfully.',
+            'flash_connected' => ':provider connected successfully.',
+            'flash_already_linked' => 'That :provider account is already linked to another user.',
             'flash_cannot_disconnect' => 'You cannot disconnect your only sign-in method. Set a password or connect another provider first.',
         ],
     ],

--- a/lang/es/settings.php
+++ b/lang/es/settings.php
@@ -100,6 +100,8 @@ return [
             'connect' => 'Conectar',
             'disconnect' => 'Desconectar',
             'flash_disconnected' => ':provider desconectada correctamente.',
+            'flash_connected' => ':provider conectada correctamente.',
+            'flash_already_linked' => 'Esa cuenta de :provider ya está vinculada a otro usuario.',
             'flash_cannot_disconnect' => 'No puedes desconectar tu único método de inicio de sesión. Define una contraseña o conecta otro proveedor primero.',
         ],
     ],

--- a/lang/pt-BR/settings.php
+++ b/lang/pt-BR/settings.php
@@ -100,6 +100,8 @@ return [
             'connect' => 'Conectar',
             'disconnect' => 'Desconectar',
             'flash_disconnected' => ':provider desconectada com sucesso.',
+            'flash_connected' => ':provider conectada com sucesso.',
+            'flash_already_linked' => 'Essa conta do :provider já está vinculada a outro usuário.',
             'flash_cannot_disconnect' => 'Você não pode desconectar seu único método de login. Defina uma senha ou conecte outro provedor primeiro.',
         ],
     ],

--- a/resources/js/pages/settings/profile/Authentication.vue
+++ b/resources/js/pages/settings/profile/Authentication.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { Form, Head, Link } from '@inertiajs/vue3';
+import { Form, Head } from '@inertiajs/vue3';
 import { IconDeviceDesktop, IconDeviceMobile } from '@tabler/icons-vue';
 import { trans } from 'laravel-vue-i18n';
 import { computed, ref } from 'vue';
@@ -327,18 +327,16 @@ const logoutDialogOpen = ref(false);
                                     {{ $t('settings.authentication.providers.disconnect') }}
                                 </Button>
                             </Form>
-                            <Link
+                            <Button
                                 v-else-if="!account.connected"
+                                variant="outline"
+                                size="sm"
+                                as="a"
                                 :href="connectProvider(account.provider).url"
+                                :data-test="`connect-${account.provider}`"
                             >
-                                <Button
-                                    variant="outline"
-                                    size="sm"
-                                    :data-test="`connect-${account.provider}`"
-                                >
-                                    {{ $t('settings.authentication.providers.connect') }}
-                                </Button>
-                            </Link>
+                                {{ $t('settings.authentication.providers.connect') }}
+                            </Button>
                         </div>
                     </div>
                 </div>

--- a/resources/js/pages/settings/profile/Authentication.vue
+++ b/resources/js/pages/settings/profile/Authentication.vue
@@ -26,11 +26,9 @@ import { Separator } from '@/components/ui/separator';
 import AppLayout from '@/layouts/AppLayout.vue';
 import { isMobileDevice, parseBrowserName, parseOsName } from '@/lib/userAgent';
 import { settings as settingsHub } from '@/routes/app';
-import { edit as editAuthentication } from '@/routes/app/authentication';
+import { connectProvider, edit as editAuthentication } from '@/routes/app/authentication';
 import { preferences as notificationPreferences } from '@/routes/app/notifications';
 import { edit as editProfile } from '@/routes/app/profile';
-import { redirect as githubRedirect } from '@/routes/auth/github';
-import { redirect as googleRedirect } from '@/routes/auth/google';
 import type { BreadcrumbItem } from '@/types';
 
 type Session = {
@@ -66,10 +64,6 @@ const tabs = computed(() => [
     { name: 'notifications', label: trans('settings.nav.notifications'), href: notificationPreferences().url },
 ]);
 
-const providerRedirects: Record<ConnectedAccount['provider'], () => { url: string }> = {
-    google: googleRedirect,
-    github: githubRedirect,
-};
 
 const passwordHeading = computed(() =>
     props.hasPassword
@@ -335,7 +329,7 @@ const logoutDialogOpen = ref(false);
                             </Form>
                             <Link
                                 v-else-if="!account.connected"
-                                :href="providerRedirects[account.provider]().url"
+                                :href="connectProvider(account.provider).url"
                             >
                                 <Button
                                     variant="outline"

--- a/routes/app.php
+++ b/routes/app.php
@@ -251,8 +251,6 @@ Route::middleware(['auth'])->group(function () {
         ->name('app.authentication.destroy-other-sessions');
     Route::get('settings/authentication/providers/{provider}/connect', [AuthenticationController::class, 'connectProvider'])
         ->name('app.authentication.connect-provider');
-    Route::get('settings/authentication/providers/{provider}/callback', [AuthenticationController::class, 'connectProviderCallback'])
-        ->name('app.authentication.connect-provider.callback');
     Route::delete('settings/authentication/providers/{provider}', [AuthenticationController::class, 'disconnectProvider'])
         ->name('app.authentication.disconnect-provider');
 

--- a/routes/app.php
+++ b/routes/app.php
@@ -249,6 +249,8 @@ Route::middleware(['auth'])->group(function () {
         ->name('app.authentication.update-password');
     Route::delete('settings/authentication/sessions', [AuthenticationController::class, 'destroyOtherSessions'])
         ->name('app.authentication.destroy-other-sessions');
+    Route::get('settings/authentication/providers/{provider}/connect', [AuthenticationController::class, 'connectProvider'])
+        ->name('app.authentication.connect-provider');
     Route::delete('settings/authentication/providers/{provider}', [AuthenticationController::class, 'disconnectProvider'])
         ->name('app.authentication.disconnect-provider');
 

--- a/routes/app.php
+++ b/routes/app.php
@@ -251,6 +251,8 @@ Route::middleware(['auth'])->group(function () {
         ->name('app.authentication.destroy-other-sessions');
     Route::get('settings/authentication/providers/{provider}/connect', [AuthenticationController::class, 'connectProvider'])
         ->name('app.authentication.connect-provider');
+    Route::get('settings/authentication/providers/{provider}/callback', [AuthenticationController::class, 'connectProviderCallback'])
+        ->name('app.authentication.connect-provider.callback');
     Route::delete('settings/authentication/providers/{provider}', [AuthenticationController::class, 'disconnectProvider'])
         ->name('app.authentication.disconnect-provider');
 

--- a/routes/auth.php
+++ b/routes/auth.php
@@ -31,15 +31,11 @@ Route::middleware(['guest'])->group(function () {
     Route::post('/reset-password', [NewPasswordController::class, 'store'])->name('password.store');
 
     Route::get('/auth/google/redirect', [GoogleController::class, 'redirect'])->name('auth.google.redirect');
-    Route::get('/auth/github/redirect', [GitHubController::class, 'redirect'])->name('auth.github.redirect');
-});
+    Route::get('/auth/google/callback', [GoogleController::class, 'callback'])->name('auth.google.callback');
 
-// Callbacks must be reachable by both guests (signup/login flow) and
-// authenticated users (connect-from-settings flow). Branching on
-// `Auth::check()` inside the callback is safe because the redirect that
-// initiated the round-trip enforces the right middleware.
-Route::get('/auth/google/callback', [GoogleController::class, 'callback'])->name('auth.google.callback');
-Route::get('/auth/github/callback', [GitHubController::class, 'callback'])->name('auth.github.callback');
+    Route::get('/auth/github/redirect', [GitHubController::class, 'redirect'])->name('auth.github.redirect');
+    Route::get('/auth/github/callback', [GitHubController::class, 'callback'])->name('auth.github.callback');
+});
 
 Route::middleware(['auth'])->group(function () {
     Route::get('/register/success', SignupSuccessController::class)->name('register.success');

--- a/routes/auth.php
+++ b/routes/auth.php
@@ -31,11 +31,15 @@ Route::middleware(['guest'])->group(function () {
     Route::post('/reset-password', [NewPasswordController::class, 'store'])->name('password.store');
 
     Route::get('/auth/google/redirect', [GoogleController::class, 'redirect'])->name('auth.google.redirect');
-    Route::get('/auth/google/callback', [GoogleController::class, 'callback'])->name('auth.google.callback');
-
     Route::get('/auth/github/redirect', [GitHubController::class, 'redirect'])->name('auth.github.redirect');
-    Route::get('/auth/github/callback', [GitHubController::class, 'callback'])->name('auth.github.callback');
 });
+
+// Callbacks must be reachable by both guests (signup/login) and authenticated
+// users (connect-from-settings). The redirect routes that initiate the OAuth
+// round-trip enforce the right middleware, so the callback can safely branch
+// on `Auth::check()` to dispatch to the matching flow.
+Route::get('/auth/google/callback', [GoogleController::class, 'callback'])->name('auth.google.callback');
+Route::get('/auth/github/callback', [GitHubController::class, 'callback'])->name('auth.github.callback');
 
 Route::middleware(['auth'])->group(function () {
     Route::get('/register/success', SignupSuccessController::class)->name('register.success');

--- a/routes/auth.php
+++ b/routes/auth.php
@@ -31,11 +31,15 @@ Route::middleware(['guest'])->group(function () {
     Route::post('/reset-password', [NewPasswordController::class, 'store'])->name('password.store');
 
     Route::get('/auth/google/redirect', [GoogleController::class, 'redirect'])->name('auth.google.redirect');
-    Route::get('/auth/google/callback', [GoogleController::class, 'callback'])->name('auth.google.callback');
-
     Route::get('/auth/github/redirect', [GitHubController::class, 'redirect'])->name('auth.github.redirect');
-    Route::get('/auth/github/callback', [GitHubController::class, 'callback'])->name('auth.github.callback');
 });
+
+// Callbacks must be reachable by both guests (signup/login flow) and
+// authenticated users (connect-from-settings flow). Branching on
+// `Auth::check()` inside the callback is safe because the redirect that
+// initiated the round-trip enforces the right middleware.
+Route::get('/auth/google/callback', [GoogleController::class, 'callback'])->name('auth.google.callback');
+Route::get('/auth/github/callback', [GitHubController::class, 'callback'])->name('auth.github.callback');
 
 Route::middleware(['auth'])->group(function () {
     Route::get('/register/success', SignupSuccessController::class)->name('register.success');

--- a/tests/Feature/Auth/ConnectProviderTest.php
+++ b/tests/Feature/Auth/ConnectProviderTest.php
@@ -4,13 +4,15 @@ declare(strict_types=1);
 
 use App\Models\User;
 use Laravel\Socialite\Facades\Socialite;
+use Laravel\Socialite\Two\AbstractProvider;
 use Laravel\Socialite\Two\User as SocialiteUser;
 
 test('authenticated user can hit the connect-provider route for github', function () {
     $user = User::factory()->create();
 
-    $driver = Mockery::mock();
+    $driver = Mockery::mock(AbstractProvider::class);
     $driver->shouldReceive('scopes')->andReturnSelf();
+    $driver->shouldReceive('redirectUrl')->andReturnSelf();
     $driver->shouldReceive('redirect')->andReturn(redirect('https://github.com/login/oauth/authorize'));
     Socialite::shouldReceive('driver')->with('github')->andReturn($driver);
 
@@ -22,7 +24,8 @@ test('authenticated user can hit the connect-provider route for github', functio
 test('authenticated user can hit the connect-provider route for google', function () {
     $user = User::factory()->create();
 
-    $driver = Mockery::mock();
+    $driver = Mockery::mock(AbstractProvider::class);
+    $driver->shouldReceive('redirectUrl')->andReturnSelf();
     $driver->shouldReceive('redirect')->andReturn(redirect('https://accounts.google.com/o/oauth2/auth'));
     Socialite::shouldReceive('driver')->with('google-auth')->andReturn($driver);
 
@@ -44,7 +47,7 @@ test('connect-provider route requires authentication', function () {
         ->assertRedirect(route('login'));
 });
 
-test('authenticated callback connects github to the current user', function () {
+test('connect-provider callback connects github to the current user', function () {
     $user = User::factory()->create([
         'email' => 'me@example.com',
         'google_id' => 'g-me',
@@ -56,21 +59,21 @@ test('authenticated callback connects github to the current user', function () {
     $socialiteUser->name = 'Me';
     $socialiteUser->email = 'me@example.com';
 
-    Socialite::shouldReceive('driver')
-        ->with('github')
-        ->andReturn($driver = Mockery::mock());
-
+    $driver = Mockery::mock(AbstractProvider::class);
+    $driver->shouldReceive('scopes')->andReturnSelf();
+    $driver->shouldReceive('redirectUrl')->andReturnSelf();
     $driver->shouldReceive('user')->andReturn($socialiteUser);
+    Socialite::shouldReceive('driver')->with('github')->andReturn($driver);
 
     $this->actingAs($user)
-        ->get(route('auth.github.callback'))
+        ->get(route('app.authentication.connect-provider.callback', 'github'))
         ->assertRedirect(route('app.authentication.edit'))
         ->assertSessionHas('flash.success');
 
     expect($user->fresh()->github_id)->toBe('gh-me');
 });
 
-test('authenticated callback links github by current user, not by email', function () {
+test('connect-provider callback links github by current user, not by email', function () {
     $user = User::factory()->create([
         'email' => 'work@example.com',
         'google_id' => 'g-me',
@@ -82,14 +85,14 @@ test('authenticated callback links github by current user, not by email', functi
     $socialiteUser->name = 'Me';
     $socialiteUser->email = 'personal@example.com';
 
-    Socialite::shouldReceive('driver')
-        ->with('github')
-        ->andReturn($driver = Mockery::mock());
-
+    $driver = Mockery::mock(AbstractProvider::class);
+    $driver->shouldReceive('scopes')->andReturnSelf();
+    $driver->shouldReceive('redirectUrl')->andReturnSelf();
     $driver->shouldReceive('user')->andReturn($socialiteUser);
+    Socialite::shouldReceive('driver')->with('github')->andReturn($driver);
 
     $this->actingAs($user)
-        ->get(route('auth.github.callback'))
+        ->get(route('app.authentication.connect-provider.callback', 'github'))
         ->assertRedirect(route('app.authentication.edit'))
         ->assertSessionHas('flash.success');
 
@@ -98,7 +101,7 @@ test('authenticated callback links github by current user, not by email', functi
     $this->assertAuthenticatedAs($user);
 });
 
-test('authenticated callback rejects when github account is already linked to another user', function () {
+test('connect-provider callback rejects when github account is already linked to another user', function () {
     User::factory()->create(['github_id' => 'gh-taken']);
 
     $me = User::factory()->create(['email' => 'me@example.com', 'github_id' => null]);
@@ -108,14 +111,14 @@ test('authenticated callback rejects when github account is already linked to an
     $socialiteUser->name = 'Me';
     $socialiteUser->email = 'me@example.com';
 
-    Socialite::shouldReceive('driver')
-        ->with('github')
-        ->andReturn($driver = Mockery::mock());
-
+    $driver = Mockery::mock(AbstractProvider::class);
+    $driver->shouldReceive('scopes')->andReturnSelf();
+    $driver->shouldReceive('redirectUrl')->andReturnSelf();
     $driver->shouldReceive('user')->andReturn($socialiteUser);
+    Socialite::shouldReceive('driver')->with('github')->andReturn($driver);
 
     $this->actingAs($me)
-        ->get(route('auth.github.callback'))
+        ->get(route('app.authentication.connect-provider.callback', 'github'))
         ->assertRedirect(route('app.authentication.edit'))
         ->assertSessionHas('flash.error');
 
@@ -123,7 +126,7 @@ test('authenticated callback rejects when github account is already linked to an
     $this->assertAuthenticatedAs($me);
 });
 
-test('authenticated callback connects google to the current user', function () {
+test('connect-provider callback connects google to the current user', function () {
     $user = User::factory()->create([
         'email' => 'me@example.com',
         'github_id' => 'gh-me',
@@ -135,21 +138,20 @@ test('authenticated callback connects google to the current user', function () {
     $socialiteUser->name = 'Me';
     $socialiteUser->email = 'me@example.com';
 
-    Socialite::shouldReceive('driver')
-        ->with('google-auth')
-        ->andReturn($driver = Mockery::mock());
-
+    $driver = Mockery::mock(AbstractProvider::class);
+    $driver->shouldReceive('redirectUrl')->andReturnSelf();
     $driver->shouldReceive('user')->andReturn($socialiteUser);
+    Socialite::shouldReceive('driver')->with('google-auth')->andReturn($driver);
 
     $this->actingAs($user)
-        ->get(route('auth.google.callback'))
+        ->get(route('app.authentication.connect-provider.callback', 'google'))
         ->assertRedirect(route('app.authentication.edit'))
         ->assertSessionHas('flash.success');
 
     expect($user->fresh()->google_id)->toBe('g-me');
 });
 
-test('authenticated callback rejects when google account is already linked to another user', function () {
+test('connect-provider callback rejects when google account is already linked to another user', function () {
     User::factory()->create(['google_id' => 'g-taken']);
 
     $me = User::factory()->create(['email' => 'me@example.com', 'google_id' => null]);
@@ -159,17 +161,29 @@ test('authenticated callback rejects when google account is already linked to an
     $socialiteUser->name = 'Me';
     $socialiteUser->email = 'me@example.com';
 
-    Socialite::shouldReceive('driver')
-        ->with('google-auth')
-        ->andReturn($driver = Mockery::mock());
-
+    $driver = Mockery::mock(AbstractProvider::class);
+    $driver->shouldReceive('redirectUrl')->andReturnSelf();
     $driver->shouldReceive('user')->andReturn($socialiteUser);
+    Socialite::shouldReceive('driver')->with('google-auth')->andReturn($driver);
 
     $this->actingAs($me)
-        ->get(route('auth.google.callback'))
+        ->get(route('app.authentication.connect-provider.callback', 'google'))
         ->assertRedirect(route('app.authentication.edit'))
         ->assertSessionHas('flash.error');
 
     expect($me->fresh()->google_id)->toBeNull();
     $this->assertAuthenticatedAs($me);
+});
+
+test('connect-provider callback rejects unknown provider', function () {
+    $user = User::factory()->create();
+
+    $this->actingAs($user)
+        ->get(route('app.authentication.connect-provider.callback', 'twitter'))
+        ->assertNotFound();
+});
+
+test('connect-provider callback requires authentication', function () {
+    $this->get(route('app.authentication.connect-provider.callback', 'github'))
+        ->assertRedirect(route('login'));
 });

--- a/tests/Feature/Auth/ConnectProviderTest.php
+++ b/tests/Feature/Auth/ConnectProviderTest.php
@@ -12,7 +12,6 @@ test('authenticated user can hit the connect-provider route for github', functio
 
     $driver = Mockery::mock(AbstractProvider::class);
     $driver->shouldReceive('scopes')->andReturnSelf();
-    $driver->shouldReceive('redirectUrl')->andReturnSelf();
     $driver->shouldReceive('redirect')->andReturn(redirect('https://github.com/login/oauth/authorize'));
     Socialite::shouldReceive('driver')->with('github')->andReturn($driver);
 
@@ -25,7 +24,6 @@ test('authenticated user can hit the connect-provider route for google', functio
     $user = User::factory()->create();
 
     $driver = Mockery::mock(AbstractProvider::class);
-    $driver->shouldReceive('redirectUrl')->andReturnSelf();
     $driver->shouldReceive('redirect')->andReturn(redirect('https://accounts.google.com/o/oauth2/auth'));
     Socialite::shouldReceive('driver')->with('google-auth')->andReturn($driver);
 
@@ -47,7 +45,7 @@ test('connect-provider route requires authentication', function () {
         ->assertRedirect(route('login'));
 });
 
-test('connect-provider callback connects github to the current user', function () {
+test('authenticated callback connects github to the current user', function () {
     $user = User::factory()->create([
         'email' => 'me@example.com',
         'google_id' => 'g-me',
@@ -60,20 +58,18 @@ test('connect-provider callback connects github to the current user', function (
     $socialiteUser->email = 'me@example.com';
 
     $driver = Mockery::mock(AbstractProvider::class);
-    $driver->shouldReceive('scopes')->andReturnSelf();
-    $driver->shouldReceive('redirectUrl')->andReturnSelf();
     $driver->shouldReceive('user')->andReturn($socialiteUser);
     Socialite::shouldReceive('driver')->with('github')->andReturn($driver);
 
     $this->actingAs($user)
-        ->get(route('app.authentication.connect-provider.callback', 'github'))
+        ->get(route('auth.github.callback'))
         ->assertRedirect(route('app.authentication.edit'))
         ->assertSessionHas('flash.success');
 
     expect($user->fresh()->github_id)->toBe('gh-me');
 });
 
-test('connect-provider callback links github by current user, not by email', function () {
+test('authenticated callback links github by current user, not by email', function () {
     $user = User::factory()->create([
         'email' => 'work@example.com',
         'google_id' => 'g-me',
@@ -86,13 +82,11 @@ test('connect-provider callback links github by current user, not by email', fun
     $socialiteUser->email = 'personal@example.com';
 
     $driver = Mockery::mock(AbstractProvider::class);
-    $driver->shouldReceive('scopes')->andReturnSelf();
-    $driver->shouldReceive('redirectUrl')->andReturnSelf();
     $driver->shouldReceive('user')->andReturn($socialiteUser);
     Socialite::shouldReceive('driver')->with('github')->andReturn($driver);
 
     $this->actingAs($user)
-        ->get(route('app.authentication.connect-provider.callback', 'github'))
+        ->get(route('auth.github.callback'))
         ->assertRedirect(route('app.authentication.edit'))
         ->assertSessionHas('flash.success');
 
@@ -101,7 +95,7 @@ test('connect-provider callback links github by current user, not by email', fun
     $this->assertAuthenticatedAs($user);
 });
 
-test('connect-provider callback rejects when github account is already linked to another user', function () {
+test('authenticated callback rejects when github account is already linked to another user', function () {
     User::factory()->create(['github_id' => 'gh-taken']);
 
     $me = User::factory()->create(['email' => 'me@example.com', 'github_id' => null]);
@@ -112,13 +106,11 @@ test('connect-provider callback rejects when github account is already linked to
     $socialiteUser->email = 'me@example.com';
 
     $driver = Mockery::mock(AbstractProvider::class);
-    $driver->shouldReceive('scopes')->andReturnSelf();
-    $driver->shouldReceive('redirectUrl')->andReturnSelf();
     $driver->shouldReceive('user')->andReturn($socialiteUser);
     Socialite::shouldReceive('driver')->with('github')->andReturn($driver);
 
     $this->actingAs($me)
-        ->get(route('app.authentication.connect-provider.callback', 'github'))
+        ->get(route('auth.github.callback'))
         ->assertRedirect(route('app.authentication.edit'))
         ->assertSessionHas('flash.error');
 
@@ -126,7 +118,7 @@ test('connect-provider callback rejects when github account is already linked to
     $this->assertAuthenticatedAs($me);
 });
 
-test('connect-provider callback connects google to the current user', function () {
+test('authenticated callback connects google to the current user', function () {
     $user = User::factory()->create([
         'email' => 'me@example.com',
         'github_id' => 'gh-me',
@@ -139,19 +131,18 @@ test('connect-provider callback connects google to the current user', function (
     $socialiteUser->email = 'me@example.com';
 
     $driver = Mockery::mock(AbstractProvider::class);
-    $driver->shouldReceive('redirectUrl')->andReturnSelf();
     $driver->shouldReceive('user')->andReturn($socialiteUser);
     Socialite::shouldReceive('driver')->with('google-auth')->andReturn($driver);
 
     $this->actingAs($user)
-        ->get(route('app.authentication.connect-provider.callback', 'google'))
+        ->get(route('auth.google.callback'))
         ->assertRedirect(route('app.authentication.edit'))
         ->assertSessionHas('flash.success');
 
     expect($user->fresh()->google_id)->toBe('g-me');
 });
 
-test('connect-provider callback rejects when google account is already linked to another user', function () {
+test('authenticated callback rejects when google account is already linked to another user', function () {
     User::factory()->create(['google_id' => 'g-taken']);
 
     $me = User::factory()->create(['email' => 'me@example.com', 'google_id' => null]);
@@ -162,28 +153,14 @@ test('connect-provider callback rejects when google account is already linked to
     $socialiteUser->email = 'me@example.com';
 
     $driver = Mockery::mock(AbstractProvider::class);
-    $driver->shouldReceive('redirectUrl')->andReturnSelf();
     $driver->shouldReceive('user')->andReturn($socialiteUser);
     Socialite::shouldReceive('driver')->with('google-auth')->andReturn($driver);
 
     $this->actingAs($me)
-        ->get(route('app.authentication.connect-provider.callback', 'google'))
+        ->get(route('auth.google.callback'))
         ->assertRedirect(route('app.authentication.edit'))
         ->assertSessionHas('flash.error');
 
     expect($me->fresh()->google_id)->toBeNull();
     $this->assertAuthenticatedAs($me);
-});
-
-test('connect-provider callback rejects unknown provider', function () {
-    $user = User::factory()->create();
-
-    $this->actingAs($user)
-        ->get(route('app.authentication.connect-provider.callback', 'twitter'))
-        ->assertNotFound();
-});
-
-test('connect-provider callback requires authentication', function () {
-    $this->get(route('app.authentication.connect-provider.callback', 'github'))
-        ->assertRedirect(route('login'));
 });

--- a/tests/Feature/Auth/ConnectProviderTest.php
+++ b/tests/Feature/Auth/ConnectProviderTest.php
@@ -1,0 +1,175 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\User;
+use Laravel\Socialite\Facades\Socialite;
+use Laravel\Socialite\Two\User as SocialiteUser;
+
+test('authenticated user can hit the connect-provider route for github', function () {
+    $user = User::factory()->create();
+
+    $driver = Mockery::mock();
+    $driver->shouldReceive('scopes')->andReturnSelf();
+    $driver->shouldReceive('redirect')->andReturn(redirect('https://github.com/login/oauth/authorize'));
+    Socialite::shouldReceive('driver')->with('github')->andReturn($driver);
+
+    $this->actingAs($user)
+        ->get(route('app.authentication.connect-provider', 'github'))
+        ->assertRedirect('https://github.com/login/oauth/authorize');
+});
+
+test('authenticated user can hit the connect-provider route for google', function () {
+    $user = User::factory()->create();
+
+    $driver = Mockery::mock();
+    $driver->shouldReceive('redirect')->andReturn(redirect('https://accounts.google.com/o/oauth2/auth'));
+    Socialite::shouldReceive('driver')->with('google-auth')->andReturn($driver);
+
+    $this->actingAs($user)
+        ->get(route('app.authentication.connect-provider', 'google'))
+        ->assertRedirect('https://accounts.google.com/o/oauth2/auth');
+});
+
+test('connect-provider route rejects unknown provider', function () {
+    $user = User::factory()->create();
+
+    $this->actingAs($user)
+        ->get(route('app.authentication.connect-provider', 'twitter'))
+        ->assertNotFound();
+});
+
+test('connect-provider route requires authentication', function () {
+    $this->get(route('app.authentication.connect-provider', 'github'))
+        ->assertRedirect(route('login'));
+});
+
+test('authenticated callback connects github to the current user', function () {
+    $user = User::factory()->create([
+        'email' => 'me@example.com',
+        'google_id' => 'g-me',
+        'github_id' => null,
+    ]);
+
+    $socialiteUser = new SocialiteUser;
+    $socialiteUser->id = 'gh-me';
+    $socialiteUser->name = 'Me';
+    $socialiteUser->email = 'me@example.com';
+
+    Socialite::shouldReceive('driver')
+        ->with('github')
+        ->andReturn($driver = Mockery::mock());
+
+    $driver->shouldReceive('user')->andReturn($socialiteUser);
+
+    $this->actingAs($user)
+        ->get(route('auth.github.callback'))
+        ->assertRedirect(route('app.authentication.edit'))
+        ->assertSessionHas('flash.success');
+
+    expect($user->fresh()->github_id)->toBe('gh-me');
+});
+
+test('authenticated callback links github by current user, not by email', function () {
+    $user = User::factory()->create([
+        'email' => 'work@example.com',
+        'google_id' => 'g-me',
+        'github_id' => null,
+    ]);
+
+    $socialiteUser = new SocialiteUser;
+    $socialiteUser->id = 'gh-personal';
+    $socialiteUser->name = 'Me';
+    $socialiteUser->email = 'personal@example.com';
+
+    Socialite::shouldReceive('driver')
+        ->with('github')
+        ->andReturn($driver = Mockery::mock());
+
+    $driver->shouldReceive('user')->andReturn($socialiteUser);
+
+    $this->actingAs($user)
+        ->get(route('auth.github.callback'))
+        ->assertRedirect(route('app.authentication.edit'))
+        ->assertSessionHas('flash.success');
+
+    expect($user->fresh()->github_id)->toBe('gh-personal');
+    expect(User::where('email', 'personal@example.com')->exists())->toBeFalse();
+    $this->assertAuthenticatedAs($user);
+});
+
+test('authenticated callback rejects when github account is already linked to another user', function () {
+    User::factory()->create(['github_id' => 'gh-taken']);
+
+    $me = User::factory()->create(['email' => 'me@example.com', 'github_id' => null]);
+
+    $socialiteUser = new SocialiteUser;
+    $socialiteUser->id = 'gh-taken';
+    $socialiteUser->name = 'Me';
+    $socialiteUser->email = 'me@example.com';
+
+    Socialite::shouldReceive('driver')
+        ->with('github')
+        ->andReturn($driver = Mockery::mock());
+
+    $driver->shouldReceive('user')->andReturn($socialiteUser);
+
+    $this->actingAs($me)
+        ->get(route('auth.github.callback'))
+        ->assertRedirect(route('app.authentication.edit'))
+        ->assertSessionHas('flash.error');
+
+    expect($me->fresh()->github_id)->toBeNull();
+    $this->assertAuthenticatedAs($me);
+});
+
+test('authenticated callback connects google to the current user', function () {
+    $user = User::factory()->create([
+        'email' => 'me@example.com',
+        'github_id' => 'gh-me',
+        'google_id' => null,
+    ]);
+
+    $socialiteUser = new SocialiteUser;
+    $socialiteUser->id = 'g-me';
+    $socialiteUser->name = 'Me';
+    $socialiteUser->email = 'me@example.com';
+
+    Socialite::shouldReceive('driver')
+        ->with('google-auth')
+        ->andReturn($driver = Mockery::mock());
+
+    $driver->shouldReceive('user')->andReturn($socialiteUser);
+
+    $this->actingAs($user)
+        ->get(route('auth.google.callback'))
+        ->assertRedirect(route('app.authentication.edit'))
+        ->assertSessionHas('flash.success');
+
+    expect($user->fresh()->google_id)->toBe('g-me');
+});
+
+test('authenticated callback rejects when google account is already linked to another user', function () {
+    User::factory()->create(['google_id' => 'g-taken']);
+
+    $me = User::factory()->create(['email' => 'me@example.com', 'google_id' => null]);
+
+    $socialiteUser = new SocialiteUser;
+    $socialiteUser->id = 'g-taken';
+    $socialiteUser->name = 'Me';
+    $socialiteUser->email = 'me@example.com';
+
+    Socialite::shouldReceive('driver')
+        ->with('google-auth')
+        ->andReturn($driver = Mockery::mock());
+
+    $driver->shouldReceive('user')->andReturn($socialiteUser);
+
+    $this->actingAs($me)
+        ->get(route('auth.google.callback'))
+        ->assertRedirect(route('app.authentication.edit'))
+        ->assertSessionHas('flash.error');
+
+    expect($me->fresh()->google_id)->toBeNull();
+    $this->assertAuthenticatedAs($me);
+});


### PR DESCRIPTION
## Summary

Fixes a bug in the Settings → Authentication "Connect" button: clicking it while logged in was bouncing the user to /app/home (because the OAuth redirect lived behind `guest` middleware) and would have corrupted the session even if it had reached the callback (different-email GitHub account → new user registered, original user logged out).

## Root cause

Two compounding issues:

1. **Routing**: `auth.{provider}.redirect` and `auth.{provider}.callback` were both inside `routes/auth.php`'s `guest` group. Authenticated users couldn't reach either.
2. **Callback logic**: The callbacks had no branch for "user is already authenticated and wants to link a provider". They ran the lookup-or-register flow, which would either silently swap the session to a different account (if the OAuth email matched another user) or create a brand-new account (if it didn't).

## The fix

Splits signup/login from connect-from-settings by **intent**, not by guessing in the callback:

- **New route** `app.authentication.connect-provider` in `routes/app.php`'s `auth` group, handled by `App\Settings\AuthenticationController::connectProvider`. Sits next to `disconnectProvider` for symmetry.
- **`auth.{provider}.redirect` stays in the `guest` group** (original behavior: signup/login only).
- **`auth.{provider}.callback` moves out of `guest`** since OAuth providers only allow one registered callback URL — it has to accept both flows. It gains a single `Auth::check()` branch that delegates to `connectToCurrentUser()`.
- **`connectToCurrentUser()`** refuses to rebind a provider id that's already tied to a different user (flash error → settings); otherwise updates the current user's `{provider}_id` and flashes success.
- **`Authentication.vue`** now uses `connectProvider(account.provider)` instead of the OAuth signup link.

## Test plan

- [x] `tests/Feature/Auth/ConnectProviderTest.php` — 9 tests covering route accessibility (auth required, unknown provider 404, both providers redirect to OAuth) and callback behavior (link to current user including different-email case, reject when already linked elsewhere).
- [x] Existing OAuth tests for signup/login still pass — the guest-group redirect routes are unchanged.
- [x] Full suite: **1396 pass / 2 skipped**.
- [x] Pint clean.

## Why not separate callback URLs

OAuth providers (Google, GitHub) only let you register a fixed list of callback URLs per app. Splitting signup vs connect into separate URLs would mean a second URL registered in each provider's console plus a second env var per provider — overhead with no real win, since the callback's branch is one `if (Auth::check())` line. The middleware separation on the **redirect** routes is what guarantees the branch is safe (a guest can never reach the connect-provider route, and an authenticated user is bounced from `auth.{provider}.redirect` by the `guest` middleware).