### PR TITLE
feat: GTM dataLayer context + checkout/purchase events

### DIFF
--- a/app/Http/Middleware/App/HandleInertiaRequests.php
+++ b/app/Http/Middleware/App/HandleInertiaRequests.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace App\Http\Middleware\App;
 
+use App\Http\Resources\App\HandleInertiaRequests\AuthAccountResource;
+use App\Http\Resources\App\HandleInertiaRequests\AuthPlanResource;
 use App\Http\Resources\App\HandleInertiaRequests\AuthUserResource;
 use App\Http\Resources\App\HandleInertiaRequests\AuthWorkspaceResource;
 use App\Models\Account;
@@ -40,7 +42,8 @@ class HandleInertiaRequests extends Middleware
                 'workspaces' => $user
                     ? $user->workspaces()->with('media')->get()->map(fn ($ws) => AuthWorkspaceResource::summary($ws))
                     : [],
-                'plan' => $account?->plan,
+                'account' => $account ? AuthAccountResource::make($account) : null,
+                'plan' => $account && $account->plan ? AuthPlanResource::make($account, $account->plan) : null,
                 'hasActiveSubscription' => $account ? $account->hasActiveSubscription() : false,
                 'currentPriceId' => $account?->subscription(Account::SUBSCRIPTION_NAME)?->stripe_price,
             ],

--- a/app/Http/Resources/App/HandleInertiaRequests/AuthAccountResource.php
+++ b/app/Http/Resources/App/HandleInertiaRequests/AuthAccountResource.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Resources\App\HandleInertiaRequests;
+
+use App\Models\Account;
+
+class AuthAccountResource
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public static function make(Account $account): array
+    {
+        return [
+            'id' => $account->id,
+            'name' => $account->name,
+            'created_at' => $account->created_at,
+        ];
+    }
+}

--- a/app/Http/Resources/App/HandleInertiaRequests/AuthPlanResource.php
+++ b/app/Http/Resources/App/HandleInertiaRequests/AuthPlanResource.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Resources\App\HandleInertiaRequests;
+
+use App\Models\Account;
+use App\Models\Plan;
+
+class AuthPlanResource
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public static function make(Account $account, Plan $plan): array
+    {
+        $subscription = $account->subscription(Account::SUBSCRIPTION_NAME);
+        $interval = ($subscription && $subscription->stripe_price === $plan->stripe_yearly_price_id)
+            ? 'yearly'
+            : 'monthly';
+
+        return [
+            'id' => $plan->id,
+            'slug' => $plan->slug->value,
+            'name' => $plan->name,
+            'interval' => $interval,
+        ];
+    }
+}

--- a/resources/js/app.ts
+++ b/resources/js/app.ts
@@ -8,6 +8,7 @@ import type { DefineComponent } from 'vue';
 import { createApp, h } from 'vue';
 
 import { initializeTheme } from './composables/useAppearance';
+import { initializeDataLayer } from './datalayer';
 import dayjs from './dayjs';
 import posthog from './posthog';
 import type { Auth } from './types';
@@ -33,6 +34,16 @@ createInertiaApp({
         dayjs.locale(locale.toLowerCase());
 
         const auth = props.initialPage.props.auth as Auth | undefined;
+        const flash = props.initialPage.props.flash as
+            | { conversion_event?: string; [key: string]: unknown }
+            | undefined;
+
+        initializeDataLayer(
+            auth,
+            flash,
+            props.initialPage.props.applicationUrl as string,
+            props.initialPage.props.env as string,
+        );
 
         if (auth?.user) {
             posthog.identify(auth.user.id, {

--- a/resources/js/composables/useTracking.ts
+++ b/resources/js/composables/useTracking.ts
@@ -17,34 +17,28 @@ export const useTracking = () => ({
         });
     },
 
-    trackBeginCheckout: (plan: { name: string; price: number; interval: string }) => {
+    trackBeginCheckout: (plan: { name: string; interval: string }) => {
         posthog.capture('checkout.started', {
             plan_name: plan.name,
-            plan_price: plan.price,
             interval: plan.interval,
         });
 
         push({
             event: 'begin_checkout',
-            currency: 'USD',
             plan_name: plan.name,
-            plan_price: plan.price,
             plan_interval: plan.interval,
         });
     },
 
-    trackPurchase: (plan: { name: string; price: number; interval: string }) => {
+    trackPurchase: (plan: { name: string; interval: string }) => {
         posthog.capture('checkout.completed', {
             plan_name: plan.name,
-            plan_price: plan.price,
             interval: plan.interval,
         });
 
         push({
             event: 'purchase',
-            currency: 'USD',
             plan_name: plan.name,
-            plan_price: plan.price,
             plan_interval: plan.interval,
         });
     },

--- a/resources/js/datalayer.ts
+++ b/resources/js/datalayer.ts
@@ -1,0 +1,64 @@
+import type { Auth } from './types';
+
+interface FlashData {
+    conversion_event?: string;
+    [key: string]: unknown;
+}
+
+/**
+ * Push app + identity context to GTM's dataLayer on every page load. The
+ * pushes are no-ops when GTM isn't configured (the array still exists in
+ * memory; nothing reads it). Self-hosted instances without GTM_ID set
+ * incur zero error noise.
+ *
+ * Billing is account-scoped (not workspace-scoped) in trypost, so the
+ * plan/subscription fields are emitted under `account_*` keys.
+ */
+export const initializeDataLayer = (
+    auth: Auth | undefined,
+    flash: FlashData | undefined,
+    applicationUrl: string,
+    env: string,
+): void => {
+    window.dataLayer = window.dataLayer || [];
+
+    window.dataLayer.push({
+        app_url: applicationUrl,
+        app_env: env,
+        app_context: 'app',
+    });
+
+    if (flash?.conversion_event) {
+        window.dataLayer.push({ event: flash.conversion_event });
+    }
+
+    if (!auth?.user) {
+        return;
+    }
+
+    window.dataLayer.push({
+        user_id: auth.user.id,
+        user_email: auth.user.email,
+        user_name: auth.user.name,
+        user_created_at: auth.user.created_at,
+    });
+
+    if (auth.account) {
+        window.dataLayer.push({
+            account_id: auth.account.id,
+            account_name: auth.account.name,
+            account_created_at: auth.account.created_at,
+            account_plan: auth.plan?.name ?? null,
+            account_plan_slug: auth.plan?.slug ?? null,
+            account_subscribed: Boolean(auth.hasActiveSubscription),
+        });
+    }
+
+    if (auth.currentWorkspace) {
+        window.dataLayer.push({
+            workspace_id: auth.currentWorkspace.id,
+            workspace_name: auth.currentWorkspace.name,
+            workspace_count: auth.workspaces?.length ?? 0,
+        });
+    }
+};

--- a/resources/js/pages/billing/Processing.vue
+++ b/resources/js/pages/billing/Processing.vue
@@ -1,28 +1,60 @@
 <script setup lang="ts">
-import { Head, router, usePoll } from '@inertiajs/vue3';
+import { Head, router, usePage, usePoll } from '@inertiajs/vue3';
 import { IconLoader2 } from '@tabler/icons-vue';
-import { watch } from 'vue';
+import { onMounted, watch } from 'vue';
 
+import { useTracking } from '@/composables/useTracking';
 import { home } from '@/routes/app';
+import type { Auth } from '@/types';
 
 const props = defineProps<{
     subscriptionActive: boolean;
 }>();
 
+const page = usePage();
+
+// Polls `auth` alongside so `auth.plan.interval` is fresh once the Stripe
+// webhook creates the local Subscription row — at /billing/processing's
+// initial render that row doesn't exist yet, so the interval would default
+// to 'monthly' even for a yearly purchase.
 const { stop } = usePoll(2000, {
-    only: ['subscriptionActive'],
+    only: ['subscriptionActive', 'auth'],
 });
 
+const { trackPurchase } = useTracking();
+
+const goHome = () => router.visit(home.url());
+
+// `watch` (without `immediate`) only fires on transition false → true, which
+// is exactly the purchase moment. The `onMounted` fallback covers the case
+// where the user lands here with an already-active subscription (back button,
+// refresh after the redirect) — we just bounce them home, no extra event.
 watch(
     () => props.subscriptionActive,
     (active) => {
-        if (active) {
-            stop();
-            router.visit(home.url());
+        if (! active) {
+            return;
         }
+
+        stop();
+
+        const plan = (page.props.auth as Auth | undefined)?.plan;
+        if (plan) {
+            trackPurchase({
+                name: plan.name,
+                interval: plan.interval,
+            });
+        }
+
+        goHome();
     },
-    { immediate: true },
 );
+
+onMounted(() => {
+    if (props.subscriptionActive) {
+        goHome();
+    }
+});
 </script>
 
 <template>

--- a/resources/js/pages/billing/Subscribe.vue
+++ b/resources/js/pages/billing/Subscribe.vue
@@ -7,6 +7,7 @@ import { ref } from 'vue';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Switch } from '@/components/ui/switch';
+import { useTracking } from '@/composables/useTracking';
 import { checkout } from '@/routes/app/billing';
 
 interface Plan {
@@ -29,6 +30,8 @@ defineProps<{
 const isYearly = ref(false);
 const processing = ref<string | null>(null);
 
+const { trackBeginCheckout } = useTracking();
+
 const getPrice = (plan: Plan): string => {
     const key = `billing.subscribe.prices.${plan.slug}.${isYearly.value ? 'yearly' : 'monthly'}`;
     return trans(key);
@@ -36,7 +39,15 @@ const getPrice = (plan: Plan): string => {
 
 const selectPlan = (plan: Plan) => {
     processing.value = plan.id;
+
+    const interval = isYearly.value ? 'yearly' : 'monthly';
     const priceId = isYearly.value ? plan.stripe_yearly_price_id : plan.stripe_monthly_price_id;
+
+    trackBeginCheckout({
+        name: plan.name,
+        interval,
+    });
+
     router.post(checkout.url(plan.id), {
         price_id: priceId,
     });

--- a/resources/js/types/index.d.ts
+++ b/resources/js/types/index.d.ts
@@ -11,11 +11,28 @@ export interface Workspace {
     [key: string]: unknown;
 }
 
+export interface AuthPlan {
+    id: string;
+    slug: string;
+    name: string;
+    interval: 'monthly' | 'yearly';
+}
+
+export interface AuthAccount {
+    id: string;
+    name: string;
+    created_at: string | null;
+}
+
 export interface Auth {
     user: User;
     role: WorkspaceRole | null;
     currentWorkspace: Workspace | null;
     workspaces: Workspace[];
+    account: AuthAccount | null;
+    plan: AuthPlan | null;
+    hasActiveSubscription: boolean;
+    currentPriceId: string | null;
 }
 
 export interface FlashData {

--- a/tests/Feature/BillingControllerTest.php
+++ b/tests/Feature/BillingControllerTest.php
@@ -120,6 +120,22 @@ test('billing processing shows processing page', function () {
     );
 });
 
+test('shared auth.plan exposes name slug and interval via AuthPlanResource', function () {
+    config(['trypost.self_hosted' => false]);
+
+    $plan = Plan::where('slug', 'pro')->firstOrFail();
+    $this->account->update(['plan_id' => $plan->id]);
+
+    $response = $this->actingAs($this->user->fresh())->get(route('app.billing.processing'));
+
+    $response->assertOk();
+    $response->assertInertia(fn ($page) => $page
+        ->where('auth.plan.name', 'Pro')
+        ->where('auth.plan.slug', 'pro')
+        ->where('auth.plan.interval', 'monthly')
+    );
+});
+
 test('billing processing redirects to calendar in self hosted mode', function () {
     config(['trypost.self_hosted' => true]);
 


### PR DESCRIPTION
## Summary

Adds the missing piece of GTM integration in TryPost: app/identity **context** pushed to `window.dataLayer` on every page load, plus wires `trackBeginCheckout` and `trackPurchase` (which already existed in `useTracking` but were dead) into the billing flow. Mirrors SendKit's pattern, adapted to TryPost's account-vs-workspace split.

The GTM `<script>` and `<noscript>` partials were already conditional on `config('services.gtm.id')` — this PR doesn't change that. Self-hosted instances without `GTM_ID` set keep working with zero error noise: the dataLayer array is created in memory, pushes accumulate, nothing reads them.

## Changes

### Backend

- **`AuthAccountResource`** (new) — id, name, created_at. Follows the existing `AuthUserResource` / `AuthWorkspaceResource` pattern.
- **`AuthPlanResource`** (new) — id, slug, name, interval. Interval is derived from the active Cashier subscription's `stripe_price` (yearly vs monthly).
- **`HandleInertiaRequests`** wires both resources so `auth.account` and `auth.plan` are available on every Inertia response. `auth.plan` was previously the raw model with no interval info — now it's enriched.

### Frontend

- **`resources/js/datalayer.ts`** (new) — `initializeDataLayer(auth, flash, applicationUrl, env)` pushes:
  - `app_url`, `app_env`, `app_context`
  - `event` from `flash.conversion_event` if set (server-driven one-shot)
  - `user_id`, `user_email`, `user_name`, `user_created_at`
  - `account_id`, `account_name`, `account_created_at`, `account_plan`, `account_plan_slug`, `account_subscribed` — billing is account-scoped in TryPost
  - `workspace_id`, `workspace_name`, `workspace_count` — separate, for content/usage analytics
- **`app.ts`** calls `initializeDataLayer` during Inertia setup.
- **`useTracking.ts`** signatures slimmed: `trackBeginCheckout` and `trackPurchase` now take `{name, interval}` only.
- **`Subscribe.vue`** fires `trackBeginCheckout` before the Stripe redirect.
- **`Processing.vue`** fires `trackPurchase` when `subscriptionActive` flips false → true.
- **`Auth` type** updated to expose `AuthAccount` and `AuthPlan`.

## Subtleties caught during review

- **Stale auth on poll**: The Stripe webhook is async, so at `/billing/processing`'s initial render the local Cashier `Subscription` row doesn't exist yet — `AuthPlanResource` would default `interval` to `'monthly'` even for yearly purchases. Fixed by including `auth` in `usePoll`'s `only` so `auth.plan.interval` is refreshed when `subscriptionActive` flips.
- **Re-firing on revisit**: A `watch(..., { immediate: true })` would re-fire `trackPurchase` if a user came back to `/billing/processing` with an already-active subscription (back button, refresh after the redirect). Removed `immediate`. The `watch` now only fires on the `false → true` transition; an `onMounted` fallback redirects landing-with-active-sub users home without re-firing.

## Test plan

- [x] `tests/Feature/BillingControllerTest.php` — extended with a test verifying `auth.plan.{name,slug,interval}` flow through `AuthPlanResource`.
- [x] Full suite: **1397 pass / 2 skipped**.
- [x] Pint clean. ESLint clean.
- [x] Manual flows traced end-to-end: anonymous + GTM off, anonymous + GTM on, signup, begin_checkout, purchase (initial + already-active landings).

## Without GTM (open source / self-hosted)

`config('services.gtm.id')` empty → script and noscript partials emit nothing. `window.dataLayer = window.dataLayer || []` always succeeds. Pushes accumulate in memory; nothing consumes them. PostHog is independently gated by `VITE_POSTHOG_API_KEY`. **Zero errors, zero side effects.**