### PR TITLE
fix: cast cached post count to int (Redis serializer crash)

### DIFF
--- a/app/Models/Traits/HasUsage.php
+++ b/app/Models/Traits/HasUsage.php
@@ -66,6 +66,15 @@ trait HasUsage
     }
 
     /**
+     * The `(int)` cast on the cached value is load-bearing: Laravel's
+     * RedisStore skips serialize()/unserialize() for is_numeric values so
+     * they can be incremented atomically — the side effect is that an int
+     * stored via `Cache::put` comes back as a string on read. Without the
+     * cast, the strict `: int` return type throws a TypeError under the
+     * Redis cache driver (production). File/array/database drivers don't
+     * have this optimisation and preserve the type, which is why the bug
+     * never surfaced in tests or local dev.
+     *
      * @param  array<int, string>  $workspaceIds
      */
     private function cachedPostCount(array $workspaceIds): int
@@ -74,7 +83,7 @@ trait HasUsage
             return 0;
         }
 
-        return Cache::remember(
+        return (int) Cache::remember(
             "account:{$this->id}:posts_count",
             self::POST_COUNT_CACHE_TTL,
             fn () => Post::whereIn('workspace_id', $workspaceIds)->count(),

--- a/config/cache.php
+++ b/config/cache.php
@@ -17,7 +17,7 @@ return [
     |
     */
 
-    'default' => env('CACHE_STORE', 'database'),
+    'default' => env('CACHE_STORE', 'redis'),
 
     /*
     |--------------------------------------------------------------------------

--- a/tests/Feature/Models/HasUsageTraitTest.php
+++ b/tests/Feature/Models/HasUsageTraitTest.php
@@ -104,3 +104,22 @@ test('postCount returns zero without querying when account has no workspaces', f
     // No cache entry should be written for the empty case.
     expect(Cache::has("account:{$this->account->id}:posts_count"))->toBeFalse();
 });
+
+test('postCount survives a string-typed cache value (Redis serializer quirk)', function () {
+    // Laravel's RedisStore stores numeric values raw (not serialised) so they
+    // can be INCRemented atomically. The side effect: an int written via
+    // Cache::put comes back as a string on read. The test driver is `array`
+    // which preserves type, so we seed the cache with a literal string here
+    // to mimic what production sees and assert the return type stays int.
+    Workspace::factory()->create([
+        'account_id' => $this->account->id,
+        'user_id' => $this->owner->id,
+    ]);
+
+    Cache::put("account:{$this->account->id}:posts_count", '42', 300);
+
+    $usage = $this->account->usage();
+
+    expect($usage['postCount'])->toBe(42);
+    expect($usage['postCount'])->toBeInt();
+});


### PR DESCRIPTION
## Summary
- Adds an `(int)` cast to `Account::cachedPostCount()` so the strict `: int` return type survives Redis's `is_numeric` raw-store optimisation, which returns ints as strings on read.
- Changes the local `CACHE_STORE` default from `database` to `redis` so dev matches production and driver-specific bugs surface before deploy.
- Regression test seeds the cache with a literal string (what prod's Redis returns) and asserts the function still returns an `int`.

## Why
Production crashed on every Inertia request right after the PostHog branch (#20) merged:

```
TypeError: App\Models\Account::cachedPostCount(): Return value must be
of type int, string returned at app/Models/Traits/HasUsage.php:80
```

Laravel's `RedisStore` stores `is_numeric` values raw (not serialised) so they stay INCR/DECR-able atomically — the side effect is that an `int` written via `Cache::put` comes back as a `string` on read. Local/CI used `array`/`database`/`file` drivers that serialise blindly and preserve the type, so the bug never showed up until production hit Redis.

## Test plan
- [ ] `php artisan test --compact tests/Feature/Models/HasUsageTraitTest.php` — 6/6 pass, including the new `postCount survives a string-typed cache value (Redis serializer quirk)` regression.
- [ ] Full suite: 1446 passed / 2 skipped / 0 failed.
- [ ] Manually verify in a Redis-backed environment that requests no longer 500 on `account.usage()`.
- [ ] After merge: `php artisan cache:clear` on the affected production deploy to evict the stale string values that were poisoning warm caches.