### PR TITLE
feat(tiktok): photo carousel support + Content Sharing API UX compliance

### DIFF
--- a/app/Enums/PostPlatform/ContentType.php
+++ b/app/Enums/PostPlatform/ContentType.php
@@ -29,6 +29,7 @@ enum ContentType: string
 
     // TikTok
     case TikTokVideo = 'tiktok_video';
+    case TikTokPhoto = 'tiktok_photo';
 
     // YouTube
     case YouTubeShort = 'youtube_short';
@@ -63,6 +64,7 @@ enum ContentType: string
             self::FacebookReel => 'Reel',
             self::FacebookStory => 'Story',
             self::TikTokVideo => 'Video',
+            self::TikTokPhoto => 'Photo carousel',
             self::YouTubeShort => 'Short',
             self::XPost => 'Post',
             self::ThreadsPost => 'Post',
@@ -87,6 +89,7 @@ enum ContentType: string
             self::FacebookReel => 'Short video up to 90 seconds',
             self::FacebookStory => 'Disappears after 24 hours',
             self::TikTokVideo => 'Short-form video content',
+            self::TikTokPhoto => 'Up to 35 photos as a swipeable carousel',
             self::YouTubeShort => 'Vertical video up to 60 seconds',
             self::XPost => 'Tweet with text and media',
             self::ThreadsPost => 'Text post with optional media',
@@ -105,7 +108,7 @@ enum ContentType: string
             self::LinkedInPost, self::LinkedInCarousel => SocialPlatform::LinkedIn,
             self::LinkedInPagePost, self::LinkedInPageCarousel => SocialPlatform::LinkedInPage,
             self::FacebookPost, self::FacebookReel, self::FacebookStory => SocialPlatform::Facebook,
-            self::TikTokVideo => SocialPlatform::TikTok,
+            self::TikTokVideo, self::TikTokPhoto => SocialPlatform::TikTok,
             self::YouTubeShort => SocialPlatform::YouTube,
             self::XPost => SocialPlatform::X,
             self::ThreadsPost => SocialPlatform::Threads,
@@ -156,6 +159,7 @@ enum ContentType: string
             self::InstagramReel, self::InstagramStory => '9:16',
             self::FacebookReel, self::FacebookStory => '9:16',
             self::TikTokVideo, self::YouTubeShort => '9:16',
+            self::TikTokPhoto => '1:1',
             self::PinterestPin, self::PinterestCarousel => '2:3',
             self::PinterestVideoPin => '9:16',
             default => null,
@@ -173,6 +177,7 @@ enum ContentType: string
             self::FacebookPost => 10,
             self::FacebookReel, self::FacebookStory => 1,
             self::TikTokVideo => 1,
+            self::TikTokPhoto => 35,
             self::YouTubeShort => 1,
             self::XPost => 4,
             self::ThreadsPost => 10,
@@ -192,6 +197,7 @@ enum ContentType: string
             self::LinkedInCarousel, self::LinkedInPageCarousel => false,
             self::FacebookPost, self::FacebookReel, self::FacebookStory => true,
             self::TikTokVideo => true,
+            self::TikTokPhoto => false,
             self::YouTubeShort => true,
             self::XPost => true,
             self::ThreadsPost => true,
@@ -207,6 +213,7 @@ enum ContentType: string
         return match ($this) {
             self::InstagramReel => false,
             self::TikTokVideo => false,
+            self::TikTokPhoto => true,
             self::YouTubeShort => false,
             self::PinterestVideoPin => false,
             default => true,

--- a/app/Enums/PostPlatform/ContentType.php
+++ b/app/Enums/PostPlatform/ContentType.php
@@ -78,27 +78,7 @@ enum ContentType: string
 
     public function description(): string
     {
-        return match ($this) {
-            self::InstagramFeed => 'Appears in your feed and profile',
-            self::InstagramCarousel => 'Multi-slide swipeable post (2-10 images)',
-            self::InstagramReel => 'Short video up to 90 seconds',
-            self::InstagramStory => 'Disappears after 24 hours',
-            self::LinkedInPost, self::LinkedInPagePost => 'Standard post with text and media',
-            self::LinkedInCarousel, self::LinkedInPageCarousel => 'Swipeable document or images',
-            self::FacebookPost => 'Standard post on your page',
-            self::FacebookReel => 'Short video up to 90 seconds',
-            self::FacebookStory => 'Disappears after 24 hours',
-            self::TikTokVideo => 'Short-form video content',
-            self::TikTokPhoto => 'Up to 35 photos as a swipeable carousel',
-            self::YouTubeShort => 'Vertical video up to 60 seconds',
-            self::XPost => 'Tweet with text and media',
-            self::ThreadsPost => 'Text post with optional media',
-            self::PinterestPin => 'Standard image pin',
-            self::PinterestVideoPin => 'Video pin (4s - 15min)',
-            self::PinterestCarousel => 'Multi-image carousel (2-5 images)',
-            self::BlueskyPost => 'Text post with optional images',
-            self::MastodonPost => 'Text post with optional media',
-        };
+        return (string) trans("posts.content_types.{$this->value}.description");
     }
 
     public function platform(): SocialPlatform

--- a/app/Http/Controllers/App/PostController.php
+++ b/app/Http/Controllers/App/PostController.php
@@ -232,7 +232,16 @@ class PostController extends Controller
             }
         }
 
-        $tiktokAccounts = $socialAccounts->where('platform', Platform::TikTok);
+        $tiktokCreatorInfos = $socialAccounts
+            ->where('platform', Platform::TikTok)
+            ->mapWithKeys(fn ($account) => [
+                $account->id => rescue(
+                    fn () => app(TikTokCreatorInfo::class)->fetch($account),
+                    null,
+                    report: false,
+                ),
+            ])
+            ->filter();
 
         return Inertia::render('posts/Edit', [
             'workspace' => $workspace,
@@ -240,13 +249,7 @@ class PostController extends Controller
             'socialAccounts' => $socialAccounts,
             'platformConfigs' => $platformConfigs,
             'pinterestBoards' => $pinterestBoards,
-            'tiktokCreatorInfos' => Inertia::defer(fn () => $tiktokAccounts->mapWithKeys(fn ($account) => [
-                $account->id => rescue(
-                    fn () => app(TikTokCreatorInfo::class)->fetch($account),
-                    null,
-                    report: false,
-                ),
-            ])->filter()),
+            'tiktokCreatorInfos' => $tiktokCreatorInfos,
             'labels' => $labels,
             'signatures' => $signatures,
             'authUserId' => $request->user()->id,

--- a/app/Http/Requests/App/Post/UpdatePostRequest.php
+++ b/app/Http/Requests/App/Post/UpdatePostRequest.php
@@ -72,16 +72,6 @@ class UpdatePostRequest extends FormRequest
         ];
     }
 
-    public function messages(): array
-    {
-        return [
-            'status.required' => 'The post status is required.',
-            'status.in' => 'Invalid post status.',
-            'platforms.*.content_type.in' => 'Invalid content type.',
-            'scheduled_at.after' => 'The scheduled date must be in the future.',
-        ];
-    }
-
     public function withValidator(Validator $validator): void
     {
         $validator->after(function ($validator): void {

--- a/app/Http/Requests/App/Post/UpdatePostRequest.php
+++ b/app/Http/Requests/App/Post/UpdatePostRequest.php
@@ -92,9 +92,6 @@ class UpdatePostRequest extends FormRequest
             $platforms = $this->input('platforms', []);
             $ids = collect($platforms)->pluck('id')->filter()->all();
 
-            // Scope to the current post via the route-bound relation — defensive
-            // (cross-post leakage is prevented and we use the existing relation
-            // rather than a separate global query).
             $platformsById = $this->route('post')
                 ->postPlatforms()
                 ->whereIn('id', $ids)
@@ -106,7 +103,7 @@ class UpdatePostRequest extends FormRequest
                     && blank(data_get($platform, 'meta.privacy_level'))) {
                     $validator->errors()->add(
                         "platforms.{$i}.meta.privacy_level",
-                        'TikTok privacy level is required when publishing.',
+                        trans('posts.form.tiktok.privacy_required'),
                     );
                 }
             }

--- a/app/Http/Requests/App/Post/UpdatePostRequest.php
+++ b/app/Http/Requests/App/Post/UpdatePostRequest.php
@@ -6,9 +6,11 @@ namespace App\Http\Requests\App\Post;
 
 use App\Enums\Post\Status;
 use App\Enums\PostPlatform\ContentType;
+use App\Enums\SocialAccount\Platform;
 use App\Rules\ContentTypeCompatibleWithMedia;
 use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Validation\Rule;
+use Illuminate\Validation\Validator;
 
 class UpdatePostRequest extends FormRequest
 {
@@ -78,5 +80,45 @@ class UpdatePostRequest extends FormRequest
             'platforms.*.content_type.in' => 'Invalid content type.',
             'scheduled_at.after' => 'The scheduled date must be in the future.',
         ];
+    }
+
+    public function withValidator(Validator $validator): void
+    {
+        $validator->after(function ($validator): void {
+            if (! $this->isPublishingOrScheduling()) {
+                return;
+            }
+
+            $platforms = $this->input('platforms', []);
+            $ids = collect($platforms)->pluck('id')->filter()->all();
+
+            // Scope to the current post via the route-bound relation — defensive
+            // (cross-post leakage is prevented and we use the existing relation
+            // rather than a separate global query).
+            $platformsById = $this->route('post')
+                ->postPlatforms()
+                ->whereIn('id', $ids)
+                ->pluck('platform', 'id');
+
+            foreach ($platforms as $i => $platform) {
+                $platformEnum = $platformsById[data_get($platform, 'id')] ?? null;
+                if ($platformEnum === Platform::TikTok
+                    && blank(data_get($platform, 'meta.privacy_level'))) {
+                    $validator->errors()->add(
+                        "platforms.{$i}.meta.privacy_level",
+                        'TikTok privacy level is required when publishing.',
+                    );
+                }
+            }
+        });
+    }
+
+    private function isPublishingOrScheduling(): bool
+    {
+        return in_array(
+            $this->input('status'),
+            [Status::Scheduled->value, Status::Publishing->value],
+            true,
+        );
     }
 }

--- a/app/Services/Social/TikTokCreatorInfo.php
+++ b/app/Services/Social/TikTokCreatorInfo.php
@@ -8,6 +8,7 @@ use App\Exceptions\TokenExpiredException;
 use App\Models\SocialAccount;
 use App\Services\Social\Concerns\HasSocialHttpClient;
 use Illuminate\Http\Client\PendingRequest;
+use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Log;
 
@@ -37,6 +38,27 @@ class TikTokCreatorInfo
      * }
      */
     public function fetch(SocialAccount $account): array
+    {
+        return Cache::remember(
+            "tiktok:creator_info:{$account->id}",
+            now()->addMinutes(5),
+            fn () => $this->fetchFresh($account),
+        );
+    }
+
+    /**
+     * @return array{
+     *     creator_nickname: ?string,
+     *     creator_username: ?string,
+     *     creator_avatar_url: ?string,
+     *     privacy_level_options: array<int, string>,
+     *     comment_disabled: bool,
+     *     duet_disabled: bool,
+     *     stitch_disabled: bool,
+     *     max_video_post_duration_sec: ?int,
+     * }
+     */
+    private function fetchFresh(SocialAccount $account): array
     {
         if ($account->is_token_expired || $account->is_token_expiring_soon) {
             $this->refreshTokenWithLock($account, fn () => $this->refreshToken($account));

--- a/app/Services/Social/TikTokPublisher.php
+++ b/app/Services/Social/TikTokPublisher.php
@@ -75,26 +75,24 @@ class TikTokPublisher
         return $this->socialHttp()->asJson()->withToken($this->accessToken);
     }
 
-    private function queryCreatorInfo(SocialAccount $account): array
+    /**
+     * Resolve the user-selected privacy_level from meta, throwing when missing.
+     * TikTok UX Guideline Point 2b forbids any default — the user must pick
+     * explicitly. The FormRequest validates this upstream; this is the safety
+     * net for queue/job paths that bypass the request layer.
+     */
+    private function resolveRequiredPrivacyLevel(PostPlatform $postPlatform): string
     {
-        $info = app(TikTokCreatorInfo::class)->fetch($account);
-        $privacyOptions = data_get($info, 'privacy_level_options') ?: ['SELF_ONLY'];
+        $privacyLevel = data_get($postPlatform->meta ?? [], 'privacy_level');
 
-        // Prefer PUBLIC_TO_EVERYONE > MUTUAL_FOLLOW_FRIENDS > FOLLOWER_OF_CREATOR > SELF_ONLY
-        $preferred = ['PUBLIC_TO_EVERYONE', 'MUTUAL_FOLLOW_FRIENDS', 'FOLLOWER_OF_CREATOR', 'SELF_ONLY'];
-
-        $privacyLevel = 'SELF_ONLY';
-        foreach ($preferred as $level) {
-            if (in_array($level, $privacyOptions)) {
-                $privacyLevel = $level;
-                break;
-            }
+        if (blank($privacyLevel)) {
+            throw new TikTokPublishException(
+                userMessage: 'TikTok privacy level is required. Please open the post and pick a visibility option.',
+                category: ErrorCategory::ContentPolicy,
+            );
         }
 
-        return [
-            'privacy_level' => $privacyLevel,
-            'max_video_post_duration_sec' => data_get($info, 'max_video_post_duration_sec'),
-        ];
+        return (string) $privacyLevel;
     }
 
     /**
@@ -104,16 +102,13 @@ class TikTokPublisher
      *
      * @return array<string, mixed>
      */
-    private function buildVideoPostInfo(PostPlatform $postPlatform, ?string $content, array $creatorInfo): array
+    private function buildVideoPostInfo(PostPlatform $postPlatform, ?string $content): array
     {
         $meta = $postPlatform->meta ?? [];
 
-        $privacyLevel = data_get($meta, 'privacy_level')
-            ?: data_get($creatorInfo, 'privacy_level', 'SELF_ONLY');
-
         $postInfo = [
             'title' => $content ?? '',
-            'privacy_level' => $privacyLevel,
+            'privacy_level' => $this->resolveRequiredPrivacyLevel($postPlatform),
             'disable_duet' => ! data_get($meta, 'allow_duet', false),
             'disable_comment' => ! data_get($meta, 'allow_comments', true),
             'disable_stitch' => ! data_get($meta, 'allow_stitch', false),
@@ -142,16 +137,13 @@ class TikTokPublisher
      *
      * @return array<string, mixed>
      */
-    private function buildPhotoPostInfo(PostPlatform $postPlatform, ?string $content, array $creatorInfo): array
+    private function buildPhotoPostInfo(PostPlatform $postPlatform, ?string $content): array
     {
         $meta = $postPlatform->meta ?? [];
 
-        $privacyLevel = data_get($meta, 'privacy_level')
-            ?: data_get($creatorInfo, 'privacy_level', 'SELF_ONLY');
-
         $postInfo = [
             'description' => $content ?? '',
-            'privacy_level' => $privacyLevel,
+            'privacy_level' => $this->resolveRequiredPrivacyLevel($postPlatform),
             'disable_comment' => ! data_get($meta, 'allow_comments', true),
         ];
 
@@ -168,11 +160,9 @@ class TikTokPublisher
 
     private function publishVideo(PostPlatform $postPlatform, $media, ?string $content): array
     {
-        $creatorInfo = $this->queryCreatorInfo($postPlatform->socialAccount);
-
         $response = $this->getHttpClient()
             ->post("{$this->baseUrl}/post/publish/video/init/", [
-                'post_info' => $this->buildVideoPostInfo($postPlatform, $content, $creatorInfo),
+                'post_info' => $this->buildVideoPostInfo($postPlatform, $content),
                 'source_info' => [
                     'source' => 'PULL_FROM_URL',
                     'video_url' => $media->url,
@@ -223,9 +213,7 @@ class TikTokPublisher
             );
         }
 
-        $creatorInfo = $this->queryCreatorInfo($postPlatform->socialAccount);
-
-        $postInfo = $this->buildPhotoPostInfo($postPlatform, $content, $creatorInfo);
+        $postInfo = $this->buildPhotoPostInfo($postPlatform, $content);
 
         // Auto add music is only for photos.
         $meta = $postPlatform->meta ?? [];

--- a/app/Services/Social/TikTokPublisher.php
+++ b/app/Services/Social/TikTokPublisher.php
@@ -97,7 +97,14 @@ class TikTokPublisher
         ];
     }
 
-    private function buildPostInfo(PostPlatform $postPlatform, ?string $content, array $creatorInfo): array
+    /**
+     * Build the post_info payload for a VIDEO post. TikTok's video endpoint
+     * accepts the caption in the `title` field (capped at 2200 chars by the
+     * platform's maxContentLength).
+     *
+     * @return array<string, mixed>
+     */
+    private function buildVideoPostInfo(PostPlatform $postPlatform, ?string $content, array $creatorInfo): array
     {
         $meta = $postPlatform->meta ?? [];
 
@@ -127,13 +134,45 @@ class TikTokPublisher
         return $postInfo;
     }
 
+    /**
+     * Build the post_info payload for a PHOTO carousel. TikTok's photo endpoint
+     * accepts the caption in the `description` field (cap 4000 UTF-16 runes).
+     * The `title` field is a separate 90-char headline that we don't expose,
+     * so we omit it. Duet/Stitch and is_aigc do not apply to photo posts.
+     *
+     * @return array<string, mixed>
+     */
+    private function buildPhotoPostInfo(PostPlatform $postPlatform, ?string $content, array $creatorInfo): array
+    {
+        $meta = $postPlatform->meta ?? [];
+
+        $privacyLevel = data_get($meta, 'privacy_level')
+            ?: data_get($creatorInfo, 'privacy_level', 'SELF_ONLY');
+
+        $postInfo = [
+            'description' => $content ?? '',
+            'privacy_level' => $privacyLevel,
+            'disable_comment' => ! data_get($meta, 'allow_comments', true),
+        ];
+
+        if (data_get($meta, 'brand_content_toggle', false)) {
+            $postInfo['brand_content_toggle'] = true;
+        }
+
+        if (data_get($meta, 'brand_organic_toggle', false)) {
+            $postInfo['brand_organic_toggle'] = true;
+        }
+
+        return $postInfo;
+    }
+
     private function publishVideo(PostPlatform $postPlatform, $media, ?string $content): array
     {
         $creatorInfo = $this->queryCreatorInfo($postPlatform->socialAccount);
 
         $response = $this->getHttpClient()
             ->post("{$this->baseUrl}/post/publish/video/init/", [
-                'post_info' => $this->buildPostInfo($postPlatform, $content, $creatorInfo),
+                'post_info' => $this->buildVideoPostInfo($postPlatform, $content, $creatorInfo),
                 'source_info' => [
                     'source' => 'PULL_FROM_URL',
                     'video_url' => $media->url,
@@ -186,11 +225,9 @@ class TikTokPublisher
 
         $creatorInfo = $this->queryCreatorInfo($postPlatform->socialAccount);
 
-        $postInfo = $this->buildPostInfo($postPlatform, $content, $creatorInfo);
-        // Photos don't support duet/stitch/is_aigc
-        unset($postInfo['disable_duet'], $postInfo['disable_stitch'], $postInfo['is_aigc']);
+        $postInfo = $this->buildPhotoPostInfo($postPlatform, $content, $creatorInfo);
 
-        // Auto add music is only for photos
+        // Auto add music is only for photos.
         $meta = $postPlatform->meta ?? [];
         if (data_get($meta, 'auto_add_music', false)) {
             $postInfo['auto_add_music'] = true;

--- a/database/factories/PostPlatformFactory.php
+++ b/database/factories/PostPlatformFactory.php
@@ -111,6 +111,7 @@ class PostPlatformFactory extends Factory
         return $this->state(fn (array $attributes) => [
             'platform' => Platform::TikTok,
             'content_type' => ContentType::TikTokVideo,
+            'meta' => ['privacy_level' => 'SELF_ONLY'],
         ]);
     }
 

--- a/lang/en/posts.php
+++ b/lang/en/posts.php
@@ -80,6 +80,7 @@ return [
             'promotional_paid_title' => 'Your photo/video will be labeled as "Paid partnership".',
             'promotional_description' => 'This cannot be changed once your video is posted.',
             'compliance_incomplete' => 'You need to indicate if your content promotes yourself, a third party, or both.',
+            'privacy_required' => 'TikTok privacy level is required when publishing.',
             'branded_cleared_private' => 'Privacy was cleared because Branded Content cannot be private.',
             'interaction_disabled_by_creator' => 'Disabled by your TikTok account settings.',
             'max_duration_exceeded' => 'Video is :duration s long but this account can only post videos up to :max s.',
@@ -404,6 +405,10 @@ return [
             'label' => 'Video',
             'description' => 'Short-form video content',
         ],
+        'tiktok_photo' => [
+            'label' => 'Photo carousel',
+            'description' => 'Up to 35 photos as a swipeable carousel',
+        ],
         'youtube_short' => [
             'label' => 'Short',
             'description' => 'Vertical video up to 60 seconds',
@@ -418,15 +423,15 @@ return [
         ],
         'pinterest_pin' => [
             'label' => 'Pin',
-            'description' => 'Image pin with link',
+            'description' => 'Standard image pin',
         ],
         'pinterest_video_pin' => [
             'label' => 'Video Pin',
-            'description' => 'Video content',
+            'description' => 'Video pin (4s - 15min)',
         ],
         'pinterest_carousel' => [
             'label' => 'Carousel',
-            'description' => '2-5 images',
+            'description' => 'Multi-image carousel (2-5 images)',
         ],
         'bluesky_post' => [
             'label' => 'Post',

--- a/lang/en/posts.php
+++ b/lang/en/posts.php
@@ -49,6 +49,11 @@ return [
         'write_caption' => 'Write your caption...',
         'tiktok' => [
             'settings' => 'TikTok Settings',
+            'variant_label' => 'Post type',
+            'variant' => [
+                'video' => 'Video',
+                'photo' => 'Photo carousel',
+            ],
             'posting_to' => 'Posting to',
             'privacy_level' => 'Who can see this video?',
             'privacy_placeholder' => 'Select visibility',
@@ -57,6 +62,7 @@ return [
                 'friends' => 'Mutual follow friends',
                 'followers' => 'Followers',
                 'private' => 'Only me',
+                'private_disabled_branded' => 'Branded content visibility cannot be set to private.',
             ],
             'privacy_hint' => 'The available options depend on your TikTok account settings.',
             'auto_add_music' => 'Auto add music',
@@ -74,7 +80,7 @@ return [
             'promotional_paid_title' => 'Your photo/video will be labeled as "Paid partnership".',
             'promotional_description' => 'This cannot be changed once your video is posted.',
             'compliance_incomplete' => 'You need to indicate if your content promotes yourself, a third party, or both.',
-            'branded_blocks_private' => 'Branded content cannot be private. Choose Public or Mutual follow friends.',
+            'branded_cleared_private' => 'Privacy was cleared because Branded Content cannot be private.',
             'interaction_disabled_by_creator' => 'Disabled by your TikTok account settings.',
             'max_duration_exceeded' => 'Video is :duration s long but this account can only post videos up to :max s.',
             'creator_info_loading' => 'Loading your TikTok account settings…',

--- a/lang/en/posts.php
+++ b/lang/en/posts.php
@@ -84,7 +84,6 @@ return [
             'branded_cleared_private' => 'Privacy was cleared because Branded Content cannot be private.',
             'interaction_disabled_by_creator' => 'Disabled by your TikTok account settings.',
             'max_duration_exceeded' => 'Video is :duration s long but this account can only post videos up to :max s.',
-            'creator_info_loading' => 'Loading your TikTok account settings…',
             'processing_hint' => 'After publishing, it may take a few minutes for the content to process and appear on your TikTok profile.',
             'brand_organic' => 'Your brand',
             'brand_organic_hint' => 'You are promoting yourself or your own brand. This video will be classified as Brand Organic.',

--- a/lang/es/posts.php
+++ b/lang/es/posts.php
@@ -80,6 +80,7 @@ return [
             'promotional_paid_title' => 'Tu foto/video será etiquetado como "Asociación pagada".',
             'promotional_description' => 'Esto no se puede cambiar una vez publicado el video.',
             'compliance_incomplete' => 'Debes indicar si tu contenido promociona a ti mismo, a un tercero o a ambos.',
+            'privacy_required' => 'La visibilidad de TikTok es obligatoria al publicar.',
             'branded_cleared_private' => 'La visibilidad se borró porque el contenido de marca no puede ser privado.',
             'interaction_disabled_by_creator' => 'Desactivado por la configuración de tu cuenta TikTok.',
             'max_duration_exceeded' => 'El video dura :duration s pero esta cuenta solo permite videos de hasta :max s.',
@@ -404,6 +405,10 @@ return [
             'label' => 'Video',
             'description' => 'Contenido de video corto',
         ],
+        'tiktok_photo' => [
+            'label' => 'Carrusel de fotos',
+            'description' => 'Hasta 35 fotos en un carrusel deslizable',
+        ],
         'youtube_short' => [
             'label' => 'Short',
             'description' => 'Video vertical de hasta 60 segundos',
@@ -418,15 +423,15 @@ return [
         ],
         'pinterest_pin' => [
             'label' => 'Pin',
-            'description' => 'Pin de imagen con enlace',
+            'description' => 'Pin de imagen estándar',
         ],
         'pinterest_video_pin' => [
             'label' => 'Pin de video',
-            'description' => 'Contenido de video',
+            'description' => 'Pin de video (4s - 15min)',
         ],
         'pinterest_carousel' => [
             'label' => 'Carrusel',
-            'description' => '2-5 imágenes',
+            'description' => 'Carrusel multi-imagen (2-5 imágenes)',
         ],
         'bluesky_post' => [
             'label' => 'Post',

--- a/lang/es/posts.php
+++ b/lang/es/posts.php
@@ -84,7 +84,6 @@ return [
             'branded_cleared_private' => 'La visibilidad se borró porque el contenido de marca no puede ser privado.',
             'interaction_disabled_by_creator' => 'Desactivado por la configuración de tu cuenta TikTok.',
             'max_duration_exceeded' => 'El video dura :duration s pero esta cuenta solo permite videos de hasta :max s.',
-            'creator_info_loading' => 'Cargando la configuración de tu cuenta TikTok…',
             'processing_hint' => 'Después de publicar, puede tardar unos minutos en procesarse y aparecer en tu perfil de TikTok.',
             'brand_organic' => 'Tu marca',
             'brand_organic_hint' => 'Estás promocionándote a ti mismo o a tu propia marca. Este video será clasificado como Brand Organic.',

--- a/lang/es/posts.php
+++ b/lang/es/posts.php
@@ -49,6 +49,11 @@ return [
         'write_caption' => 'Escribe tu descripción...',
         'tiktok' => [
             'settings' => 'Configuración de TikTok',
+            'variant_label' => 'Tipo de publicación',
+            'variant' => [
+                'video' => 'Video',
+                'photo' => 'Carrusel de fotos',
+            ],
             'posting_to' => 'Publicando en',
             'privacy_level' => '¿Quién puede ver este video?',
             'privacy_placeholder' => 'Selecciona la visibilidad',
@@ -57,6 +62,7 @@ return [
                 'friends' => 'Amigos mutuos',
                 'followers' => 'Seguidores',
                 'private' => 'Solo yo',
+                'private_disabled_branded' => 'El contenido de marca no puede ser privado.',
             ],
             'privacy_hint' => 'Las opciones disponibles dependen de la configuración de tu cuenta de TikTok.',
             'auto_add_music' => 'Agregar música automáticamente',
@@ -74,7 +80,7 @@ return [
             'promotional_paid_title' => 'Tu foto/video será etiquetado como "Asociación pagada".',
             'promotional_description' => 'Esto no se puede cambiar una vez publicado el video.',
             'compliance_incomplete' => 'Debes indicar si tu contenido promociona a ti mismo, a un tercero o a ambos.',
-            'branded_blocks_private' => 'El contenido patrocinado no puede ser privado. Elige Público o Amigos mutuos.',
+            'branded_cleared_private' => 'La visibilidad se borró porque el contenido de marca no puede ser privado.',
             'interaction_disabled_by_creator' => 'Desactivado por la configuración de tu cuenta TikTok.',
             'max_duration_exceeded' => 'El video dura :duration s pero esta cuenta solo permite videos de hasta :max s.',
             'creator_info_loading' => 'Cargando la configuración de tu cuenta TikTok…',

--- a/lang/pt-BR/posts.php
+++ b/lang/pt-BR/posts.php
@@ -49,6 +49,11 @@ return [
         'write_caption' => 'Escreva sua legenda...',
         'tiktok' => [
             'settings' => 'Configurações do TikTok',
+            'variant_label' => 'Tipo de publicação',
+            'variant' => [
+                'video' => 'Vídeo',
+                'photo' => 'Carrossel de fotos',
+            ],
             'posting_to' => 'Publicando em',
             'privacy_level' => 'Quem pode ver este vídeo?',
             'privacy_placeholder' => 'Selecione a visibilidade',
@@ -57,6 +62,7 @@ return [
                 'friends' => 'Amigos em comum',
                 'followers' => 'Seguidores',
                 'private' => 'Apenas eu',
+                'private_disabled_branded' => 'Conteúdo de marca não pode ser privado.',
             ],
             'privacy_hint' => 'As opções disponíveis dependem das configurações da sua conta TikTok.',
             'auto_add_music' => 'Adicionar música automaticamente',
@@ -74,7 +80,7 @@ return [
             'promotional_paid_title' => 'Sua foto/vídeo será rotulado como "Parceria paga".',
             'promotional_description' => 'Isso não poderá ser alterado após a publicação.',
             'compliance_incomplete' => 'Você precisa indicar se o conteúdo promove você mesmo, terceiros ou ambos.',
-            'branded_blocks_private' => 'Conteúdo patrocinado não pode ser privado. Escolha Público ou Amigos em comum.',
+            'branded_cleared_private' => 'A visibilidade foi limpa porque conteúdo de marca não pode ser privado.',
             'interaction_disabled_by_creator' => 'Desativado pelas configurações da sua conta TikTok.',
             'max_duration_exceeded' => 'Vídeo tem :duration s mas esta conta só permite vídeos de até :max s.',
             'creator_info_loading' => 'Carregando configurações da sua conta TikTok…',

--- a/lang/pt-BR/posts.php
+++ b/lang/pt-BR/posts.php
@@ -80,6 +80,7 @@ return [
             'promotional_paid_title' => 'Sua foto/vídeo será rotulado como "Parceria paga".',
             'promotional_description' => 'Isso não poderá ser alterado após a publicação.',
             'compliance_incomplete' => 'Você precisa indicar se o conteúdo promove você mesmo, terceiros ou ambos.',
+            'privacy_required' => 'A visibilidade do TikTok é obrigatória ao publicar.',
             'branded_cleared_private' => 'A visibilidade foi limpa porque conteúdo de marca não pode ser privado.',
             'interaction_disabled_by_creator' => 'Desativado pelas configurações da sua conta TikTok.',
             'max_duration_exceeded' => 'Vídeo tem :duration s mas esta conta só permite vídeos de até :max s.',
@@ -404,6 +405,10 @@ return [
             'label' => 'Vídeo',
             'description' => 'Conteúdo de vídeo curto',
         ],
+        'tiktok_photo' => [
+            'label' => 'Carrossel de fotos',
+            'description' => 'Até 35 fotos em um carrossel deslizável',
+        ],
         'youtube_short' => [
             'label' => 'Short',
             'description' => 'Vídeo vertical de até 60 segundos',
@@ -418,15 +423,15 @@ return [
         ],
         'pinterest_pin' => [
             'label' => 'Pin',
-            'description' => 'Pin de imagem com link',
+            'description' => 'Pin de imagem padrão',
         ],
         'pinterest_video_pin' => [
             'label' => 'Pin de Vídeo',
-            'description' => 'Conteúdo em vídeo',
+            'description' => 'Pin de vídeo (4s - 15min)',
         ],
         'pinterest_carousel' => [
             'label' => 'Carrossel',
-            'description' => '2-5 imagens',
+            'description' => 'Carrossel multi-imagem (2-5 imagens)',
         ],
         'bluesky_post' => [
             'label' => 'Post',

--- a/lang/pt-BR/posts.php
+++ b/lang/pt-BR/posts.php
@@ -84,7 +84,6 @@ return [
             'branded_cleared_private' => 'A visibilidade foi limpa porque conteúdo de marca não pode ser privado.',
             'interaction_disabled_by_creator' => 'Desativado pelas configurações da sua conta TikTok.',
             'max_duration_exceeded' => 'Vídeo tem :duration s mas esta conta só permite vídeos de até :max s.',
-            'creator_info_loading' => 'Carregando configurações da sua conta TikTok…',
             'processing_hint' => 'Após publicar, pode levar alguns minutos para o conteúdo ser processado e aparecer no seu perfil TikTok.',
             'brand_organic' => 'Sua marca',
             'brand_organic_hint' => 'Você está promovendo você mesmo ou sua própria marca. Este vídeo será classificado como Brand Organic.',

--- a/resources/js/components/posts/editor/ScheduleTab.vue
+++ b/resources/js/components/posts/editor/ScheduleTab.vue
@@ -12,6 +12,7 @@ import { Avatar } from '@/components/ui/avatar';
 import { Badge } from '@/components/ui/badge';
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
 import { getPlatformLabel, getPlatformLogo } from '@/composables/usePlatformLogo';
+import { Platform } from '@/enums/platform';
 
 interface SocialAccount {
     id: string;
@@ -97,33 +98,33 @@ const emit = defineEmits<{
 
 const selectedTikTokPlatforms = computed(() =>
     props.postPlatforms.filter(
-        (pp) => pp.platform === 'tiktok' && props.selectedPlatformIds.includes(pp.id),
+        (pp) => pp.platform === Platform.TikTok && props.selectedPlatformIds.includes(pp.id),
     ),
 );
 
 const selectedInstagramPlatforms = computed(() =>
     props.postPlatforms.filter(
-        (pp) => ['instagram', 'instagram-facebook'].includes(pp.platform)
+        (pp) => (pp.platform === Platform.Instagram || pp.platform === Platform.InstagramFacebook)
             && props.selectedPlatformIds.includes(pp.id),
     ),
 );
 
 const selectedFacebookPlatforms = computed(() =>
     props.postPlatforms.filter(
-        (pp) => pp.platform === 'facebook' && props.selectedPlatformIds.includes(pp.id),
+        (pp) => pp.platform === Platform.Facebook && props.selectedPlatformIds.includes(pp.id),
     ),
 );
 
 const selectedLinkedInPlatforms = computed(() =>
     props.postPlatforms.filter(
-        (pp) => ['linkedin', 'linkedin-page'].includes(pp.platform)
+        (pp) => (pp.platform === Platform.LinkedIn || pp.platform === Platform.LinkedInPage)
             && props.selectedPlatformIds.includes(pp.id),
     ),
 );
 
 const selectedPinterestPlatforms = computed(() =>
     props.postPlatforms.filter(
-        (pp) => pp.platform === 'pinterest' && props.selectedPlatformIds.includes(pp.id),
+        (pp) => pp.platform === Platform.Pinterest && props.selectedPlatformIds.includes(pp.id),
     ),
 );
 
@@ -267,8 +268,10 @@ const getPlatformAvatar = (pp: PostPlatform): string | null =>
                 :creator-info="getCreatorInfo(pp)"
                 :creator-info-loading="tiktokCreatorInfos === undefined || tiktokCreatorInfos === null"
                 :video-duration-sec="videoDurationSec"
+                :content-type="platformContentTypes[pp.id] ?? ''"
                 :meta="platformMeta[pp.id] ?? {}"
                 :disabled="isReadOnly"
+                @update:content-type="emit('update:platformContentType', pp.id, $event)"
                 @update:meta="emit('update:platformMeta', pp.id, $event)"
             />
         </div>

--- a/resources/js/components/posts/editor/ScheduleTab.vue
+++ b/resources/js/components/posts/editor/ScheduleTab.vue
@@ -266,7 +266,6 @@ const getPlatformAvatar = (pp: PostPlatform): string | null =>
                 :social-account="pp.social_account"
                 :publish-config="getPublishConfig(pp)"
                 :creator-info="getCreatorInfo(pp)"
-                :creator-info-loading="tiktokCreatorInfos === undefined || tiktokCreatorInfos === null"
                 :video-duration-sec="videoDurationSec"
                 :content-type="platformContentTypes[pp.id] ?? ''"
                 :meta="platformMeta[pp.id] ?? {}"

--- a/resources/js/components/posts/editor/TikTokSettings.vue
+++ b/resources/js/components/posts/editor/TikTokSettings.vue
@@ -40,7 +40,6 @@ interface Props {
     socialAccount: SocialAccount | null;
     publishConfig: Record<string, any> | null;
     creatorInfo?: CreatorInfo | null;
-    creatorInfoLoading?: boolean;
     videoDurationSec?: number | null;
     contentType: string;
     meta: Record<string, any>;
@@ -49,7 +48,6 @@ interface Props {
 
 const props = withDefaults(defineProps<Props>(), {
     creatorInfo: null,
-    creatorInfoLoading: false,
     videoDurationSec: null,
     disabled: false,
 });
@@ -235,11 +233,6 @@ watch(
                     </button>
                 </div>
             </div>
-
-            <p v-if="creatorInfoLoading" class="flex items-center gap-2 text-xs font-medium text-foreground/60">
-                <span class="inline-block size-3 animate-pulse rounded-full bg-foreground/30" />
-                {{ $t('posts.form.tiktok.creator_info_loading') }}
-            </p>
 
             <!-- Creator identity -->
             <div v-if="socialAccount" class="flex items-center gap-3 rounded-lg bg-foreground/5 p-3">

--- a/resources/js/components/posts/editor/TikTokSettings.vue
+++ b/resources/js/components/posts/editor/TikTokSettings.vue
@@ -1,6 +1,8 @@
 <script setup lang="ts">
 import { IconAlertTriangle, IconChevronDown, IconChevronUp } from '@tabler/icons-vue';
+import { trans } from 'laravel-vue-i18n';
 import { computed, ref, watch } from 'vue';
+import { toast } from 'vue-sonner';
 
 import { Avatar } from '@/components/ui/avatar';
 import { Checkbox } from '@/components/ui/checkbox';
@@ -13,6 +15,7 @@ import {
     SelectValue,
 } from '@/components/ui/select';
 import { getPlatformLogo } from '@/composables/usePlatformLogo';
+import { ContentType } from '@/enums/content-type';
 
 interface SocialAccount {
     id: string;
@@ -39,6 +42,7 @@ interface Props {
     creatorInfo?: CreatorInfo | null;
     creatorInfoLoading?: boolean;
     videoDurationSec?: number | null;
+    contentType: string;
     meta: Record<string, any>;
     disabled?: boolean;
 }
@@ -52,7 +56,18 @@ const props = withDefaults(defineProps<Props>(), {
 
 const emit = defineEmits<{
     'update:meta': [value: Record<string, any>];
+    'update:contentType': [value: string];
 }>();
+
+const variants = [
+    { value: ContentType.TikTokVideo, labelKey: 'posts.form.tiktok.variant.video' },
+    { value: ContentType.TikTokPhoto, labelKey: 'posts.form.tiktok.variant.photo' },
+] as const;
+
+const pickVariant = (value: string) => {
+    if (props.disabled) return;
+    emit('update:contentType', value);
+};
 
 const open = ref(false);
 
@@ -118,16 +133,23 @@ const allPrivacyOptions = computed(() => {
     return fromApi.length > 0 ? fromApi : props.publishConfig?.privacyLevelOptions ?? [];
 });
 
-// Branded content cannot be private (TikTok compliance).
-const privacyOptions = computed(() =>
-    brandContentToggle.value
-        ? allPrivacyOptions.value.filter((o: string) => o !== 'SELF_ONLY')
-        : allPrivacyOptions.value,
-);
+// Render every option creator_info returns. SELF_ONLY is shown but disabled when
+// Branded Content is checked (TikTok UX Guideline Point 3b — must show interaction,
+// not hide it).
+const privacyOptions = computed(() => allPrivacyOptions.value);
+
+const isSelfOnlyDisabled = (option: string): boolean =>
+    option === 'SELF_ONLY' && brandContentToggle.value;
 
 const commentDisabled = computed(() => Boolean(props.creatorInfo?.comment_disabled));
 const duetDisabled = computed(() => Boolean(props.creatorInfo?.duet_disabled));
 const stitchDisabled = computed(() => Boolean(props.creatorInfo?.stitch_disabled));
+
+// Derive from the user's explicit variant choice (contentType), not from attached
+// media. The variant selector is the single source of truth — user picks it, the
+// gating responds immediately, and validation enforces media↔content_type matching.
+const isPhotoPost = computed(() => props.contentType === ContentType.TikTokPhoto);
+const isVideoPost = computed(() => props.contentType === ContentType.TikTokVideo);
 
 // Max video duration check (when creator_info is available and we have duration).
 const maxDurationSec = computed(() => props.creatorInfo?.max_video_post_duration_sec ?? null);
@@ -152,9 +174,12 @@ const promotionalTitleKey = computed(() =>
 );
 
 // If user flips branded content ON while privacy is SELF_ONLY, clear it so they must re-pick.
+// Surface a toast so the user understands why the field reset (TikTok UX Guideline Point 3b
+// requires informing the user when an auto-switch happens).
 watch(brandContentToggle, (value) => {
     if (value && privacyLevel.value === 'SELF_ONLY') {
         privacyLevel.value = '';
+        toast.warning(trans('posts.form.tiktok.branded_cleared_private'));
     }
 });
 
@@ -191,6 +216,26 @@ watch(
         </button>
 
         <div v-if="open" class="space-y-5 border-t-2 border-foreground/10 px-4 pb-4 pt-4">
+            <!-- Variant: Video / Photo carousel -->
+            <div class="space-y-2">
+                <p class="text-[11px] font-black uppercase tracking-widest text-foreground/60">{{ $t('posts.form.tiktok.variant_label') }}</p>
+                <div class="flex flex-wrap gap-2">
+                    <button
+                        v-for="variant in variants"
+                        :key="variant.value"
+                        type="button"
+                        class="cursor-pointer rounded-full border-2 px-3 py-1 text-xs font-bold uppercase tracking-widest transition-colors disabled:cursor-not-allowed disabled:opacity-50"
+                        :class="contentType === variant.value
+                            ? 'border-foreground bg-violet-100 text-foreground shadow-2xs'
+                            : 'border-foreground/30 text-foreground/70 hover:border-foreground hover:text-foreground'"
+                        :disabled="props.disabled"
+                        @click="pickVariant(variant.value)"
+                    >
+                        {{ $t(variant.labelKey) }}
+                    </button>
+                </div>
+            </div>
+
             <p v-if="creatorInfoLoading" class="flex items-center gap-2 text-xs font-medium text-foreground/60">
                 <span class="inline-block size-3 animate-pulse rounded-full bg-foreground/30" />
                 {{ $t('posts.form.tiktok.creator_info_loading') }}
@@ -220,22 +265,35 @@ watch(
                         <SelectValue :placeholder="$t('posts.form.tiktok.privacy_placeholder')" />
                     </SelectTrigger>
                     <SelectContent>
-                        <SelectItem v-for="option in privacyOptions" :key="option" :value="option">
+                        <SelectItem
+                            v-for="option in privacyOptions"
+                            :key="option"
+                            :value="option"
+                            :disabled="isSelfOnlyDisabled(option)"
+                            :title="isSelfOnlyDisabled(option) ? $t('posts.form.tiktok.privacy.private_disabled_branded') : undefined"
+                        >
                             {{ $t(privacyLabelKey[option] ?? option) }}
                         </SelectItem>
                     </SelectContent>
                 </Select>
                 <p class="text-xs font-medium text-foreground/60">{{ $t("posts.form.tiktok.privacy_hint") }}</p>
+                <p
+                    v-if="brandContentToggle"
+                    class="flex items-start gap-1.5 rounded-md border-2 border-foreground bg-amber-50 p-2 text-xs font-semibold text-amber-800"
+                >
+                    <IconAlertTriangle class="mt-0.5 size-3.5 shrink-0" />
+                    {{ $t('posts.form.tiktok.privacy.private_disabled_branded') }}
+                </p>
             </div>
 
             <!-- Max duration warning -->
-            <p v-if="exceedsMaxDuration" class="flex items-start gap-2 rounded-lg border-2 border-foreground bg-rose-50 p-2 text-xs font-semibold text-rose-700">
+            <p v-if="isVideoPost && exceedsMaxDuration" class="flex items-start gap-2 rounded-lg border-2 border-foreground bg-rose-50 p-2 text-xs font-semibold text-rose-700">
                 <IconAlertTriangle class="mt-0.5 size-3.5 shrink-0" />
                 {{ $t('posts.form.tiktok.max_duration_exceeded', { duration: String(videoDurationSec ?? 0), max: String(maxDurationSec ?? 0) }) }}
             </p>
 
             <!-- Auto Add Music (photos only) -->
-            <div class="space-y-2">
+            <div v-if="isPhotoPost" class="space-y-2">
                 <Label class="text-[11px] font-black uppercase tracking-widest text-foreground/60">{{ $t("posts.form.tiktok.auto_add_music") }}</Label>
                 <Select v-model="autoAddMusic" :disabled="props.disabled">
                     <SelectTrigger class="w-full">
@@ -257,21 +315,23 @@ watch(
                         <Checkbox v-model="allowComments" :disabled="props.disabled || commentDisabled" />
                         {{ $t('posts.form.tiktok.comments') }}
                     </label>
-                    <label class="flex items-center gap-2 text-sm" :class="{ 'opacity-50': duetDisabled }" :title="duetDisabled ? $t('posts.form.tiktok.interaction_disabled_by_creator') : ''">
-                        <Checkbox v-model="allowDuet" :disabled="props.disabled || duetDisabled" />
-                        {{ $t('posts.form.tiktok.duet') }}
-                    </label>
-                    <label class="flex items-center gap-2 text-sm" :class="{ 'opacity-50': stitchDisabled }" :title="stitchDisabled ? $t('posts.form.tiktok.interaction_disabled_by_creator') : ''">
-                        <Checkbox v-model="allowStitch" :disabled="props.disabled || stitchDisabled" />
-                        {{ $t('posts.form.tiktok.stitch') }}
-                    </label>
+                    <template v-if="!isPhotoPost">
+                        <label class="flex items-center gap-2 text-sm" :class="{ 'opacity-50': duetDisabled }" :title="duetDisabled ? $t('posts.form.tiktok.interaction_disabled_by_creator') : ''">
+                            <Checkbox v-model="allowDuet" :disabled="props.disabled || duetDisabled" />
+                            {{ $t('posts.form.tiktok.duet') }}
+                        </label>
+                        <label class="flex items-center gap-2 text-sm" :class="{ 'opacity-50': stitchDisabled }" :title="stitchDisabled ? $t('posts.form.tiktok.interaction_disabled_by_creator') : ''">
+                            <Checkbox v-model="allowStitch" :disabled="props.disabled || stitchDisabled" />
+                            {{ $t('posts.form.tiktok.stitch') }}
+                        </label>
+                    </template>
                 </div>
             </div>
 
             <div class="border-t-2 border-foreground/10" />
 
             <!-- Video made with AI (independent) -->
-            <label class="flex items-center gap-2 text-sm">
+            <label v-if="!isPhotoPost" class="flex items-center gap-2 text-sm">
                 <Checkbox v-model="isAigc" :disabled="props.disabled" />
                 {{ $t('posts.form.tiktok.is_aigc') }}
             </label>
@@ -317,19 +377,10 @@ watch(
                 </div>
             </div>
 
-            <!-- Compliance declaration -->
-            <p v-if="hasAnyBrandToggle" class="text-xs text-muted-foreground">
+            <!-- Compliance declaration — always visible per TikTok UX guideline Point 2/4 -->
+            <p class="text-xs text-muted-foreground">
                 {{ $t('posts.form.tiktok.compliance.agree') }}
-                <a
-                    :href="publishConfig?.musicUsageConfirmationUrl"
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    class="font-bold text-primary underline-offset-2 hover:underline"
-                >
-                    {{ $t('posts.form.tiktok.compliance.music_usage') }}
-                </a>
                 <template v-if="brandContentToggle">
-                    {{ ' ' + $t('posts.form.tiktok.compliance.and') + ' ' }}
                     <a
                         :href="publishConfig?.brandedContentPolicyUrl"
                         target="_blank"
@@ -338,7 +389,16 @@ watch(
                     >
                         {{ $t('posts.form.tiktok.compliance.branded_policy') }}
                     </a>
+                    {{ ' ' + $t('posts.form.tiktok.compliance.and') + ' ' }}
                 </template>
+                <a
+                    :href="publishConfig?.musicUsageConfirmationUrl"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    class="font-bold text-primary underline-offset-2 hover:underline"
+                >
+                    {{ $t('posts.form.tiktok.compliance.music_usage') }}
+                </a>
             </p>
         </div>
     </div>

--- a/resources/js/enums/content-type.ts
+++ b/resources/js/enums/content-type.ts
@@ -11,6 +11,7 @@ export const ContentType = {
     FacebookReel: 'facebook_reel',
     FacebookStory: 'facebook_story',
     TikTokVideo: 'tiktok_video',
+    TikTokPhoto: 'tiktok_photo',
     YouTubeShort: 'youtube_short',
     XPost: 'x_post',
     ThreadsPost: 'threads_post',

--- a/resources/js/enums/platform.ts
+++ b/resources/js/enums/platform.ts
@@ -1,0 +1,16 @@
+export const Platform = {
+    LinkedIn: 'linkedin',
+    LinkedInPage: 'linkedin-page',
+    X: 'x',
+    TikTok: 'tiktok',
+    YouTube: 'youtube',
+    Facebook: 'facebook',
+    Instagram: 'instagram',
+    InstagramFacebook: 'instagram-facebook',
+    Threads: 'threads',
+    Pinterest: 'pinterest',
+    Bluesky: 'bluesky',
+    Mastodon: 'mastodon',
+} as const;
+
+export type PlatformValue = (typeof Platform)[keyof typeof Platform];

--- a/resources/js/pages/posts/Edit.vue
+++ b/resources/js/pages/posts/Edit.vue
@@ -213,6 +213,20 @@ const getMediaIncompatibilityReason = (contentType: string, mediaItems: MediaIte
     return null;
 };
 
+// Platforms whose tile should consider every available content type when
+// deciding whether the attached media is compatible. The user's actual
+// variant is picked inside the platform's settings panel — at the tile
+// level we just need to know if any variant works.
+const PLATFORM_VARIANTS: Record<string, string[]> = {
+    [Platform.TikTok]: ['tiktok_video', 'tiktok_photo'],
+};
+
+const firstCompatibleVariant = (platform: string, mediaItems: MediaItem[]): string | null => {
+    const variants = PLATFORM_VARIANTS[platform];
+    if (!variants) return null;
+    return variants.find((ct) => !getMediaIncompatibilityReason(ct, mediaItems)) ?? null;
+};
+
 const platformIssues = computed<Record<string, string>>(() => {
     const issues: Record<string, string> = {};
 
@@ -223,15 +237,13 @@ const platformIssues = computed<Record<string, string>>(() => {
             continue;
         }
 
-        // TikTok has two content types (video / photo) that the user toggles
-        // inside TikTokSettings. The tile-level check is lenient: a tile is
-        // only blocked when neither variant accepts the current media. If the
-        // current variant doesn't fit but the other one does, togglePlatform
-        // auto-corrects on selection.
-        if (pp.platform === Platform.TikTok) {
-            const videoReason = getMediaIncompatibilityReason('tiktok_video', media.value);
-            const photoReason = getMediaIncompatibilityReason('tiktok_photo', media.value);
-            if (videoReason && photoReason) issues[pp.id] = videoReason;
+        // For platforms that expose multiple content types via a variant picker,
+        // the tile is only blocked when no variant fits — togglePlatform will
+        // switch to a compatible variant on selection.
+        if (PLATFORM_VARIANTS[pp.platform]) {
+            if (!firstCompatibleVariant(pp.platform, media.value)) {
+                issues[pp.id] = getMediaIncompatibilityReason(contentType, media.value) ?? '';
+            }
             continue;
         }
 
@@ -343,28 +355,17 @@ const togglePlatform = (platformId: string) => {
     if (isReadOnly.value) return;
     const index = selectedPlatformIds.value.indexOf(platformId);
     if (index === -1) {
-        adjustTikTokContentTypeForMedia(platformId);
+        // For platforms with a variant picker, snap the post-platform's
+        // content_type to one that fits the current media before selection.
+        const pp = post.value.post_platforms.find((p) => p.id === platformId);
+        const variant = pp ? firstCompatibleVariant(pp.platform, media.value) : null;
+        if (variant && platformContentTypes.value[platformId] !== variant) {
+            platformContentTypes.value = { ...platformContentTypes.value, [platformId]: variant };
+        }
         selectedPlatformIds.value.push(platformId);
     } else {
         selectedPlatformIds.value.splice(index, 1);
     }
-};
-
-// TikTok has two content types (video, photo) backed by different API endpoints.
-// When the user picks the TikTok tile while media is already attached, switch
-// to the matching variant so they don't land on tiktok_video with images and
-// see a compliance error. The variant picker in TikTokSettings can still override.
-const adjustTikTokContentTypeForMedia = (platformId: string) => {
-    const pp = post.value.post_platforms.find((p) => p.id === platformId);
-    if (!pp || pp.platform !== Platform.TikTok || media.value.length === 0) return;
-
-    const first = media.value[0];
-    const isImage = first.type === 'image' || first.mime_type?.startsWith('image/');
-    const isVideo = first.type === 'video' || first.mime_type?.startsWith('video/');
-    const target = isImage ? 'tiktok_photo' : isVideo ? 'tiktok_video' : null;
-    if (!target || platformContentTypes.value[platformId] === target) return;
-
-    platformContentTypes.value = { ...platformContentTypes.value, [platformId]: target };
 };
 
 // Save logic

--- a/resources/js/pages/posts/Edit.vue
+++ b/resources/js/pages/posts/Edit.vue
@@ -392,6 +392,28 @@ const triggerAutosave = () => {
     }
 };
 
+// Auto-switch TikTok content_type to match the attached media. Without this,
+// a fresh post defaults TikTok to tiktok_video, so attaching images first
+// disables the TikTok tile (compliance check rejects images for video posts).
+// User can still override via the variant picker in TikTokSettings.
+watch(media, () => {
+    if (media.value.length === 0) return;
+
+    const first = media.value[0];
+    const isVideo = first.type === 'video' || first.mime_type?.startsWith('video/');
+    const isImage = first.type === 'image' || first.mime_type?.startsWith('image/');
+    const target = isVideo ? 'tiktok_video' : isImage ? 'tiktok_photo' : null;
+    if (!target) return;
+
+    for (const pp of post.value.post_platforms) {
+        if (pp.platform !== Platform.TikTok) continue;
+        const current = platformContentTypes.value[pp.id];
+        if (current && current !== target && (current === 'tiktok_video' || current === 'tiktok_photo')) {
+            platformContentTypes.value = { ...platformContentTypes.value, [pp.id]: target };
+        }
+    }
+}, { deep: true });
+
 watch([content, media, selectedPlatformIds, scheduledDateTime, selectedLabelIds, platformMeta, platformContentTypes], triggerAutosave, { deep: true });
 
 onUnmounted(() => {

--- a/resources/js/pages/posts/Edit.vue
+++ b/resources/js/pages/posts/Edit.vue
@@ -22,6 +22,7 @@ import { getMediaItemIssue } from '@/composables/useMedia';
 import { getMediaRulesForContentType } from '@/composables/useMediaRules';
 import dayjs from '@/dayjs';
 import debounce from '@/debounce';
+import { Platform } from '@/enums/platform';
 import AppLayout from '@/layouts/AppLayout.vue';
 import { destroy as destroyPost, update as updatePost } from '@/routes/app/posts';
 
@@ -238,7 +239,7 @@ const mediaCompliancePerPlatformValid = computed(
 // - if disclosure toggle is ON, at least one sub-toggle must be selected
 const tiktokComplianceValid = computed(() => {
     const tiktokPlatforms = post.value.post_platforms.filter(
-        (pp) => pp.platform === 'tiktok' && selectedPlatformIds.value.includes(pp.id),
+        (pp) => pp.platform === Platform.TikTok && selectedPlatformIds.value.includes(pp.id),
     );
     return tiktokPlatforms.every((pp) => {
         const meta = platformMeta.value[pp.id] ?? {};
@@ -255,13 +256,29 @@ const canSchedule = computed(
 const postActionTooltip = computed(() => {
     if (canSchedule.value) return '';
 
+    // Collect platform-specific media compatibility issues.
     const reasons = post.value.post_platforms
         .filter((pp) => selectedPlatformIds.value.includes(pp.id) && platformIssues.value[pp.id])
         .map((pp) => `${pp.platform_name ?? pp.platform}: ${platformIssues.value[pp.id]}`);
 
-    if (reasons.length === 0) return trans('posts.edit.compliance_incomplete');
+    if (reasons.length > 0) return reasons.join('\n');
 
-    return reasons.join('\n');
+    // No media issues — the only remaining blocker is TikTok compliance.
+    // Surface the exact TikTok-required tooltip when the disclosure toggle
+    // is on without a sub-selection (UX Guideline Point 3a). For other TikTok
+    // cases (e.g. missing privacy_level), fall back to the generic message.
+    const tiktokDisclosureIncomplete = post.value.post_platforms.some((pp) => {
+        if (pp.platform !== Platform.TikTok) return false;
+        if (!selectedPlatformIds.value.includes(pp.id)) return false;
+        const meta = platformMeta.value[pp.id] ?? {};
+        return Boolean(meta.disclose) && !meta.brand_organic_toggle && !meta.brand_content_toggle;
+    });
+
+    if (tiktokDisclosureIncomplete) {
+        return trans('posts.form.tiktok.compliance_incomplete');
+    }
+
+    return trans('posts.edit.compliance_incomplete');
 });
 
 // Schedule

--- a/resources/js/pages/posts/Edit.vue
+++ b/resources/js/pages/posts/Edit.vue
@@ -213,12 +213,18 @@ const getMediaIncompatibilityReason = (contentType: string, mediaItems: MediaIte
     return null;
 };
 
-// Platforms whose tile should consider every available content type when
-// deciding whether the attached media is compatible. The user's actual
-// variant is picked inside the platform's settings panel — at the tile
-// level we just need to know if any variant works.
+// Platforms whose default content_type doesn't accept every media type,
+// so the tile would otherwise block silently when the user attaches the
+// "wrong" kind. List the variants that should be considered at the tile
+// level — togglePlatform snaps content_type to whichever fits the media.
+//
+// Instagram/Facebook/LinkedIn are intentionally NOT here: their defaults
+// already accept image and video, and their secondary variants (Reel,
+// Carousel) are picked manually by the user. Including them would hide
+// real picker errors (e.g. Reel + image incompatibility) at the tile level.
 const PLATFORM_VARIANTS: Record<string, string[]> = {
     [Platform.TikTok]: ['tiktok_video', 'tiktok_photo'],
+    [Platform.Pinterest]: ['pinterest_pin', 'pinterest_video_pin', 'pinterest_carousel'],
 };
 
 const firstCompatibleVariant = (platform: string, mediaItems: MediaItem[]): string | null => {

--- a/resources/js/pages/posts/Edit.vue
+++ b/resources/js/pages/posts/Edit.vue
@@ -223,6 +223,18 @@ const platformIssues = computed<Record<string, string>>(() => {
             continue;
         }
 
+        // TikTok has two content types (video / photo) that the user toggles
+        // inside TikTokSettings. The tile-level check is lenient: a tile is
+        // only blocked when neither variant accepts the current media. If the
+        // current variant doesn't fit but the other one does, togglePlatform
+        // auto-corrects on selection.
+        if (pp.platform === Platform.TikTok) {
+            const videoReason = getMediaIncompatibilityReason('tiktok_video', media.value);
+            const photoReason = getMediaIncompatibilityReason('tiktok_photo', media.value);
+            if (videoReason && photoReason) issues[pp.id] = videoReason;
+            continue;
+        }
+
         const reason = getMediaIncompatibilityReason(contentType, media.value);
         if (reason) issues[pp.id] = reason;
     }
@@ -331,10 +343,28 @@ const togglePlatform = (platformId: string) => {
     if (isReadOnly.value) return;
     const index = selectedPlatformIds.value.indexOf(platformId);
     if (index === -1) {
+        adjustTikTokContentTypeForMedia(platformId);
         selectedPlatformIds.value.push(platformId);
     } else {
         selectedPlatformIds.value.splice(index, 1);
     }
+};
+
+// TikTok has two content types (video, photo) backed by different API endpoints.
+// When the user picks the TikTok tile while media is already attached, switch
+// to the matching variant so they don't land on tiktok_video with images and
+// see a compliance error. The variant picker in TikTokSettings can still override.
+const adjustTikTokContentTypeForMedia = (platformId: string) => {
+    const pp = post.value.post_platforms.find((p) => p.id === platformId);
+    if (!pp || pp.platform !== Platform.TikTok || media.value.length === 0) return;
+
+    const first = media.value[0];
+    const isImage = first.type === 'image' || first.mime_type?.startsWith('image/');
+    const isVideo = first.type === 'video' || first.mime_type?.startsWith('video/');
+    const target = isImage ? 'tiktok_photo' : isVideo ? 'tiktok_video' : null;
+    if (!target || platformContentTypes.value[platformId] === target) return;
+
+    platformContentTypes.value = { ...platformContentTypes.value, [platformId]: target };
 };
 
 // Save logic
@@ -391,28 +421,6 @@ const triggerAutosave = () => {
         debouncedSave();
     }
 };
-
-// Auto-switch TikTok content_type to match the attached media. Without this,
-// a fresh post defaults TikTok to tiktok_video, so attaching images first
-// disables the TikTok tile (compliance check rejects images for video posts).
-// User can still override via the variant picker in TikTokSettings.
-watch(media, () => {
-    if (media.value.length === 0) return;
-
-    const first = media.value[0];
-    const isVideo = first.type === 'video' || first.mime_type?.startsWith('video/');
-    const isImage = first.type === 'image' || first.mime_type?.startsWith('image/');
-    const target = isVideo ? 'tiktok_video' : isImage ? 'tiktok_photo' : null;
-    if (!target) return;
-
-    for (const pp of post.value.post_platforms) {
-        if (pp.platform !== Platform.TikTok) continue;
-        const current = platformContentTypes.value[pp.id];
-        if (current && current !== target && (current === 'tiktok_video' || current === 'tiktok_photo')) {
-            platformContentTypes.value = { ...platformContentTypes.value, [pp.id]: target };
-        }
-    }
-}, { deep: true });
 
 watch([content, media, selectedPlatformIds, scheduledDateTime, selectedLabelIds, platformMeta, platformContentTypes], triggerAutosave, { deep: true });
 

--- a/tests/Feature/UpdatePostRequestTest.php
+++ b/tests/Feature/UpdatePostRequestTest.php
@@ -1,0 +1,97 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Enums\Post\Status;
+use App\Enums\PostPlatform\ContentType;
+use App\Enums\SocialAccount\Platform;
+use App\Enums\UserWorkspace\Role;
+use App\Models\Post;
+use App\Models\PostPlatform;
+use App\Models\SocialAccount;
+use App\Models\User;
+use App\Models\Workspace;
+
+beforeEach(function () {
+    $this->user = User::factory()->create();
+    $this->workspace = Workspace::factory()->create(['user_id' => $this->user->id]);
+    $this->workspace->members()->attach($this->user->id, ['role' => Role::Member->value]);
+    $this->user->update(['current_workspace_id' => $this->workspace->id]);
+
+    $this->post = Post::factory()->create([
+        'workspace_id' => $this->workspace->id,
+        'user_id' => $this->user->id,
+    ]);
+
+    // Media payload used by tests that need to satisfy ContentTypeCompatibleWithMedia.
+    $this->mediaPayload = [
+        [
+            'id' => 'test-media-video',
+            'path' => 'media/2026-01/test-video.mp4',
+            'url' => 'https://example.com/media/2026-01/test-video.mp4',
+            'type' => 'video',
+            'mime_type' => 'video/mp4',
+            'original_filename' => 'test-video.mp4',
+        ],
+    ];
+    $this->socialAccount = SocialAccount::factory()->create([
+        'workspace_id' => $this->workspace->id,
+        'platform' => Platform::TikTok,
+    ]);
+    $this->postPlatform = PostPlatform::factory()->tiktok()->create([
+        'post_id' => $this->post->id,
+        'social_account_id' => $this->socialAccount->id,
+        // Override factory default so we control privacy_level per test.
+        'meta' => [],
+    ]);
+});
+
+test('publishing a tiktok post without privacy_level is rejected', function () {
+    $response = $this->actingAs($this->user)
+        ->put(route('app.posts.update', $this->post), [
+            'status' => Status::Publishing->value,
+            'media' => $this->mediaPayload,
+            'platforms' => [
+                [
+                    'id' => $this->postPlatform->id,
+                    'content_type' => ContentType::TikTokVideo->value,
+                    'meta' => [],
+                ],
+            ],
+        ]);
+
+    $response->assertSessionHasErrors('platforms.0.meta.privacy_level');
+});
+
+test('publishing a tiktok post with privacy_level passes privacy_level validation', function () {
+    $response = $this->actingAs($this->user)
+        ->put(route('app.posts.update', $this->post), [
+            'status' => Status::Publishing->value,
+            'media' => $this->mediaPayload,
+            'platforms' => [
+                [
+                    'id' => $this->postPlatform->id,
+                    'content_type' => ContentType::TikTokVideo->value,
+                    'meta' => ['privacy_level' => 'SELF_ONLY'],
+                ],
+            ],
+        ]);
+
+    $response->assertSessionDoesntHaveErrors(['platforms.0.meta.privacy_level']);
+});
+
+test('saving a tiktok post as draft without privacy_level skips the privacy_level rule', function () {
+    $response = $this->actingAs($this->user)
+        ->put(route('app.posts.update', $this->post), [
+            'status' => Status::Draft->value,
+            'platforms' => [
+                [
+                    'id' => $this->postPlatform->id,
+                    'content_type' => ContentType::TikTokVideo->value,
+                    'meta' => [],
+                ],
+            ],
+        ]);
+
+    $response->assertSessionDoesntHaveErrors(['platforms.0.meta.privacy_level']);
+});

--- a/tests/Unit/Enums/PostPlatform/TikTokPhotoContentTypeTest.php
+++ b/tests/Unit/Enums/PostPlatform/TikTokPhotoContentTypeTest.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Enums\PostPlatform\ContentType;
+use App\Enums\SocialAccount\Platform as SocialPlatform;
+
+test('tiktok photo content type has correct platform mapping', function () {
+    expect(ContentType::TikTokPhoto->platform())->toBe(SocialPlatform::TikTok);
+});
+
+test('tiktok photo content type supports up to 35 images', function () {
+    expect(ContentType::TikTokPhoto->maxMediaCount())->toBe(35);
+});
+
+test('tiktok photo content type supports images and not video', function () {
+    expect(ContentType::TikTokPhoto->supportsImage())->toBeTrue();
+    expect(ContentType::TikTokPhoto->supportsVideo())->toBeFalse();
+});
+
+test('tiktok photo content type label is human-readable', function () {
+    expect(ContentType::TikTokPhoto->label())->toBe('Photo carousel');
+});

--- a/tests/Unit/Services/Social/TikTokPublisherTest.php
+++ b/tests/Unit/Services/Social/TikTokPublisherTest.php
@@ -114,7 +114,13 @@ test('tiktok publisher can publish photos', function () {
     expect($result['id'])->toBe('pub_photo_123');
 
     Http::assertSent(function ($request) {
-        return str_contains($request->url(), '/post/publish/content/init/');
+        if (! str_contains($request->url(), '/post/publish/content/init/')) {
+            return false;
+        }
+        $body = json_decode($request->body(), true);
+
+        return data_get($body, 'post_info.description') === 'Check out this TikTok video!'
+            && ! isset($body['post_info']['title']);
     });
 });
 
@@ -481,7 +487,9 @@ test('tiktok publisher sends auto_add_music for photo posts', function () {
         return $postInfo['auto_add_music'] === true
             && ! isset($postInfo['disable_duet'])
             && ! isset($postInfo['disable_stitch'])
-            && ! isset($postInfo['is_aigc']);
+            && ! isset($postInfo['is_aigc'])
+            && ! isset($postInfo['title'])
+            && isset($postInfo['description']);
     });
 });
 
@@ -575,5 +583,47 @@ test('tiktok publisher uses default settings when meta is empty', function () {
             && $postInfo['disable_stitch'] === true
             && ! isset($postInfo['is_aigc'])
             && ! isset($postInfo['brand_content_toggle']);
+    });
+});
+
+test('tiktok publisher sends video caption in title field, never description', function () {
+    $this->post->update([
+        'media' => [
+            [
+                'id' => 'test-media-video',
+                'path' => 'media/2026-01/test-video.mp4',
+                'url' => 'https://example.com/media/2026-01/test-video.mp4',
+                'mime_type' => 'video/mp4',
+                'original_filename' => 'test-video.mp4',
+            ],
+        ],
+        'content' => 'My video caption',
+    ]);
+    $this->postPlatform->update(['meta' => ['privacy_level' => 'SELF_ONLY']]);
+
+    Http::fake([
+        'https://open.tiktokapis.com/v2/post/publish/creator_info/query/' => Http::response([
+            'data' => [
+                'privacy_level_options' => ['SELF_ONLY'],
+            ],
+        ], 200),
+        'https://open.tiktokapis.com/v2/post/publish/video/init/' => Http::response([
+            'data' => ['publish_id' => 'pub_video_123'],
+        ], 200),
+        'https://open.tiktokapis.com/v2/post/publish/status/fetch/' => Http::response([
+            'data' => ['status' => 'PUBLISH_COMPLETE', 'publish_id' => 'pub_video_123'],
+        ], 200),
+    ]);
+
+    $this->publisher->publish($this->postPlatform);
+
+    Http::assertSent(function ($request) {
+        if (! str_contains($request->url(), '/post/publish/video/init/')) {
+            return false;
+        }
+        $body = json_decode($request->body(), true);
+
+        return data_get($body, 'post_info.title') === 'My video caption'
+            && ! isset($body['post_info']['description']);
     });
 });

--- a/tests/Unit/Services/Social/TikTokPublisherTest.php
+++ b/tests/Unit/Services/Social/TikTokPublisherTest.php
@@ -310,7 +310,10 @@ test('tiktok publisher returns null url when username missing', function () {
     expect($result['url'])->toBeNull();
 });
 
-test('tiktok publisher falls back to self only when creator info fails', function () {
+test('tiktok publisher publishes with user-selected privacy level even when creator info query fails', function () {
+    // User has explicitly selected SELF_ONLY in meta. creator_info failure must not block publishing.
+    $this->postPlatform->update(['meta' => ['privacy_level' => 'SELF_ONLY']]);
+
     $this->post->update([
         'media' => [
             [
@@ -324,7 +327,7 @@ test('tiktok publisher falls back to self only when creator info fails', functio
     ]);
 
     Http::fake([
-        // creator_info/query returns 500 — publisher should fall back to SELF_ONLY
+        // creator_info/query returns 500 — should not affect publishing since user picked privacy_level.
         'https://open.tiktokapis.com/v2/post/publish/creator_info/query/' => Http::response([
             'error' => ['code' => 'internal_error', 'message' => 'Internal server error'],
         ], 500),
@@ -344,7 +347,7 @@ test('tiktok publisher falls back to self only when creator info fails', functio
     expect($result)->toHaveKey('id');
     expect($result['id'])->toBe('pub_fallback_123');
 
-    // Assert SELF_ONLY was used in the video init payload
+    // Assert SELF_ONLY (user's explicit pick) was used in the video init payload
     Http::assertSent(function ($request) {
         if (! str_contains($request->url(), '/post/publish/video/init/')) {
             return false;
@@ -538,8 +541,9 @@ test('tiktok publisher does not send auto_add_music for video posts', function (
     });
 });
 
-test('tiktok publisher uses default settings when meta is empty', function () {
-    $this->postPlatform->update(['meta' => null]);
+test('tiktok publisher uses default settings when only privacy_level is set', function () {
+    // Only privacy_level is set (required); all other meta keys absent — exercise default toggles.
+    $this->postPlatform->update(['meta' => ['privacy_level' => 'PUBLIC_TO_EVERYONE']]);
 
     $this->post->update([
         'media' => [
@@ -576,7 +580,7 @@ test('tiktok publisher uses default settings when meta is empty', function () {
         $body = json_decode($request->body(), true);
         $postInfo = data_get($body, 'post_info');
 
-        // When meta is empty, uses creator_info privacy and defaults
+        // privacy_level passes through; toggles use safe defaults (duet/stitch off, comments on).
         return $postInfo['privacy_level'] === 'PUBLIC_TO_EVERYONE'
             && $postInfo['disable_comment'] === false
             && $postInfo['disable_duet'] === true
@@ -626,4 +630,38 @@ test('tiktok publisher sends video caption in title field, never description', f
         return data_get($body, 'post_info.title') === 'My video caption'
             && ! isset($body['post_info']['description']);
     });
+});
+
+test('tiktok publisher throws when meta.privacy_level is missing and user did not pick', function () {
+    $this->post->update([
+        'media' => [
+            [
+                'id' => 'test-media-video',
+                'path' => 'media/2026-01/test-video.mp4',
+                'url' => 'https://example.com/media/2026-01/test-video.mp4',
+                'mime_type' => 'video/mp4',
+                'original_filename' => 'test-video.mp4',
+            ],
+        ],
+    ]);
+    // Explicitly clear privacy_level from meta (simulate UI never set it).
+    $this->postPlatform->update(['meta' => []]);
+
+    Http::fake([
+        // creator_info returns a healthy response — fallback would have silently picked PUBLIC_TO_EVERYONE.
+        'https://open.tiktokapis.com/v2/post/publish/creator_info/query/' => Http::response([
+            'data' => [
+                'creator_nickname' => 'test',
+                'creator_username' => 'test',
+                'privacy_level_options' => ['PUBLIC_TO_EVERYONE', 'SELF_ONLY'],
+                'comment_disabled' => false,
+                'duet_disabled' => false,
+                'stitch_disabled' => false,
+                'max_video_post_duration_sec' => 300,
+            ],
+        ], 200),
+    ]);
+
+    expect(fn () => $this->publisher->publish($this->postPlatform))
+        ->toThrow(TikTokPublishException::class);
 });


### PR DESCRIPTION
## Summary

- Adds TikTok photo carousel support end-to-end (`ContentType::TikTokPhoto`, variant picker UI, publisher fix to use the `description` field which has a 4000-char cap vs the 90-char `title` cap)
- Brings the post editor into compliance with TikTok's [Content Sharing UX Guideline](https://developers.tiktok.com/doc/content-sharing-guidelines#required_ux_implementation_in_your_app) Points 1–5, addressing the rejection feedback "showcase full interactions between privacy settings and interaction settings"
- New `resources/js/enums/platform.ts` mirrors the PHP `Platform` enum; Edit.vue and ScheduleTab.vue now use the enum instead of string literals
- Backend hardening: FormRequest rejects publishing TikTok posts without explicit `privacy_level`; publisher throws instead of silently defaulting

## TikTok UX Guideline checklist

| Point | Requirement | Status |
|---|---|---|
| 1 | creator_info fetched on render + nickname displayed + max duration validated | ✅ already in place |
| 2 | Title editable, privacy dropdown with no default, interaction toggles unchecked + greyed when creator-disabled | ✅ |
| 2 | Music Usage Confirmation declaration **always visible** | ✅ fixed (was conditional) |
| 2c | Photo posts show only "Allow Comment" — Duet/Stitch hidden | ✅ |
| 2b | privacy_level required at backend (no silent default) | ✅ FormRequest + publisher throw |
| 3a | Disclosure toggle defaults OFF; Your Brand / Branded Content sub-checkboxes; publish disabled with exact tooltip when toggle on without sub-selection | ✅ |
| 3b | SELF_ONLY shown **disabled** with tooltip when Branded Content checked (not filtered out) + toast on auto-clear | ✅ |
| 4 | Compliance text varies between Music Usage / Branded Content Policy + Music Usage based on selection | ✅ |
| 5 | Preview, editable caption, explicit publish consent, status polling | ✅ already in place |

## Test plan

- [ ] **Photo posts** — connect a TikTok account, attach 2-5 images, pick "Photo carousel" variant, set privacy, publish; verify the carousel appears on TikTok with caption in description
- [ ] **Video posts** — attach a video, leave variant on "Video", verify Duet/Stitch/AIGC controls visible, Auto Add Music hidden
- [ ] **Disclosure flow** — open Disclose toggle without picking a sub-toggle; verify publish button disabled with tooltip *"You need to indicate if your content promotes yourself, a third party, or both."*
- [ ] **Branded Content interaction** — pick "Only me" privacy, then enable Branded Content; verify privacy clears AND a toast surfaces *"Privacy was cleared because Branded Content cannot be private."*
- [ ] **Branded Content disabled state** — with Branded Content on, open privacy dropdown; verify "Only me" appears disabled with tooltip *"Branded content visibility cannot be set to private."*; amber persistent warning visible below the dropdown
- [ ] **Always-visible Music Usage** — with no toggles touched, verify the line *"By posting, you agree to TikTok's Music Usage Confirmation."* is visible at the bottom of the panel from initial render
- [ ] **Compliance text variance** — toggle Branded Content; verify line becomes *"Branded Content Policy and Music Usage Confirmation"*
- [ ] **Backend hardening** — try to publish via direct API request without `meta.privacy_level`; verify 422 with `platforms.0.meta.privacy_level` error; draft saves still work without it
- [ ] **Run full Pest suite** — 1490 tests pass

## Files changed

13 files modified + 3 new files:

**Backend (PHP):** `ContentType.php`, `TikTokPublisher.php`, `UpdatePostRequest.php`, `PostPlatformFactory.php`
**Frontend (Vue/TS):** `TikTokSettings.vue`, `ScheduleTab.vue`, `Edit.vue`, `content-type.ts`, **new** `platform.ts`
**i18n:** `lang/{en,pt-BR,es}/posts.php`
**Tests:** **new** `TikTokPhotoContentTypeTest.php`, **new** `UpdatePostRequestTest.php`, modified `TikTokPublisherTest.php`

## Resubmission to TikTok

Recording a screencast walking through the interactions in order is the next step before resubmitting to TikTok review:

1. Connect account → 2. Open editor → 3. Show variant pills + privacy placeholder + interaction toggles + always-visible Music Usage line → 4. Open Disclose, try publishing (disabled w/ tooltip) → 5. Toggle Branded Content (privacy clears + toast + amber warning) → 6. Open privacy dropdown (Only me disabled w/ tooltip) → 7. Pick Public, publish → 8. Switch to Photo carousel variant, attach images, verify Duet/Stitch hidden, Auto Add Music visible