### PR TITLE
feat(tracking): push Google Ads conversion data to dataLayer on purchase

### DIFF
--- a/app/Http/Controllers/App/BillingController.php
+++ b/app/Http/Controllers/App/BillingController.php
@@ -11,8 +11,8 @@ use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Gate;
 use Inertia\Inertia;
 use Inertia\Response;
-use Stripe\Exception\ApiErrorException as StripeApiErrorException;
 use Symfony\Component\HttpFoundation\Response as SymfonyResponse;
+use Throwable;
 
 class BillingController extends Controller
 {
@@ -101,7 +101,7 @@ class BillingController extends Controller
                 $sessionId,
                 ['expand' => ['line_items.data.price']],
             );
-        } catch (StripeApiErrorException) {
+        } catch (Throwable) {
             return null;
         }
 

--- a/app/Http/Controllers/App/BillingController.php
+++ b/app/Http/Controllers/App/BillingController.php
@@ -11,6 +11,7 @@ use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Gate;
 use Inertia\Inertia;
 use Inertia\Response;
+use Stripe\Exception\ApiErrorException as StripeApiErrorException;
 use Symfony\Component\HttpFoundation\Response as SymfonyResponse;
 
 class BillingController extends Controller
@@ -66,7 +67,7 @@ class BillingController extends Controller
             ->trialDays(config('cashier.trial_days'));
 
         $checkoutSession = $subscription->checkout([
-            'success_url' => route('app.billing.processing'),
+            'success_url' => route('app.billing.processing').'?session_id={CHECKOUT_SESSION_ID}',
             'cancel_url' => route('app.subscribe'),
         ]);
 
@@ -80,10 +81,47 @@ class BillingController extends Controller
         }
 
         $account = $request->user()->account;
+        $sessionId = $request->query('session_id');
 
         return Inertia::render('billing/Processing', [
             'subscriptionActive' => $account && $account->subscribed(Account::SUBSCRIPTION_NAME),
+            'conversion' => is_string($sessionId) && $sessionId !== '' && $account?->stripe_id
+                ? fn () => $this->buildConversionData($account, $sessionId)
+                : null,
         ]);
+    }
+
+    /**
+     * @return array{value: float, currency: string, transaction_id: string}|null
+     */
+    private function buildConversionData(Account $account, string $sessionId): ?array
+    {
+        try {
+            $session = $account->stripe()->checkout->sessions->retrieve(
+                $sessionId,
+                ['expand' => ['line_items.data.price']],
+            );
+        } catch (StripeApiErrorException) {
+            return null;
+        }
+
+        if (data_get($session, 'customer') !== $account->stripe_id) {
+            return null;
+        }
+
+        $unitAmount = data_get($session, 'line_items.data.0.price.unit_amount');
+        $currency = data_get($session, 'line_items.data.0.price.currency');
+        $transactionId = data_get($session, 'id');
+
+        if (! is_int($unitAmount) || ! is_string($currency) || ! is_string($transactionId)) {
+            return null;
+        }
+
+        return [
+            'value' => $unitAmount / 100,
+            'currency' => strtoupper($currency),
+            'transaction_id' => $transactionId,
+        ];
     }
 
     public function index(Request $request): Response|RedirectResponse

--- a/resources/js/composables/useTracking.ts
+++ b/resources/js/composables/useTracking.ts
@@ -30,16 +30,29 @@ export const useTracking = () => ({
         });
     },
 
-    trackPurchase: (plan: { name: string; interval: string }) => {
+    trackPurchase: (
+        plan: { name: string; interval: string },
+        conversion?: { value: number; currency: string; transaction_id: string } | null,
+    ) => {
         captureEvent('checkout.completed', {
             plan_name: plan.name,
             interval: plan.interval,
+            ...(conversion ? {
+                conversion_value: conversion.value,
+                conversion_currency: conversion.currency,
+                conversion_transaction_id: conversion.transaction_id,
+            } : {}),
         });
 
         push({
             event: 'purchase',
             plan_name: plan.name,
             plan_interval: plan.interval,
+            ...(conversion ? {
+                conversion_value: conversion.value,
+                conversion_currency: conversion.currency,
+                conversion_transaction_id: conversion.transaction_id,
+            } : {}),
         });
     },
 });

--- a/resources/js/pages/billing/Processing.vue
+++ b/resources/js/pages/billing/Processing.vue
@@ -9,6 +9,7 @@ import type { Auth } from '@/types';
 
 const props = defineProps<{
     subscriptionActive: boolean;
+    conversion?: { value: number; currency: string; transaction_id: string } | null;
 }>();
 
 const page = usePage();
@@ -40,10 +41,13 @@ watch(
 
         const plan = (page.props.auth as Auth | undefined)?.plan;
         if (plan) {
-            trackPurchase({
-                name: plan.name,
-                interval: plan.interval,
-            });
+            trackPurchase(
+                {
+                    name: plan.name,
+                    interval: plan.interval,
+                },
+                props.conversion ?? null,
+            );
         }
 
         goHome();

--- a/tests/Feature/BillingControllerTest.php
+++ b/tests/Feature/BillingControllerTest.php
@@ -117,7 +117,30 @@ test('billing processing shows processing page', function () {
     $response->assertInertia(fn ($page) => $page
         ->component('billing/Processing', false)
         ->has('subscriptionActive')
+        ->where('conversion', null)
     );
+});
+
+test('billing processing exposes null conversion when session_id query param is missing', function () {
+    config(['trypost.self_hosted' => false]);
+
+    $response = $this->actingAs($this->user)
+        ->get(route('app.billing.processing', ['session_id' => '']));
+
+    $response->assertOk();
+    $response->assertInertia(fn ($page) => $page->where('conversion', null));
+});
+
+test('billing processing exposes null conversion when account has no stripe_id', function () {
+    config(['trypost.self_hosted' => false]);
+
+    expect($this->account->stripe_id)->toBeNull();
+
+    $response = $this->actingAs($this->user)
+        ->get(route('app.billing.processing', ['session_id' => 'cs_test_123']));
+
+    $response->assertOk();
+    $response->assertInertia(fn ($page) => $page->where('conversion', null));
 });
 
 test('shared auth.plan exposes name slug and interval via AuthPlanResource', function () {


### PR DESCRIPTION
## Summary
- Wires Stripe Checkout Session data (`value`, `currency`, `transaction_id`) into the `purchase` dataLayer event so GTM can fire **Google Ads Conversion Tracking** (`AW-18156274196/Dl3oCNKAvKscEJSEy9FD`) with accurate per-plan revenue and deduped transaction IDs.
- `BillingController::checkout` now appends `{CHECKOUT_SESSION_ID}` to the Stripe `success_url`.
- `BillingController::processing` lazily retrieves the Checkout Session (closure prop — polling partial reloads don't re-hit the Stripe API) and exposes a `conversion` prop with `value`/`currency`/`transaction_id`. Uses `data_get` with dot notation + type guards so Stripe shape changes degrade to `null` instead of crashing.
- `Processing.vue` forwards `conversion` to `trackPurchase`.
- `useTracking.trackPurchase` pushes `conversion_value`, `conversion_currency`, `conversion_transaction_id` to dataLayer + PostHog.

## GTM setup (manual, after merge)
1. Create 3 **Data Layer Variables**: `conversion_value`, `conversion_currency`, `conversion_transaction_id`.
2. Create a **Google Ads Conversion Tracking** tag:
   - Conversion ID: `18156274196` (digits only, no `AW-` prefix)
   - Conversion Label: `Dl3oCNKAvKscEJSEy9FD`
   - Conversion Value: `{{conversion_value}}`
   - Transaction ID: `{{conversion_transaction_id}}`
   - Currency Code: `{{conversion_currency}}`
3. Trigger: Custom Event = `purchase`.

## Test plan
- [x] `php artisan test --compact --filter=BillingControllerTest` — 20 passed
- [ ] Manual checkout in Stripe test mode → confirm `purchase` event in GTM Preview with populated `conversion_*` fields
- [ ] Verify Google Ads Conversion Tracking tag fires once per checkout (dedup via `transaction_id`)
- [ ] Confirm polling partial reloads on `/billing/processing` don't trigger duplicate Stripe API calls