### PR TITLE
fix(social): proactive token refresh actually refreshes (not just verifies)

### DIFF
--- a/app/Console/Commands/RefreshExpiringTokens.php
+++ b/app/Console/Commands/RefreshExpiringTokens.php
@@ -13,7 +13,7 @@ class RefreshExpiringTokens extends Command
 {
     protected $signature = 'social:refresh-expiring-tokens';
 
-    protected $description = 'Proactively refresh tokens expiring in the next 2 hours';
+    protected $description = 'Proactively refresh tokens expiring in the next 2 hours (or already expired)';
 
     public function handle(): void
     {
@@ -23,7 +23,6 @@ class RefreshExpiringTokens extends Command
             ->where('status', Status::Connected)
             ->whereNotNull('token_expires_at')
             ->where('token_expires_at', '<=', now()->addHours(2))
-            ->where('token_expires_at', '>', now())
             ->chunk(50, function ($accounts) use (&$count) {
                 foreach ($accounts as $account) {
                     RefreshSocialToken::dispatch($account);

--- a/app/Jobs/RefreshSocialToken.php
+++ b/app/Jobs/RefreshSocialToken.php
@@ -4,11 +4,13 @@ declare(strict_types=1);
 
 namespace App\Jobs;
 
+use App\Exceptions\TokenExpiredException;
 use App\Models\SocialAccount;
 use App\Services\Social\ConnectionVerifier;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Queue\Queueable;
 use Illuminate\Support\Facades\Log;
+use Throwable;
 
 class RefreshSocialToken implements ShouldQueue
 {
@@ -21,8 +23,14 @@ class RefreshSocialToken implements ShouldQueue
     public function handle(ConnectionVerifier $verifier): void
     {
         try {
-            $verifier->verify($this->account);
-        } catch (\Throwable $e) {
+            $verifier->refreshToken($this->account);
+        } catch (TokenExpiredException $e) {
+            // refresh_token rejected by the provider (revoked / rotated /
+            // expired beyond refresh). Mark the account so the user is
+            // notified immediately instead of waiting for the next failed
+            // publish or the daily verify pass.
+            $this->account->markAsTokenExpired($e->getMessage());
+        } catch (Throwable $e) {
             Log::warning('Proactive token refresh failed', [
                 'account_id' => $this->account->id,
                 'platform' => $this->account->platform->value,

--- a/app/Services/Social/ConnectionVerifier.php
+++ b/app/Services/Social/ConnectionVerifier.php
@@ -28,7 +28,7 @@ class ConnectionVerifier
         // refresh, so proactive refreshes during races cause false-positive
         // disconnects even though the access_token still works fine.
         if ($account->is_token_expired) {
-            $this->refreshTokenIfNeeded($account);
+            $this->refreshToken($account);
 
             return $this->callVerifyEndpoint($account);
         }
@@ -39,7 +39,7 @@ class ConnectionVerifier
             // Verify returned 401: the access_token is actually invalid.
             // Refresh and retry once with the new token.
             try {
-                $this->refreshTokenIfNeeded($account);
+                $this->refreshToken($account);
             } catch (TokenExpiredException) {
                 throw $e;
             }
@@ -69,11 +69,14 @@ class ConnectionVerifier
     }
 
     /**
-     * Refresh token based on platform type.
+     * Refresh the account's token via the platform-specific OAuth flow.
+     * Callers that want the smart "try access_token first" behavior should
+     * use verify() instead. This method always attempts a refresh under
+     * the per-account lock and throws TokenExpiredException on failure.
      *
      * @throws TokenExpiredException if refresh fails
      */
-    private function refreshTokenIfNeeded(SocialAccount $account): void
+    public function refreshToken(SocialAccount $account): void
     {
         $lock = Cache::lock("token_refresh:{$account->id}", 30);
 

--- a/tests/Feature/Commands/RefreshExpiringTokensTest.php
+++ b/tests/Feature/Commands/RefreshExpiringTokensTest.php
@@ -9,7 +9,7 @@ use App\Models\SocialAccount;
 use App\Models\Workspace;
 use Illuminate\Support\Facades\Queue;
 
-test('it dispatches refresh jobs for tokens expiring within 2 hours', function () {
+test('it dispatches refresh jobs for tokens expiring within 2 hours or already expired', function () {
     Queue::fake();
 
     $workspace = Workspace::factory()->create();
@@ -22,7 +22,7 @@ test('it dispatches refresh jobs for tokens expiring within 2 hours', function (
         'token_expires_at' => now()->addHour(),
     ]);
 
-    // Should NOT be refreshed (expires in 5 hours)
+    // Should NOT be refreshed (expires in 5 hours — outside the proactive window)
     SocialAccount::factory()->create([
         'workspace_id' => $workspace->id,
         'platform' => Platform::Instagram,
@@ -30,8 +30,9 @@ test('it dispatches refresh jobs for tokens expiring within 2 hours', function (
         'token_expires_at' => now()->addHours(5),
     ]);
 
-    // Should NOT be refreshed (already expired)
-    SocialAccount::factory()->create([
+    // SHOULD be refreshed (already expired — last-chance attempt before the
+    // refresh_token also dies at the provider).
+    $justExpired = SocialAccount::factory()->create([
         'workspace_id' => $workspace->id,
         'platform' => Platform::TikTok,
         'status' => Status::Connected,
@@ -46,11 +47,20 @@ test('it dispatches refresh jobs for tokens expiring within 2 hours', function (
         'token_expires_at' => now()->addHour(),
     ]);
 
+    // Should NOT be refreshed (already token expired — daily verify handles these)
+    SocialAccount::factory()->create([
+        'workspace_id' => $workspace->id,
+        'platform' => Platform::Pinterest,
+        'status' => Status::TokenExpired,
+        'token_expires_at' => now()->subHour(),
+    ]);
+
     $this->artisan('social:refresh-expiring-tokens')
         ->assertSuccessful();
 
-    Queue::assertPushed(RefreshSocialToken::class, 1);
+    Queue::assertPushed(RefreshSocialToken::class, 2);
     Queue::assertPushed(RefreshSocialToken::class, fn ($job) => $job->account->id === $expiringSoon->id);
+    Queue::assertPushed(RefreshSocialToken::class, fn ($job) => $job->account->id === $justExpired->id);
 });
 
 test('it dispatches nothing when no tokens are expiring', function () {

--- a/tests/Feature/Jobs/RefreshSocialTokenTest.php
+++ b/tests/Feature/Jobs/RefreshSocialTokenTest.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Enums\SocialAccount\Status;
+use App\Exceptions\TokenExpiredException;
+use App\Jobs\RefreshSocialToken;
+use App\Jobs\SendNotification;
+use App\Models\SocialAccount;
+use App\Models\User;
+use App\Models\Workspace;
+use App\Services\Social\ConnectionVerifier;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\Queue;
+
+beforeEach(function () {
+    $this->owner = User::factory()->create();
+    $this->workspace = Workspace::factory()->create(['user_id' => $this->owner->id]);
+    $this->account = SocialAccount::factory()->x()->create([
+        'workspace_id' => $this->workspace->id,
+        'status' => Status::Connected,
+        'username' => 'testuser',
+    ]);
+});
+
+test('refresh job calls refreshToken (not verify) on the verifier', function () {
+    $verifier = mock(ConnectionVerifier::class);
+    $verifier->shouldReceive('refreshToken')->once()->with(
+        Mockery::on(fn ($account) => $account->id === $this->account->id)
+    );
+    $verifier->shouldNotReceive('verify');
+    app()->instance(ConnectionVerifier::class, $verifier);
+
+    (new RefreshSocialToken($this->account))->handle($verifier);
+});
+
+test('refresh job marks account as TokenExpired when refresh_token is rejected', function () {
+    Queue::fake();
+
+    $verifier = mock(ConnectionVerifier::class);
+    $verifier->shouldReceive('refreshToken')->once()->andThrow(
+        new TokenExpiredException('refresh_token revoked')
+    );
+    app()->instance(ConnectionVerifier::class, $verifier);
+
+    (new RefreshSocialToken($this->account))->handle($verifier);
+
+    expect($this->account->fresh()->status)->toBe(Status::TokenExpired);
+    expect($this->account->fresh()->error_message)->toBe('refresh_token revoked');
+
+    // Notification dispatched because account transitioned from Connected.
+    Queue::assertPushed(SendNotification::class);
+});
+
+test('refresh job logs warning on non-token errors and leaves status alone', function () {
+    Log::shouldReceive('warning')->once()->withArgs(function ($message, $context) {
+        return $message === 'Proactive token refresh failed'
+            && $context['account_id'] === $this->account->id
+            && $context['error'] === 'network blip';
+    });
+
+    $verifier = mock(ConnectionVerifier::class);
+    $verifier->shouldReceive('refreshToken')->once()->andThrow(new RuntimeException('network blip'));
+    app()->instance(ConnectionVerifier::class, $verifier);
+
+    (new RefreshSocialToken($this->account))->handle($verifier);
+
+    expect($this->account->fresh()->status)->toBe(Status::Connected);
+});


### PR DESCRIPTION
## Context

After [#29](https://github.com/trypostit/trypost/pull/29) shipped, an audit of the daily commands revealed that the hourly proactive-refresh cron was silently letting tokens age out and die at the provider. The original failure (PR #29) was the visible symptom; this PR fixes the underlying cause so the same situation doesn't recur.

**Why tokens were dying despite the hourly cron:**

1. `RefreshSocialToken` job called `ConnectionVerifier::verify()` — which is optimized for the publish-time path and **tries the access_token first**. If verify succeeds, no refresh happens. So the cron's whole purpose (refresh proactively) was defeated by verify()'s smart-skip.
2. `RefreshExpiringTokens` command excluded already-expired tokens via `where('token_expires_at', '>', now())`. So if a token aged out between cron passes, it never got a last-chance refresh — by the time anyone noticed, the refresh_token at the provider had also been revoked.
3. When `RefreshSocialToken` did fail, it just logged a warning and left the account `Connected`. User was never notified, the cron kept retrying every hour, and the account only flipped to `TokenExpired` when the user tried to publish (PR #29's fix) or the daily `CheckSocialConnections` ran.

## The three orthogonal fixes

### (C) `ConnectionVerifier::refreshToken` is now public
Renamed from private `refreshTokenIfNeeded` → public `refreshToken`. The body is unchanged (lock + per-platform refresh dispatch). `verify()` still uses it internally. Callers that want a proactive refresh (the cron) call it directly and skip verify()'s smart-skip logic.

### (B) Cron window widened to include already-expired tokens
Removed `where('token_expires_at', '>', now())` in `RefreshExpiringTokens`. Already-expired-but-still-Connected tokens now get a last-chance refresh attempt before the refresh_token also dies at the provider. The `status = Connected` filter still excludes accounts already in `TokenExpired` or `Disconnected` state.

### (D) `RefreshSocialToken` marks TokenExpired on refresh failure
Two separate catch branches now:
- `TokenExpiredException` (refresh_token rejected → terminal): call `markAsTokenExpired($e->getMessage())`. The lock + transition detection in `markAsTokenExpired` (from #29) means user gets exactly one notification per transition, no spam if subsequent cron passes retry.
- `Throwable` (network blip, 5xx, etc. → transient): log warning, account stays Connected, next cron pass tries again.

## End-to-end behavior now

**Happy path:**
- Token expires in 2h → cron picks it up → refresh succeeds → new tokens persisted → cycle continues

**Refresh_token revoked at provider:**
- Cron picks it up → refresh fails with TokenExpiredException → account marked TokenExpired → user notified (in-app + email) immediately → subsequent cron passes filter it out (`status = Connected` no longer matches) → no spam

**Already-expired token (B fix):**
- Token expired at 02:00, missed previous cron window → 03:00 cron now includes it (no more `> now` filter) → either succeeds (provider hasn't reaped yet) or falls into the TokenExpired path above

## Test plan
- [x] `php artisan test --compact --parallel` — **1502 passed, 2 skipped, 0 failed** (+3 over main, all new)
- [x] New: `refresh job calls refreshToken (not verify) on the verifier`
- [x] New: `refresh job marks account as TokenExpired when refresh_token is rejected`
- [x] New: `refresh job logs warning on non-token errors and leaves status alone`
- [x] Updated: `it dispatches refresh jobs for tokens expiring within 2 hours or already expired` (flipped from "should NOT" to "SHOULD" for already-expired)
- [x] Production data check: 0 stuck accounts (`status=connected` + `token_expires_at < NOW()`) — no notification spike on deploy
- [ ] Manual: trigger `social:refresh-expiring-tokens` against a real expired X account → confirm `markAsTokenExpired` fires + email arrives

## Known gaps (out of scope, follow-up)
- Tokens with `token_expires_at = null` (Facebook pages, Mastodon, Bluesky, Instagram-via-Facebook) are still only checked by the daily `CheckSocialConnections`. Provider-side revocations on these accounts have up to a 24h discovery window. Worth a separate PR if it becomes a problem.