### PR TITLE
fix(x): drop chunked upload chunk size from 5MB to 1MB

### DIFF
--- a/app/Exceptions/Social/XPublishException.php
+++ b/app/Exceptions/Social/XPublishException.php
@@ -47,6 +47,15 @@ class XPublishException extends SocialPublishException
             );
         }
 
+        if ($statusCode === 413) {
+            return new static(
+                userMessage: 'Media chunk rejected by X (payload too large).',
+                category: ErrorCategory::MediaFormat,
+                platformErrorCode: (string) $statusCode,
+                rawResponse: $rawResponse,
+            );
+        }
+
         if (in_array($statusCode, [500, 502, 503, 504], true)) {
             return new static(
                 userMessage: 'X server error. Please try again later.',

--- a/app/Services/Social/XPublisher.php
+++ b/app/Services/Social/XPublisher.php
@@ -205,8 +205,11 @@ class XPublisher
             throw new \Exception('No media_id returned from INIT');
         }
 
-        // APPEND - Read from temp file in 5MB chunks (memory-safe)
-        $chunkSize = 5 * 1024 * 1024;
+        // APPEND - Read from temp file in 1MB chunks. Matches the
+        // twitter-api-v2 SDK default and X's own quickstart examples;
+        // larger chunks (we previously used 5MB) trigger 413 at the X
+        // edge with an empty body, surfacing as "An unknown X error".
+        $chunkSize = 1024 * 1024;
         $handle = fopen($tempFile, 'r');
         $index = 0;
 
@@ -220,7 +223,7 @@ class XPublisher
 
                 $appendResponse = $this->socialHttp()->withToken($this->accessToken)
                     ->timeout(300)
-                    ->attach('media', $chunk, 'chunk'.$index)
+                    ->attach('media', $chunk, 'chunk'.$index, ['Content-Type' => $mimeType])
                     ->post("{$this->baseUrl}/media/upload/{$mediaId}/append", [
                         'segment_index' => $index,
                     ]);

--- a/tests/Unit/Exceptions/Social/XPublishExceptionTest.php
+++ b/tests/Unit/Exceptions/Social/XPublishExceptionTest.php
@@ -77,6 +77,18 @@ test('HTTP 500 maps to ServerError category', function () {
         ->and($exception->userMessage)->toBe('X server error. Please try again later.');
 });
 
+test('HTTP 413 with empty body maps to MediaFormat category', function () {
+    $response = Http::response('', 413);
+
+    $fakeResponse = Http::fake(['*' => $response])->post('https://api.x.com/test');
+
+    $exception = XPublishException::fromApiResponse($fakeResponse);
+
+    expect($exception->category)->toBe(ErrorCategory::MediaFormat)
+        ->and($exception->userMessage)->toBe('Media chunk rejected by X (payload too large).')
+        ->and($exception->platformErrorCode)->toBe('413');
+});
+
 test('unknown type maps to Unknown category with detail as message', function () {
     $response = Http::response([
         'type' => 'https://api.x.com/2/problems/some-unknown-problem',


### PR DESCRIPTION
## Context

Every video post to X has been failing in production with the cryptic error **'An unknown X error occurred.'** Logs show the pattern:

\`\`\`
production.ERROR: X chunked upload APPEND error {\"status\":413,\"body\":\"\",\"segment\":0}
production.ERROR: Social publish failed: An unknown X error occurred.
\`\`\`

Status 413 with **empty body** on the very first chunk — the classic signature of an edge/CDN rejection (the gateway is denying the request before X's application code sees it).

## Root cause

We were using **5MB chunks** (max documented size per X v2 reference), but every canonical reference uses **1MB**:

- X's official Python quickstart: \`chunk_size = 1024 * 1024\`
- X's official JavaScript quickstart: \`const chunkSize = 1024 * 1024\`
- [twitter-api-v2](https://github.com/PLhery/node-twitter-api-v2) (the most-used Node SDK, used by Postiz and the broader ecosystem): \`chunkSize: number = 1024 * 1024\` as the default

The docs say 5MB max, but with multipart-form overhead, the actual HTTP request body exceeds an undocumented edge limit. 1MB is the empirically safe size everyone converges on.

## Changes

1. **`XPublisher.php:209`** — drop chunk size from \`5 * 1024 * 1024\` to \`1024 * 1024\`. An 8MB video uploads as 8 APPEND segments instead of 2; more roundtrips but actually succeeds.

2. **`XPublisher.php:224`** — set explicit \`Content-Type\` on each chunk attach (matches the simple-upload path in the same file at line 144-151).

3. **\`XPublishException::fromApiResponse\`** — map HTTP 413 to \`ErrorCategory::MediaFormat\` with the message **'Media chunk rejected by X (payload too large).'** so we don't surface 413 as 'unknown' if it ever recurs for any reason.

## Test plan
- [x] \`php artisan test --compact --parallel\` — **1503 passed, 2 skipped, 0 failed** (+1 over main, the new 413 mapping test)
- [x] New unit test: \`HTTP 413 with empty body maps to MediaFormat category\`
- [ ] Manual production verification: post an 8MB video to X via the production app after deploy → confirm successful publish (no more 'unknown' errors)