### PR TITLE
fix(facebook): use upload_url + file_url for reel transfer phase

### DIFF
--- a/app/Services/Social/FacebookPublisher.php
+++ b/app/Services/Social/FacebookPublisher.php
@@ -9,6 +9,7 @@ use App\Exceptions\Social\FacebookPublishException;
 use App\Models\PostPlatform;
 use App\Services\Social\Concerns\HasSocialHttpClient;
 use Illuminate\Http\Client\Response;
+use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Log;
 
 class FacebookPublisher
@@ -237,26 +238,43 @@ class FacebookPublisher
             $this->handleApiError($startResponse);
         }
 
-        // Phase 2 (transfer, hosted-file flow) — POST to upload_url on
-        // rupload.facebook.com with `file_url` in the JSON body and
-        // `Authorization: OAuth …` header. The previous implementation
-        // POSTed to the graph endpoint with a made-up `video_file_chunk`
-        // body field; Facebook accepted the request but never fetched
-        // the video, so finish failed with error_subcode 1363130
-        // ("Video Upload Is Missing").
-        $uploadResponse = $this->socialHttp()
-            ->withHeaders(['Authorization' => "OAuth {$accessToken}"])
-            ->asJson()
-            ->post($uploadUrl, [
-                'file_url' => $media->url,
-            ]);
+        // Phase 2 (transfer, local-file flow) — download our hosted
+        // media then POST raw bytes to upload_url with the Offset and
+        // file_size headers Facebook requires (the docs describe a
+        // hosted-file shortcut with `file_url` in the body, but rupload
+        // rejects it with "Header Offset not convertable to unsigned
+        // long" — the headers are required either way).
+        $tempFile = tempnam(sys_get_temp_dir(), 'fb_reel_');
 
-        if ($uploadResponse->failed()) {
-            Log::error('Facebook reel upload transfer failed', [
-                'status' => $uploadResponse->status(),
-                'body' => $this->redactResponseBody($uploadResponse->body()),
-            ]);
-            $this->handleApiError($uploadResponse);
+        try {
+            $download = Http::withOptions(['sink' => $tempFile])
+                ->timeout(600)
+                ->get($media->url);
+
+            if ($download->failed()) {
+                throw new \Exception('Failed to download reel media: HTTP '.$download->status());
+            }
+
+            $fileSize = filesize($tempFile);
+
+            $uploadResponse = Http::withHeaders([
+                'Authorization' => "OAuth {$accessToken}",
+                'Offset' => '0',
+                'file_size' => (string) $fileSize,
+            ])
+                ->timeout(600)
+                ->withBody(file_get_contents($tempFile), $media->mime_type ?? 'video/mp4')
+                ->post($uploadUrl);
+
+            if ($uploadResponse->failed()) {
+                Log::error('Facebook reel upload transfer failed', [
+                    'status' => $uploadResponse->status(),
+                    'body' => $this->redactResponseBody($uploadResponse->body()),
+                ]);
+                $this->handleApiError($uploadResponse);
+            }
+        } finally {
+            @unlink($tempFile);
         }
 
         // Phase 3 (finish) — publish the reel.

--- a/app/Services/Social/FacebookPublisher.php
+++ b/app/Services/Social/FacebookPublisher.php
@@ -212,36 +212,54 @@ class FacebookPublisher
 
     private function publishReel(string $pageId, string $accessToken, ?string $content, $media): array
     {
-        // Upload video as reel
-        $response = $this->socialHttp()->post("{$this->baseUrl}/{$pageId}/video_reels", [
+        // Phase 1 (start) — graph endpoint returns video_id + upload_url.
+        $startResponse = $this->socialHttp()->post("{$this->baseUrl}/{$pageId}/video_reels", [
             'upload_phase' => 'start',
             'access_token' => $accessToken,
         ]);
 
-        if ($response->failed()) {
+        if ($startResponse->failed()) {
             Log::error('Facebook reel upload start failed', [
-                'status' => $response->status(),
-                'body' => $this->redactResponseBody($response->body()),
+                'status' => $startResponse->status(),
+                'body' => $this->redactResponseBody($startResponse->body()),
             ]);
-            $this->handleApiError($response);
+            $this->handleApiError($startResponse);
         }
 
-        $data = $response->json();
-        $videoId = data_get($data, 'video_id');
+        $startData = $startResponse->json();
+        $videoId = data_get($startData, 'video_id');
+        $uploadUrl = data_get($startData, 'upload_url');
 
-        // Upload the video file (Facebook accepts URL in video_file_chunk)
-        $uploadResponse = $this->socialHttp()->post("{$this->baseUrl}/{$videoId}", [
-            'upload_phase' => 'transfer',
-            'video_file_chunk' => $media->url,
-            'access_token' => $accessToken,
-        ]);
+        if (! $videoId || ! $uploadUrl) {
+            Log::error('Facebook reel start did not return video_id/upload_url', [
+                'body' => $this->redactResponseBody($startResponse->body()),
+            ]);
+            $this->handleApiError($startResponse);
+        }
+
+        // Phase 2 (transfer, hosted-file flow) — POST to upload_url on
+        // rupload.facebook.com with `file_url` in the JSON body and
+        // `Authorization: OAuth …` header. The previous implementation
+        // POSTed to the graph endpoint with a made-up `video_file_chunk`
+        // body field; Facebook accepted the request but never fetched
+        // the video, so finish failed with error_subcode 1363130
+        // ("Video Upload Is Missing").
+        $uploadResponse = $this->socialHttp()
+            ->withHeaders(['Authorization' => "OAuth {$accessToken}"])
+            ->asJson()
+            ->post($uploadUrl, [
+                'file_url' => $media->url,
+            ]);
 
         if ($uploadResponse->failed()) {
-            Log::error('Facebook reel upload transfer failed', ['body' => $this->redactResponseBody($uploadResponse->body())]);
+            Log::error('Facebook reel upload transfer failed', [
+                'status' => $uploadResponse->status(),
+                'body' => $this->redactResponseBody($uploadResponse->body()),
+            ]);
             $this->handleApiError($uploadResponse);
         }
 
-        // Finish and publish the reel
+        // Phase 3 (finish) — publish the reel.
         $finishResponse = $this->socialHttp()->post("{$this->baseUrl}/{$pageId}/video_reels", [
             'upload_phase' => 'finish',
             'video_id' => $videoId,

--- a/app/Services/Social/FacebookPublisher.php
+++ b/app/Services/Social/FacebookPublisher.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Services\Social;
 
 use App\Enums\PostPlatform\ContentType;
+use App\Exceptions\Social\ErrorCategory;
 use App\Exceptions\Social\FacebookPublishException;
 use App\Models\PostPlatform;
 use App\Services\Social\Concerns\HasSocialHttpClient;
@@ -220,10 +221,6 @@ class FacebookPublisher
         ]);
 
         if ($startResponse->failed()) {
-            Log::error('Facebook reel upload start failed', [
-                'status' => $startResponse->status(),
-                'body' => $this->redactResponseBody($startResponse->body()),
-            ]);
             $this->handleApiError($startResponse);
         }
 
@@ -232,10 +229,12 @@ class FacebookPublisher
         $uploadUrl = data_get($startData, 'upload_url');
 
         if (! $videoId || ! $uploadUrl) {
-            Log::error('Facebook reel start did not return video_id/upload_url', [
-                'body' => $this->redactResponseBody($startResponse->body()),
-            ]);
-            $this->handleApiError($startResponse);
+            throw new FacebookPublishException(
+                userMessage: 'Facebook did not return upload_url for reel start.',
+                category: ErrorCategory::ServerError,
+                platformErrorCode: null,
+                rawResponse: $startResponse->body(),
+            );
         }
 
         // Phase 2 (transfer, local-file flow) — download our hosted
@@ -252,29 +251,39 @@ class FacebookPublisher
                 ->get($media->url);
 
             if ($download->failed()) {
-                throw new \Exception('Failed to download reel media: HTTP '.$download->status());
+                throw new FacebookPublishException(
+                    userMessage: 'Could not download media for Facebook reel.',
+                    category: ErrorCategory::ServerError,
+                    platformErrorCode: (string) $download->status(),
+                    rawResponse: null,
+                );
             }
 
             $fileSize = filesize($tempFile);
+            $stream = fopen($tempFile, 'rb');
 
-            $uploadResponse = Http::withHeaders([
-                'Authorization' => "OAuth {$accessToken}",
-                'Offset' => '0',
-                'file_size' => (string) $fileSize,
-            ])
-                ->timeout(600)
-                ->withBody(file_get_contents($tempFile), $media->mime_type ?? 'video/mp4')
-                ->post($uploadUrl);
+            try {
+                $uploadResponse = Http::withHeaders([
+                    'Authorization' => "OAuth {$accessToken}",
+                    'Offset' => '0',
+                    'file_size' => (string) $fileSize,
+                ])
+                    ->timeout(600)
+                    ->withBody($stream, $media->mime_type ?? 'video/mp4')
+                    ->post($uploadUrl);
+            } finally {
+                if (is_resource($stream)) {
+                    fclose($stream);
+                }
+            }
 
             if ($uploadResponse->failed()) {
-                Log::error('Facebook reel upload transfer failed', [
-                    'status' => $uploadResponse->status(),
-                    'body' => $this->redactResponseBody($uploadResponse->body()),
-                ]);
                 $this->handleApiError($uploadResponse);
             }
         } finally {
-            @unlink($tempFile);
+            if (! unlink($tempFile)) {
+                Log::warning('Facebook reel temp file cleanup failed', ['path' => $tempFile]);
+            }
         }
 
         // Phase 3 (finish) — publish the reel.
@@ -287,9 +296,6 @@ class FacebookPublisher
         ]);
 
         if ($finishResponse->failed()) {
-            Log::error('Facebook reel finish failed', [
-                'body' => $this->redactResponseBody($finishResponse->body()),
-            ]);
             $this->handleApiError($finishResponse);
         }
 

--- a/tests/Feature/Services/Social/FacebookPublisherTest.php
+++ b/tests/Feature/Services/Social/FacebookPublisherTest.php
@@ -233,7 +233,43 @@ test('facebook publisher fails reel publish when start does not return upload_ur
     ]);
 
     expect(fn () => $this->publisher->publish($this->postPlatform))
-        ->toThrow(FacebookPublishException::class);
+        ->toThrow(
+            FacebookPublishException::class,
+            'Facebook did not return upload_url for reel start.'
+        );
+});
+
+test('facebook publisher fails reel publish with typed exception when media download fails', function () {
+    $this->postPlatform->update(['content_type' => ContentType::FacebookReel]);
+
+    $this->post->update([
+        'media' => [
+            [
+                'id' => 'test-media-reel',
+                'path' => 'media/2026-01/reel.mp4',
+                'url' => 'https://example.com/media/2026-01/reel.mp4',
+                'mime_type' => 'video/mp4',
+                'original_filename' => 'reel.mp4',
+            ],
+        ],
+    ]);
+
+    // start succeeds, but the media URL returns 404 — should surface as
+    // a typed FacebookPublishException (ServerError) instead of leaking
+    // a generic Exception that would land in the 'unknown' bucket.
+    Http::fake([
+        '*/page_123/video_reels' => Http::response([
+            'video_id' => 'reel_video_123',
+            'upload_url' => 'https://rupload.facebook.com/video-upload/v25.0/reel_video_123',
+        ], 200),
+        '*example.com/media/*' => Http::response('', 404),
+    ]);
+
+    expect(fn () => $this->publisher->publish($this->postPlatform))
+        ->toThrow(
+            FacebookPublishException::class,
+            'Could not download media for Facebook reel.'
+        );
 });
 
 test('facebook publisher can publish image story', function () {

--- a/tests/Feature/Services/Social/FacebookPublisherTest.php
+++ b/tests/Feature/Services/Social/FacebookPublisherTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 use App\Enums\PostPlatform\ContentType;
 use App\Enums\SocialAccount\Platform;
+use App\Exceptions\Social\FacebookPublishException;
 use App\Exceptions\TokenExpiredException;
 use App\Models\Post;
 use App\Models\PostPlatform;
@@ -179,10 +180,12 @@ test('facebook publisher can publish reel', function () {
 
     Http::fake([
         '*/page_123/video_reels' => Http::sequence()
-            ->push(['video_id' => 'reel_video_123'], 200)
+            ->push([
+                'video_id' => 'reel_video_123',
+                'upload_url' => 'https://rupload.facebook.com/video-upload/v25.0/reel_video_123',
+            ], 200)
             ->push(['id' => 'reel_123', 'success' => true], 200),
-        '*/reel_video_123' => Http::response(['success' => true], 200),
-        '*' => Http::response('', 200),
+        '*rupload.facebook.com/*' => Http::response(['success' => true], 200),
     ]);
 
     $result = $this->publisher->publish($this->postPlatform);
@@ -190,6 +193,45 @@ test('facebook publisher can publish reel', function () {
     expect($result)->toHaveKey('id');
     expect($result['id'])->toBe('reel_123');
     expect($result['url'])->toBe('https://www.facebook.com/reel/reel_123');
+
+    // Assert the transfer phase: POST to upload_url (rupload host) with
+    // file_url JSON body and OAuth header — not to the graph endpoint
+    // with the (legacy/wrong) video_file_chunk body param.
+    Http::assertSent(function ($request) {
+        if (! str_contains($request->url(), 'rupload.facebook.com')) {
+            return false;
+        }
+
+        return $request['file_url'] === 'https://example.com/media/2026-01/reel.mp4'
+            && str_starts_with($request->header('Authorization')[0] ?? '', 'OAuth ');
+    });
+});
+
+test('facebook publisher fails reel publish when start does not return upload_url', function () {
+    $this->postPlatform->update(['content_type' => ContentType::FacebookReel]);
+
+    $this->post->update([
+        'media' => [
+            [
+                'id' => 'test-media-reel',
+                'path' => 'media/2026-01/reel.mp4',
+                'url' => 'https://example.com/media/2026-01/reel.mp4',
+                'mime_type' => 'video/mp4',
+                'original_filename' => 'reel.mp4',
+            ],
+        ],
+    ]);
+
+    // Missing upload_url in the start response — should not silently
+    // proceed to a broken transfer (which is what the old code did).
+    Http::fake([
+        '*/page_123/video_reels' => Http::response([
+            'video_id' => 'reel_video_123',
+        ], 200),
+    ]);
+
+    expect(fn () => $this->publisher->publish($this->postPlatform))
+        ->toThrow(FacebookPublishException::class);
 });
 
 test('facebook publisher can publish image story', function () {
@@ -376,10 +418,12 @@ test('facebook publisher cleans up temp files after reel upload', function () {
 
     Http::fake([
         '*/page_123/video_reels' => Http::sequence()
-            ->push(['video_id' => 'reel_video_cleanup_123'], 200)
+            ->push([
+                'video_id' => 'reel_video_cleanup_123',
+                'upload_url' => 'https://rupload.facebook.com/video-upload/v25.0/reel_video_cleanup_123',
+            ], 200)
             ->push(['id' => 'reel_cleanup_456', 'success' => true], 200),
-        '*/reel_video_cleanup_123' => Http::response(['success' => true], 200),
-        '*' => Http::response('', 200),
+        '*rupload.facebook.com/*' => Http::response(['success' => true], 200),
     ]);
 
     $this->publisher->publish($this->postPlatform);

--- a/tests/Feature/Services/Social/FacebookPublisherTest.php
+++ b/tests/Feature/Services/Social/FacebookPublisherTest.php
@@ -185,6 +185,7 @@ test('facebook publisher can publish reel', function () {
                 'upload_url' => 'https://rupload.facebook.com/video-upload/v25.0/reel_video_123',
             ], 200)
             ->push(['id' => 'reel_123', 'success' => true], 200),
+        '*example.com/media/*' => Http::response('fake-video-binary-content', 200),
         '*rupload.facebook.com/*' => Http::response(['success' => true], 200),
     ]);
 
@@ -194,15 +195,16 @@ test('facebook publisher can publish reel', function () {
     expect($result['id'])->toBe('reel_123');
     expect($result['url'])->toBe('https://www.facebook.com/reel/reel_123');
 
-    // Assert the transfer phase: POST to upload_url (rupload host) with
-    // file_url JSON body and OAuth header — not to the graph endpoint
-    // with the (legacy/wrong) video_file_chunk body param.
+    // Assert the transfer phase: POST raw bytes to upload_url (rupload
+    // host) with OAuth header and the required Offset + file_size
+    // headers Facebook's rupload validator demands.
     Http::assertSent(function ($request) {
         if (! str_contains($request->url(), 'rupload.facebook.com')) {
             return false;
         }
 
-        return $request['file_url'] === 'https://example.com/media/2026-01/reel.mp4'
+        return ($request->header('Offset')[0] ?? null) === '0'
+            && ($request->header('file_size')[0] ?? null) === (string) strlen('fake-video-binary-content')
             && str_starts_with($request->header('Authorization')[0] ?? '', 'OAuth ');
     });
 });
@@ -423,6 +425,7 @@ test('facebook publisher cleans up temp files after reel upload', function () {
                 'upload_url' => 'https://rupload.facebook.com/video-upload/v25.0/reel_video_cleanup_123',
             ], 200)
             ->push(['id' => 'reel_cleanup_456', 'success' => true], 200),
+        '*example.com/media/*' => Http::response('fake-video', 200),
         '*rupload.facebook.com/*' => Http::response(['success' => true], 200),
     ]);
 


### PR DESCRIPTION
## Context

Every Facebook reel publish was failing in production. The first attempt at a fix (commit \`c379c4c\` — hosted-file flow) failed in local testing too, this time with:

\`\`\`
production.ERROR: Facebook reel upload transfer failed
{
  "debug_info": {
    "type": "ParameterValidationError",
    "message": "HeaderValuePredicate: Header Offset not convertable to unsigned long"
  }
}
\`\`\`

So rupload.facebook.com **requires** the \`Offset\` and \`file_size\` headers even when using the hosted-file (\`file_url\`) path that Meta's docs document without them. To work around the docs/behavior gap, this PR switches to the well-documented local-file flow.

## Root cause (full picture)

The Reels publishing API is a 3-step flow. We had **step 2 implemented twice now** but both wrong:

| Phase | Endpoint | What we did | What's needed |
|---|---|---|---|
| 1. start | \`POST graph.../{page_id}/video_reels\` (\`upload_phase=start\`) | ✓ correct | Returns \`video_id\` + \`upload_url\` |
| 2. transfer (orig) | \`POST graph.../{video_id}\` with \`video_file_chunk\` | Made-up param, FB silently no-op'd → finish saw \"Video Upload Is Missing\" | Must POST to \`upload_url\` |
| 2. transfer (1st attempt) | \`POST upload_url\` with \`file_url\` JSON body | Rejected: \"Header Offset not convertable\" | Headers also required |
| 2. transfer (this PR) | \`POST upload_url\` with raw bytes + \`Offset\`/\`file_size\` headers | ✓ matches Meta's local-file docs | — |
| 3. finish | \`POST graph.../{page_id}/video_reels\` (\`upload_phase=finish\`, …) | ✓ correct | — |

## What this PR does

1. **Capture \`upload_url\`** from the start response (was being ignored).
2. **Download the media** to a temp file (\`tempnam(sys_get_temp_dir(), 'fb_reel_')\`) via \`Http::withOptions(['sink' => …])\` — same pattern \`XPublisher\` already uses for media downloads.
3. **POST the bytes to \`upload_url\`** with:
   - \`Authorization: OAuth {token}\`
   - \`Offset: 0\`
   - \`file_size: {filesize}\`
   - Body: raw bytes
   - Content-Type: media's mime_type
4. **Cleanup the temp file** in a \`finally\` block.
5. **Bail early** with \`handleApiError\` if start doesn't return \`video_id\` + \`upload_url\` so we don't silently no-op like the original code did.

## Tests
- [x] \`php artisan test --compact --parallel\` — **1504 passed, 2 skipped, 0 failed**.
- [x] \`can publish reel\` updated: fakes the media-download GET and the rupload POST. Asserts the transfer call has \`Offset: 0\`, correct \`file_size\`, and \`Authorization: OAuth …\` headers.
- [x] \`fails reel publish when start does not return upload_url\` covers the bail-out path.
- [x] \`cleans up temp files after reel upload\` (pre-existing) now actually exercises a real cleanup since we create temp files again.
- [ ] Manual production verification after deploy.