### PR TITLE
fix(linkedin-page): persist OAuth scopes through the page-picker flow

### DIFF
--- a/app/Http/Controllers/Auth/LinkedInPageController.php
+++ b/app/Http/Controllers/Auth/LinkedInPageController.php
@@ -103,6 +103,7 @@ class LinkedInPageController extends SocialController
                     'token' => $socialUser->token,
                     'refresh_token' => $socialUser->refreshToken,
                     'expires_in' => $socialUser->expiresIn,
+                    'approved_scopes' => $socialUser->approvedScopes ?? [],
                     'organizations' => $organizations,
                     'reconnect_id' => session('linkedin_page_reconnect_id'),
                 ],
@@ -182,6 +183,8 @@ class LinkedInPageController extends SocialController
                         'access_token' => $pendingData['token'],
                         'refresh_token' => $pendingData['refresh_token'],
                         'token_expires_at' => $pendingData['expires_in'] ? now()->addSeconds($pendingData['expires_in']) : null,
+                        // LinkedIn returns scope CSV-joined but Socialite splits on space, so re-split here.
+                        'scopes' => explode(',', implode(',', $pendingData['approved_scopes'] ?? [])),
                         'meta' => [
                             'organization_id' => $request->organization_id,
                             'admin_user_id' => $pendingData['user_id'],
@@ -211,6 +214,8 @@ class LinkedInPageController extends SocialController
                     'access_token' => $pendingData['token'],
                     'refresh_token' => $pendingData['refresh_token'],
                     'token_expires_at' => $pendingData['expires_in'] ? now()->addSeconds($pendingData['expires_in']) : null,
+                    // LinkedIn returns scope CSV-joined but Socialite splits on space, so re-split here.
+                    'scopes' => explode(',', implode(',', $pendingData['approved_scopes'] ?? [])),
                     'status' => Status::Connected,
                     'error_message' => null,
                     'disconnected_at' => null,

--- a/tests/Feature/Social/LinkedInPageControllerTest.php
+++ b/tests/Feature/Social/LinkedInPageControllerTest.php
@@ -166,6 +166,40 @@ test('linkedin page select creates account', function () {
     ]);
 });
 
+test('linkedin page select splits comma-separated approvedScopes before saving', function () {
+    session([
+        'linkedin_page_pending' => [
+            'workspace_id' => $this->workspace->id,
+            'user_id' => 'user123',
+            'name' => 'John Doe',
+            'avatar' => null,
+            'token' => 'test-access-token',
+            'refresh_token' => 'test-refresh-token',
+            'expires_in' => 5184000,
+            // Simulates what Socialite returns for LinkedIn (CSV-joined into
+            // a single array element because the provider splits on space).
+            'approved_scopes' => ['email,openid,profile,w_organization_social,r_organization_social,rw_organization_admin,w_member_social'],
+            'organizations' => [
+                ['id' => 999888, 'name' => 'Scope Company', 'vanity_name' => 'scopeco', 'logo' => null],
+            ],
+        ],
+    ]);
+
+    $this->actingAs($this->user)->post(route('app.social.linkedin-page.select'), [
+        'organization_id' => 999888,
+        'organization_name' => 'Scope Company',
+        'organization_vanity_name' => 'scopeco',
+        'organization_logo' => null,
+    ]);
+
+    $account = SocialAccount::where('platform_user_id', 999888)->first();
+    expect($account->scopes)->toEqualCanonicalizing([
+        'email', 'openid', 'profile',
+        'w_organization_social', 'r_organization_social',
+        'rw_organization_admin', 'w_member_social',
+    ]);
+});
+
 test('linkedin page select fails with expired session', function () {
     // No session data
 


### PR DESCRIPTION
## Context

After connecting a LinkedIn Page and trying to post, every publish failed with:

\`\`\`
Missing permissions: w_organization_social. Please reconnect your account.
\`\`\`

…even though the OAuth flow had clearly granted the scope. Inspecting the DB:

\`\`\`sql
SELECT id, platform, scopes FROM social_accounts WHERE platform = 'linkedin-page';
-- scopes = NULL
\`\`\`

## Root cause

LinkedIn Page connection has a **two-step OAuth flow** unique to this provider:

1. \`LinkedInPageController::callback\` — receives the OAuth response, fetches the LinkedIn organizations the user admins, **stashes everything in the \`linkedin_page_pending\` session payload**, and redirects to a page-picker UI.
2. \`LinkedInPageController::select\` — when the user picks an organization, this writes the social_accounts row using \`$pendingData\`.

The session payload was carrying \`token\`, \`refresh_token\`, \`expires_in\`, \`user_id\`, \`organizations\` — but **not** \`approvedScopes\`. And both finalize paths (\`update\` for reconnect, \`updateOrCreate\` for first connect) never set the \`scopes\` column. So every LinkedIn Page row got \`scopes = NULL\`.

Verified locally with a \`Log::info($socialUser->approvedScopes)\` — the scopes ARE there in the Socialite response (CSV-joined into one element, same quirk as the LinkedIn personal provider in PR #35).

## Fix

Two minimal changes in \`LinkedInPageController\`:

**1. Stash \`approved_scopes\` in the session:**
\`\`\`php
session(['linkedin_page_pending' => [
    ...
    'approved_scopes' => \$socialUser->approvedScopes ?? [],
    ...
]]);
\`\`\`

**2. Persist with the same CSV split** as the LinkedIn personal controller, in **both** finalize paths (the reconnect \`update\` AND the first-connect \`updateOrCreate\`):
\`\`\`php
'scopes' => explode(',', implode(',', \$pendingData['approved_scopes'] ?? [])),
\`\`\`

## Test plan
- [x] \`php artisan test --compact --parallel\` — **1513 passed, 2 skipped, 0 failed** (+1 over main)
- [x] New: \`linkedin page select splits comma-separated approvedScopes before saving\`
- [x] Manual: reconnect LinkedIn Page locally → DB row has 7 separate scope entries → publish succeeds (confirmed by user)