### PR TITLE
fix(profile): member delete must not destroy the shared account

### DIFF
--- a/app/Http/Controllers/App/Settings/ProfileController.php
+++ b/app/Http/Controllers/App/Settings/ProfileController.php
@@ -94,15 +94,7 @@ class ProfileController extends Controller
             $user->update(['current_workspace_id' => null]);
 
             $account = $user->account;
-
-            // Cancel account subscription if exists
-            if ($account && $account->subscribed(Account::SUBSCRIPTION_NAME)) {
-                $account->subscription(Account::SUBSCRIPTION_NAME)->cancelNow();
-            }
-
-            if ($account) {
-                $account->subscriptions()->delete();
-            }
+            $isOwner = $user->isAccountOwner();
 
             $ownedWorkspaces = Workspace::where('user_id', $user->id)->get();
 
@@ -126,7 +118,12 @@ class ProfileController extends Controller
 
             $user->workspaces()->detach();
 
-            if ($account) {
+            if ($account && $isOwner) {
+                if ($account->subscribed(Account::SUBSCRIPTION_NAME)) {
+                    $account->subscription(Account::SUBSCRIPTION_NAME)->cancelNow();
+                }
+
+                $account->subscriptions()->delete();
                 $account->delete();
             }
         });

--- a/tests/Feature/Settings/ProfileUpdateTest.php
+++ b/tests/Feature/Settings/ProfileUpdateTest.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 use App\Enums\UserWorkspace\Role;
+use App\Models\Account;
 use App\Models\User;
 use App\Models\Workspace;
 use Illuminate\Http\UploadedFile;
@@ -250,3 +251,65 @@ test('delete account requires authentication', function () {
 
     $response->assertRedirect(route('login'));
 });
+
+test('member deleting profile does NOT destroy the shared account', function (bool $selfHosted) {
+    config()->set('trypost.self_hosted', $selfHosted);
+
+    $owner = User::factory()->create();
+    $member = User::factory()->create(['account_id' => $owner->account_id]);
+
+    $workspace = Workspace::factory()->create([
+        'account_id' => $owner->account_id,
+        'user_id' => $owner->id,
+    ]);
+    $owner->workspaces()->attach($workspace->id, ['role' => Role::Member->value]);
+    $member->workspaces()->attach($workspace->id, ['role' => Role::Member->value]);
+
+    $this->actingAs($member)->delete(route('app.profile.destroy'), [
+        'password' => 'password',
+    ]);
+
+    expect($member->fresh())->toBeNull();
+    expect(Account::find($owner->account_id))->not->toBeNull();
+    expect(Workspace::find($workspace->id))->not->toBeNull();
+    expect($owner->fresh())->not->toBeNull();
+})->with([true, false]);
+
+test('member deleting profile detaches them from workspaces', function (bool $selfHosted) {
+    config()->set('trypost.self_hosted', $selfHosted);
+
+    $owner = User::factory()->create();
+    $member = User::factory()->create(['account_id' => $owner->account_id]);
+
+    $workspace = Workspace::factory()->create([
+        'account_id' => $owner->account_id,
+        'user_id' => $owner->id,
+    ]);
+    $member->workspaces()->attach($workspace->id, ['role' => Role::Member->value]);
+
+    $this->actingAs($member)->delete(route('app.profile.destroy'), [
+        'password' => 'password',
+    ]);
+
+    expect($workspace->fresh()->members()->where('users.id', $member->id)->exists())->toBeFalse();
+})->with([true, false]);
+
+test('owner deleting profile destroys the account and cascades', function (bool $selfHosted) {
+    config()->set('trypost.self_hosted', $selfHosted);
+
+    $owner = User::factory()->create();
+    $accountId = $owner->account_id;
+
+    $workspace = Workspace::factory()->create([
+        'account_id' => $accountId,
+        'user_id' => $owner->id,
+    ]);
+    $owner->workspaces()->attach($workspace->id, ['role' => Role::Member->value]);
+
+    $this->actingAs($owner)->delete(route('app.profile.destroy'), [
+        'password' => 'password',
+    ]);
+
+    expect(Account::find($accountId))->toBeNull();
+    expect(Workspace::find($workspace->id))->toBeNull();
+})->with([true, false]);


### PR DESCRIPTION
Closes #50.

## Bug

Members joining via workspace invite share the owner's `account_id`. \`ProfileController::destroy\` was unconditionally calling \`\$account->delete()\` in every profile-deletion path, so any member could wipe the whole organization — workspaces, posts, social accounts, signatures, labels — just by clicking Delete on their own profile.

## Fix

Gate the account/subscription teardown behind \`isAccountOwner()\`. For members the destroy path now only detaches them from workspaces and deletes the user row. Owner's data is untouched.

```diff
- if ($account) {
-     $account->delete();
- }
+ if ($account && $isOwner) {
+     if ($account->subscribed(Account::SUBSCRIPTION_NAME)) {
+         $account->subscription(Account::SUBSCRIPTION_NAME)->cancelNow();
+     }
+     $account->subscriptions()->delete();
+     $account->delete();
+ }
```

(Subscription cancellation moved into the same gate — it's an owner-only concern; for a member there's no subscription to touch.)

## Tests

3 new tests, each parametrized over \`SELF_HOSTED=true\` and \`false\` (6 runs total):

- Member deletes profile → shared account, workspace, owner all survive.
- Member deletes profile → detached from workspace memberships.
- Owner deletes profile → cascade still works (account + workspace gone).

Both modes pass because the path no longer depends on \`self_hosted\` — \`isAccountOwner()\` is a pure model check, and \`\$account->subscribed(...)\` returns false on self-hosted (no Stripe records), so the cancel/delete-subscription calls naturally no-op.

Full suite: 1603 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)