### PR TITLE
feat(docker): publish multi-arch image to GHCR + self-host compose

### DIFF
--- a/.github/workflows/release-docker.yml
+++ b/.github/workflows/release-docker.yml
@@ -63,13 +63,8 @@ jobs:
           target: production
           platforms: ${{ matrix.platform }}
           labels: ${{ steps.meta.outputs.labels }}
-          # Bake a fixed public Reverb key; leave host/port/scheme empty so the
-          # frontend derives them from window.location (works on any domain).
           build-args: |
             VITE_REVERB_APP_KEY=trypost-reverb-key
-            VITE_REVERB_HOST=
-            VITE_REVERB_PORT=
-            VITE_REVERB_SCHEME=
           cache-from: type=gha,scope=${{ env.PLATFORM_PAIR }}
           cache-to: type=gha,mode=max,scope=${{ env.PLATFORM_PAIR }}
           outputs: type=image,name=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }},push-by-digest=true,name-canonical=true,push=true

--- a/.github/workflows/release-docker.yml
+++ b/.github/workflows/release-docker.yml
@@ -1,0 +1,128 @@
+name: Publish Docker image
+
+# Builds the production image and publishes it to GitHub Container Registry
+# (GHCR) on every version tag. amd64 and arm64 are built on native runners,
+# then stitched into one multi-arch manifest — no QEMU emulation.
+
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+  workflow_dispatch:
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build:
+    name: Build (${{ matrix.platform }})
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux/amd64
+            runner: ubuntu-latest
+          - platform: linux/arm64
+            runner: ubuntu-24.04-arm
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Prepare platform slug
+        run: echo "PLATFORM_PAIR=${platform//\//-}" >> "$GITHUB_ENV"
+        env:
+          platform: ${{ matrix.platform }}
+
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Docker metadata (labels)
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push by digest
+        id: build
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: docker/Dockerfile
+          target: production
+          platforms: ${{ matrix.platform }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha,scope=${{ env.PLATFORM_PAIR }}
+          cache-to: type=gha,mode=max,scope=${{ env.PLATFORM_PAIR }}
+          outputs: type=image,name=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }},push-by-digest=true,name-canonical=true,push=true
+
+      - name: Export digest
+        run: |
+          mkdir -p "${{ runner.temp }}/digests"
+          digest="${{ steps.build.outputs.digest }}"
+          touch "${{ runner.temp }}/digests/${digest#sha256:}"
+
+      - name: Upload digest
+        uses: actions/upload-artifact@v4
+        with:
+          name: digests-${{ env.PLATFORM_PAIR }}
+          path: ${{ runner.temp }}/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  merge:
+    name: Merge multi-arch manifest
+    runs-on: ubuntu-latest
+    needs: [build]
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Download digests
+        uses: actions/download-artifact@v4
+        with:
+          path: ${{ runner.temp }}/digests
+          pattern: digests-*
+          merge-multiple: true
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Docker metadata (tags)
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+            type=raw,value=latest
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Create and push manifest list
+        working-directory: ${{ runner.temp }}/digests
+        run: |
+          docker buildx imagetools create \
+            $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+            $(printf '${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@sha256:%s ' *)
+
+      - name: Inspect published image
+        run: docker buildx imagetools inspect ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.meta.outputs.version }}

--- a/.github/workflows/release-docker.yml
+++ b/.github/workflows/release-docker.yml
@@ -63,6 +63,13 @@ jobs:
           target: production
           platforms: ${{ matrix.platform }}
           labels: ${{ steps.meta.outputs.labels }}
+          # Bake a fixed public Reverb key; leave host/port/scheme empty so the
+          # frontend derives them from window.location (works on any domain).
+          build-args: |
+            VITE_REVERB_APP_KEY=trypost-reverb-key
+            VITE_REVERB_HOST=
+            VITE_REVERB_PORT=
+            VITE_REVERB_SCHEME=
           cache-from: type=gha,scope=${{ env.PLATFORM_PAIR }}
           cache-to: type=gha,mode=max,scope=${{ env.PLATFORM_PAIR }}
           outputs: type=image,name=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }},push-by-digest=true,name-canonical=true,push=true

--- a/Caddyfile
+++ b/Caddyfile
@@ -1,0 +1,6 @@
+# Caddy serves TryPost on your domain with automatic HTTPS (Let's Encrypt).
+# APP_DOMAIN is provided by the caddy service in compose.prod.yaml.
+# reverse_proxy transparently passes through WebSocket upgrades (Reverb on /app).
+{$APP_DOMAIN} {
+	reverse_proxy app:80
+}

--- a/compose.prod.yaml
+++ b/compose.prod.yaml
@@ -40,11 +40,11 @@ services:
       BROADCAST_CONNECTION: reverb
 
       # ===== WebSockets (Reverb) =====
-      # These are the INTERNAL server->Reverb connection — leave as-is even on a
-      # domain. The browser derives the WebSocket host from its own URL, and the
-      # in-container nginx proxies it on /app, so it just works on any domain.
+      # The published image bakes the client at localhost:8080. For a custom
+      # domain, rebuild the image with --build-arg VITE_REVERB_HOST=<domain>
+      # VITE_REVERB_PORT=443 VITE_REVERB_SCHEME=https.
       REVERB_APP_ID: "1001"
-      REVERB_APP_KEY: trypost-reverb-key           # matches the key baked into the published image
+      REVERB_APP_KEY: trypost-reverb-key           # must match the key baked into the published image
       REVERB_APP_SECRET: change-me-reverb-secret   # <- change me
       REVERB_HOST: localhost
       REVERB_PORT: "8080"
@@ -105,7 +105,8 @@ services:
       # ANTHROPIC_API_KEY: ""
       # GEMINI_API_KEY: ""
     ports:
-      - "8000:80"     # app (nginx); WebSocket rides this same port via /app
+      - "8000:80"     # app (nginx)
+      - "8080:8080"   # Reverb WebSocket
     volumes:
       - storage:/var/www/html/storage/app
     depends_on:

--- a/compose.prod.yaml
+++ b/compose.prod.yaml
@@ -40,10 +40,13 @@ services:
       BROADCAST_CONNECTION: reverb
 
       # ===== WebSockets (Reverb) =====
+      # These are the INTERNAL server->Reverb connection — leave as-is even on a
+      # domain. The browser derives the WebSocket host from its own URL, and the
+      # in-container nginx proxies it on /app, so it just works on any domain.
       REVERB_APP_ID: "1001"
-      REVERB_APP_KEY: trypost-reverb-key
+      REVERB_APP_KEY: trypost-reverb-key           # matches the key baked into the published image
       REVERB_APP_SECRET: change-me-reverb-secret   # <- change me
-      REVERB_HOST: localhost            # <- for a real domain, set to that host (and PORT 443 / SCHEME https)
+      REVERB_HOST: localhost
       REVERB_PORT: "8080"
       REVERB_SCHEME: http
 
@@ -102,8 +105,7 @@ services:
       # ANTHROPIC_API_KEY: ""
       # GEMINI_API_KEY: ""
     ports:
-      - "8000:80"     # app (nginx)
-      - "8080:8080"   # Reverb WebSocket
+      - "8000:80"     # app (nginx); WebSocket rides this same port via /app
     volumes:
       - storage:/var/www/html/storage/app
     depends_on:
@@ -141,7 +143,33 @@ services:
       timeout: 3s
       retries: 5
 
+  # Optional reverse proxy with automatic HTTPS (Let's Encrypt).
+  # To serve on a domain:
+  #   1. Point the domain's DNS at this host.
+  #   2. Set APP_DOMAIN below and APP_URL above to https://<that domain>.
+  #   3. Start with the proxy profile:
+  #        docker compose -f compose.prod.yaml --profile proxy up -d
+  # Without the profile, the app is served directly on http://localhost:8000.
+  caddy:
+    image: caddy:2-alpine
+    container_name: trypost-caddy
+    restart: unless-stopped
+    profiles: [proxy]
+    environment:
+      APP_DOMAIN: post.example.com    # <- your domain
+    ports:
+      - "80:80"
+      - "443:443"
+    volumes:
+      - ./Caddyfile:/etc/caddy/Caddyfile:ro
+      - caddy-data:/data
+      - caddy-config:/config
+    depends_on:
+      - app
+
 volumes:
   pgdata:
   redisdata:
   storage:
+  caddy-data:
+  caddy-config:

--- a/compose.prod.yaml
+++ b/compose.prod.yaml
@@ -1,0 +1,147 @@
+# TryPost — self-hosted production stack.
+#
+#   1. Generate an app key:   docker compose -f compose.prod.yaml run --rm app php artisan key:generate --show
+#      Paste the value into APP_KEY below.
+#   2. Edit APP_URL and the passwords marked "change me".
+#   3. Start:                 docker compose -f compose.prod.yaml up -d
+#
+# This pulls the published image — no local build. Postgres, Redis, the queue
+# workers, the scheduler and the WebSocket server all run for you.
+
+services:
+  app:
+    image: ghcr.io/trypostit/trypost:latest
+    container_name: trypost
+    restart: unless-stopped
+    environment:
+      # ===== Required =====
+      APP_NAME: TryPost
+      APP_ENV: production
+      APP_DEBUG: "false"
+      APP_KEY: ""                       # <- run key:generate (see header) and paste here
+      APP_URL: http://localhost:8000    # <- your public URL, e.g. https://post.yourdomain.com
+      SELF_HOSTED: "true"
+      TRYPOST_TARGET: production
+
+      # ===== Database (bundled postgres service below) =====
+      DB_CONNECTION: pgsql
+      DB_HOST: pgsql
+      DB_PORT: "5432"
+      DB_DATABASE: trypost
+      DB_USERNAME: trypost
+      DB_PASSWORD: trypost-password     # <- change me (must match POSTGRES_PASSWORD below)
+
+      # ===== Redis / queue / cache / broadcasting =====
+      REDIS_HOST: redis
+      REDIS_PORT: "6379"
+      QUEUE_CONNECTION: redis
+      CACHE_STORE: redis
+      SESSION_DRIVER: database
+      BROADCAST_CONNECTION: reverb
+
+      # ===== WebSockets (Reverb) =====
+      REVERB_APP_ID: "1001"
+      REVERB_APP_KEY: trypost-reverb-key
+      REVERB_APP_SECRET: change-me-reverb-secret   # <- change me
+      REVERB_HOST: localhost            # <- for a real domain, set to that host (and PORT 443 / SCHEME https)
+      REVERB_PORT: "8080"
+      REVERB_SCHEME: http
+
+      # ===== Storage =====
+      # Default: local disk, persisted in the "storage" volume below.
+      FILESYSTEM_DISK: public
+      #
+      # --- Cloudflare R2: set FILESYSTEM_DISK=r2 and fill these ---
+      # R2_ACCESS_KEY_ID: ""
+      # R2_SECRET_ACCESS_KEY: ""
+      # R2_ENDPOINT: ""
+      # R2_BUCKET: ""
+      # R2_URL: ""                       # public bucket URL (needed for media to display)
+      #
+      # --- AWS S3: set FILESYSTEM_DISK=s3 and fill these ---
+      # AWS_ACCESS_KEY_ID: ""
+      # AWS_SECRET_ACCESS_KEY: ""
+      # AWS_DEFAULT_REGION: us-east-1
+      # AWS_BUCKET: ""
+      # AWS_URL: ""
+
+      # ===== Mail =====
+      # Defaults to "log" (emails written to the container log). Configure SMTP
+      # for real password-reset / team-invite emails.
+      MAIL_MAILER: log
+      MAIL_FROM_ADDRESS: hello@example.com
+      MAIL_FROM_NAME: TryPost
+      # MAIL_MAILER: smtp
+      # MAIL_HOST: ""
+      # MAIL_PORT: "587"
+      # MAIL_USERNAME: ""
+      # MAIL_PASSWORD: ""
+      # MAIL_SCHEME: tls
+
+      # ===== Social platforms (fill in when you connect each network) =====
+      # Redirect URI in each portal: ${APP_URL}/accounts/<platform>/callback
+      # LINKEDIN_CLIENT_ID: ""
+      # LINKEDIN_CLIENT_SECRET: ""
+      # X_CLIENT_ID: ""
+      # X_CLIENT_SECRET: ""
+      # FACEBOOK_CLIENT_ID: ""
+      # FACEBOOK_CLIENT_SECRET: ""
+      # INSTAGRAM_CLIENT_ID: ""
+      # INSTAGRAM_CLIENT_SECRET: ""
+      # THREADS_CLIENT_ID: ""
+      # THREADS_CLIENT_SECRET: ""
+      # TIKTOK_CLIENT_ID: ""
+      # TIKTOK_CLIENT_SECRET: ""
+      # PINTEREST_CLIENT_ID: ""
+      # PINTEREST_CLIENT_SECRET: ""
+      # GOOGLE_CLIENT_ID: ""             # YouTube + Google login
+      # GOOGLE_CLIENT_SECRET: ""
+
+      # ===== AI (optional — leave blank to disable AI features) =====
+      # OPENAI_API_KEY: ""
+      # ANTHROPIC_API_KEY: ""
+      # GEMINI_API_KEY: ""
+    ports:
+      - "8000:80"     # app (nginx)
+      - "8080:8080"   # Reverb WebSocket
+    volumes:
+      - storage:/var/www/html/storage/app
+    depends_on:
+      pgsql:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+
+  pgsql:
+    image: postgres:16-alpine
+    container_name: trypost-pgsql
+    restart: unless-stopped
+    environment:
+      POSTGRES_DB: trypost
+      POSTGRES_USER: trypost
+      POSTGRES_PASSWORD: trypost-password   # <- must match DB_PASSWORD above
+    volumes:
+      - pgdata:/var/lib/postgresql/data
+    healthcheck:
+      test: ['CMD-SHELL', 'pg_isready -U trypost -d trypost']
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+  redis:
+    image: redis:7-alpine
+    container_name: trypost-redis
+    restart: unless-stopped
+    command: redis-server --appendonly yes
+    volumes:
+      - redisdata:/data
+    healthcheck:
+      test: ['CMD', 'redis-cli', 'ping']
+      interval: 10s
+      timeout: 3s
+      retries: 5
+
+volumes:
+  pgdata:
+  redisdata:
+  storage:

--- a/resources/js/app.ts
+++ b/resources/js/app.ts
@@ -1,7 +1,7 @@
 import '../css/app.css';
+import './echo';
 
 import { createInertiaApp, router } from '@inertiajs/vue3';
-import { configureEcho } from '@laravel/echo-vue';
 import { resolvePageComponent } from 'laravel-vite-plugin/inertia-helpers';
 import { i18nVue } from 'laravel-vue-i18n';
 import type { DefineComponent } from 'vue';
@@ -11,10 +11,6 @@ import { initializeDataLayer } from './datalayer';
 import dayjs from './dayjs';
 import { capturePageview, initializePostHog, syncPostHogContext } from './posthog';
 import type { Auth } from './types';
-
-configureEcho({
-    broadcaster: 'reverb',
-});
 
 const appName = import.meta.env.VITE_APP_NAME || 'TryPost.it';
 

--- a/resources/js/echo.ts
+++ b/resources/js/echo.ts
@@ -1,15 +1,11 @@
 import { configureEcho } from '@laravel/echo-vue';
 
-const scheme = import.meta.env.VITE_REVERB_SCHEME || (window.location.protocol === 'https:' ? 'https' : 'http');
-const forceTLS = scheme === 'https';
-const port = Number(import.meta.env.VITE_REVERB_PORT || window.location.port || (forceTLS ? 443 : 80));
-
 configureEcho({
     broadcaster: 'reverb',
     key: import.meta.env.VITE_REVERB_APP_KEY,
-    wsHost: import.meta.env.VITE_REVERB_HOST || window.location.hostname,
-    wsPort: port,
-    wssPort: port,
-    forceTLS,
+    wsHost: import.meta.env.VITE_REVERB_HOST,
+    wsPort: import.meta.env.VITE_REVERB_PORT ?? 80,
+    wssPort: import.meta.env.VITE_REVERB_PORT ?? 443,
+    forceTLS: (import.meta.env.VITE_REVERB_SCHEME ?? 'https') === 'https',
     enabledTransports: ['ws', 'wss'],
 });

--- a/resources/js/echo.ts
+++ b/resources/js/echo.ts
@@ -1,0 +1,15 @@
+import { configureEcho } from '@laravel/echo-vue';
+
+const scheme = import.meta.env.VITE_REVERB_SCHEME || (window.location.protocol === 'https:' ? 'https' : 'http');
+const forceTLS = scheme === 'https';
+const port = Number(import.meta.env.VITE_REVERB_PORT || window.location.port || (forceTLS ? 443 : 80));
+
+configureEcho({
+    broadcaster: 'reverb',
+    key: import.meta.env.VITE_REVERB_APP_KEY,
+    wsHost: import.meta.env.VITE_REVERB_HOST || window.location.hostname,
+    wsPort: port,
+    wssPort: port,
+    forceTLS,
+    enabledTransports: ['ws', 'wss'],
+});


### PR DESCRIPTION
## What

Ships a downloadable, self-hostable Docker image and the pieces to run it.

**1. `.github/workflows/release-docker.yml`** — on every `v*.*.*` tag (matches `/release`), builds `docker/Dockerfile --target production` for **amd64 + arm64 on native runners** (no QEMU) and publishes one multi-arch manifest to `ghcr.io/trypostit/trypost` (`1.2.3`, `1.2`, `1`, `latest`). Bakes `VITE_REVERB_APP_KEY` so the frontend's Reverb key matches the compose default.

**2. `compose.prod.yaml` + `Caddyfile`** — self-host stack that *pulls* the published image alongside Postgres + Redis with persistent volumes. Config is inline with sectioned comments, including a commented **S3/R2** block (storage already uses the default disk, so it's config-only). An optional **Caddy** service (`--profile proxy`) gives automatic HTTPS on a custom domain; without the profile it serves on `localhost:8000`.

**3. `resources/js/echo.ts` + `resources/js/app.ts`** — Echo setup moved into its own `echo.ts` (byte-identical to our sendkit config), reading `VITE_REVERB_*`; `app.ts` just imports it.

Builds on André's existing `docker/` setup (multi-stage Dockerfile, `production` target already proven on his homelab deploy) — reuses it, doesn't conflict.

## Validation

Ran end-to-end before opening: a real `v*.*.*` tag triggered the workflow, which published a multi-arch (amd64+arm64) public image to GHCR. That image was then pulled and run via a compose stack on macOS — migrations ran, the SPA rendered (HTTP 200, Vite assets served), and all five processes (php-fpm, nginx, Horizon, scheduler, Reverb) came up. `docker compose -f compose.prod.yaml config` passes; frontend `eslint` + `vue-tsc --noEmit` clean.

## Notes for the self-host story

- **APP_KEY** must be generated once (`docker compose -f compose.prod.yaml run --rm app php artisan key:generate --show`) — no shared default, for security.
- **First user:** the entrypoint runs migrations but no seeders, and `migrate:fresh` is blocked in production, so the first account is created via the public `/register` page (email verification is non-blocking when `SELF_HOSTED=true`).
- **Real-time on a custom domain:** the published image bakes the Reverb client at `localhost:8080`, so live updates work for a local `docker compose up`. On a custom domain via Caddy the app serves over HTTPS, but WebSocket updates need the image rebuilt with `--build-arg VITE_REVERB_HOST=<domain> VITE_REVERB_PORT=443 VITE_REVERB_SCHEME=https`.
- The dev `compose.yaml` (André's, for developing in Docker) is untouched — this adds the *run-a-release* path beside it.
