### PR TITLE
fix(linkedin): drop deprecated r_basicprofile from default scopes

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -103,11 +103,12 @@ LINKEDIN_CLIENT_ID=
 LINKEDIN_CLIENT_SECRET=
 LINKEDIN_CLIENT_REDIRECT="${APP_URL}/accounts/linkedin/callback"
 LINKEDIN_PAGE_CLIENT_REDIRECT="${APP_URL}/accounts/linkedin-page/callback"
-# Optional: comma-separated extra OAuth scopes appended to the personal
-# LinkedIn connect flow. Use this if your LinkedIn dev app has legacy or
-# enterprise products approved — e.g. `r_basicprofile` re-enables
-# vanityName lookup via /v2/me. Leave empty for the safe default set.
-# LINKEDIN_EXTRA_SCOPES=r_basicprofile
+# Optional: comma-separated OAuth scopes for each LinkedIn connect flow.
+# Override these only if your LinkedIn dev app has legacy/enterprise products
+# approved — e.g. add `r_basicprofile` to the personal set to re-enable the
+# vanityName lookup via /v2/me. Leave unset to use the safe defaults.
+# LINKEDIN_SCOPES="openid,profile,email,w_member_social"
+# LINKEDIN_PAGE_SCOPES="openid,profile,email,w_organization_social,r_organization_social,rw_organization_admin,w_member_social"
 
 # X / Twitter (https://developer.twitter.com)
 X_CLIENT_ID=

--- a/.env.example
+++ b/.env.example
@@ -103,6 +103,11 @@ LINKEDIN_CLIENT_ID=
 LINKEDIN_CLIENT_SECRET=
 LINKEDIN_CLIENT_REDIRECT="${APP_URL}/accounts/linkedin/callback"
 LINKEDIN_PAGE_CLIENT_REDIRECT="${APP_URL}/accounts/linkedin-page/callback"
+# Optional: comma-separated extra OAuth scopes appended to the personal
+# LinkedIn connect flow. Use this if your LinkedIn dev app has legacy or
+# enterprise products approved — e.g. `r_basicprofile` re-enables
+# vanityName lookup via /v2/me. Leave empty for the safe default set.
+# LINKEDIN_EXTRA_SCOPES=r_basicprofile
 
 # X / Twitter (https://developer.twitter.com)
 X_CLIENT_ID=

--- a/.env.example
+++ b/.env.example
@@ -102,12 +102,9 @@ SPACES_BUCKET=
 LINKEDIN_CLIENT_ID=
 LINKEDIN_CLIENT_SECRET=
 LINKEDIN_CLIENT_REDIRECT="${APP_URL}/accounts/linkedin/callback"
-LINKEDIN_PAGE_CLIENT_REDIRECT="${APP_URL}/accounts/linkedin-page/callback"
-# Optional: comma-separated OAuth scopes for each LinkedIn connect flow.
-# Override these only if your LinkedIn dev app has legacy/enterprise products
-# approved — e.g. add `r_basicprofile` to the personal set to re-enable the
-# vanityName lookup via /v2/me. Leave unset to use the safe defaults.
 # LINKEDIN_SCOPES="openid,profile,email,w_member_social"
+LINKEDIN_PAGE_CLIENT_REDIRECT="${APP_URL}/accounts/linkedin-page/callback"
+LINKEDIN_PAGE_CLIENT_REDIRECT="${APP_URL}/accounts/linkedin-page/callback"
 # LINKEDIN_PAGE_SCOPES="openid,profile,email,w_organization_social,r_organization_social,rw_organization_admin,w_member_social"
 
 # X / Twitter (https://developer.twitter.com)

--- a/app/Http/Controllers/Auth/LinkedInController.php
+++ b/app/Http/Controllers/Auth/LinkedInController.php
@@ -22,13 +22,6 @@ class LinkedInController extends SocialController
 
     protected SocialPlatform $platform = SocialPlatform::LinkedIn;
 
-    protected array $scopes = [
-        'openid',
-        'profile',
-        'email',
-        'w_member_social',
-    ];
-
     public function connect(Request $request): Response|RedirectResponse
     {
         $this->ensurePlatformEnabled();
@@ -45,22 +38,29 @@ class LinkedInController extends SocialController
     }
 
     /**
-     * Merge $this->scopes with any extra scopes the operator configured via
-     * `LINKEDIN_EXTRA_SCOPES` — comma-separated, e.g. `r_basicprofile`. Useful
-     * when the connected LinkedIn dev app has legacy or enterprise products
-     * not covered by the default Sign-In + Share-on-LinkedIn pair.
+     * Merge the default LinkedIn scopes with any extra scopes the operator
+     * configured via `LINKEDIN_EXTRA_SCOPES` — comma-separated, e.g.
+     * `r_basicprofile`. Useful when the connected LinkedIn dev app has legacy
+     * or enterprise products not covered by the default Sign-In +
+     * Share-on-LinkedIn pair. Both live under
+     * `config/trypost.php` → `platforms.linkedin`.
+     *
+     * @return array<int, string>
      */
     protected function resolveScopes(): array
     {
-        $extra = (string) config('services.linkedin.extra_scopes', '');
+        /** @var array<int, string> $scopes */
+        $scopes = config('trypost.platforms.linkedin.scopes', []);
+
+        $extra = (string) config('trypost.platforms.linkedin.extra_scopes', '');
 
         if ($extra === '') {
-            return $this->scopes;
+            return $scopes;
         }
 
         $extraScopes = array_filter(array_map('trim', explode(',', $extra)));
 
-        return array_values(array_unique([...$this->scopes, ...$extraScopes]));
+        return array_values(array_unique([...$scopes, ...$extraScopes]));
     }
 
     public function callback(Request $request): View

--- a/app/Http/Controllers/Auth/LinkedInController.php
+++ b/app/Http/Controllers/Auth/LinkedInController.php
@@ -26,7 +26,6 @@ class LinkedInController extends SocialController
         'openid',
         'profile',
         'email',
-        'r_basicprofile',
         'w_member_social',
     ];
 
@@ -42,7 +41,26 @@ class LinkedInController extends SocialController
 
         $this->authorize('manageAccounts', $workspace);
 
-        return $this->redirectToProvider($request, $this->driver, $this->scopes);
+        return $this->redirectToProvider($request, $this->driver, $this->resolveScopes());
+    }
+
+    /**
+     * Merge $this->scopes with any extra scopes the operator configured via
+     * `LINKEDIN_EXTRA_SCOPES` — comma-separated, e.g. `r_basicprofile`. Useful
+     * when the connected LinkedIn dev app has legacy or enterprise products
+     * not covered by the default Sign-In + Share-on-LinkedIn pair.
+     */
+    protected function resolveScopes(): array
+    {
+        $extra = (string) config('services.linkedin.extra_scopes', '');
+
+        if ($extra === '') {
+            return $this->scopes;
+        }
+
+        $extraScopes = array_filter(array_map('trim', explode(',', $extra)));
+
+        return array_values(array_unique([...$this->scopes, ...$extraScopes]));
     }
 
     public function callback(Request $request): View

--- a/app/Http/Controllers/Auth/LinkedInController.php
+++ b/app/Http/Controllers/Auth/LinkedInController.php
@@ -34,33 +34,7 @@ class LinkedInController extends SocialController
 
         $this->authorize('manageAccounts', $workspace);
 
-        return $this->redirectToProvider($request, $this->driver, $this->resolveScopes());
-    }
-
-    /**
-     * Merge the default LinkedIn scopes with any extra scopes the operator
-     * configured via `LINKEDIN_EXTRA_SCOPES` — comma-separated, e.g.
-     * `r_basicprofile`. Useful when the connected LinkedIn dev app has legacy
-     * or enterprise products not covered by the default Sign-In +
-     * Share-on-LinkedIn pair. Both live under
-     * `config/trypost.php` → `platforms.linkedin`.
-     *
-     * @return array<int, string>
-     */
-    protected function resolveScopes(): array
-    {
-        /** @var array<int, string> $scopes */
-        $scopes = config('trypost.platforms.linkedin.scopes', []);
-
-        $extra = (string) config('trypost.platforms.linkedin.extra_scopes', '');
-
-        if ($extra === '') {
-            return $scopes;
-        }
-
-        $extraScopes = array_filter(array_map('trim', explode(',', $extra)));
-
-        return array_values(array_unique([...$scopes, ...$extraScopes]));
+        return $this->redirectToProvider($request, $this->driver, config('trypost.platforms.linkedin.scopes'));
     }
 
     public function callback(Request $request): View

--- a/app/Http/Controllers/Auth/LinkedInPageController.php
+++ b/app/Http/Controllers/Auth/LinkedInPageController.php
@@ -24,16 +24,6 @@ class LinkedInPageController extends SocialController
 
     protected SocialPlatform $platform = SocialPlatform::LinkedInPage;
 
-    protected array $scopes = [
-        'openid',
-        'profile',
-        'email',
-        'w_organization_social',
-        'r_organization_social',
-        'rw_organization_admin',
-        'w_member_social',
-    ];
-
     public function connect(Request $request): SymfonyResponse|RedirectResponse
     {
         $this->ensurePlatformEnabled();
@@ -55,7 +45,7 @@ class LinkedInPageController extends SocialController
 
         return Inertia::location(
             Socialite::driver($this->driver)
-                ->scopes($this->scopes)
+                ->scopes(config('trypost.platforms.linkedin-page.scopes'))
                 ->with([
                     'redirect_uri' => config('services.linkedin-openid.redirect_page'),
                 ])
@@ -80,7 +70,7 @@ class LinkedInPageController extends SocialController
 
         try {
             $socialUser = Socialite::driver($this->driver)
-                ->scopes($this->scopes)
+                ->scopes(config('trypost.platforms.linkedin-page.scopes'))
                 ->with([
                     'redirect_uri' => config('services.linkedin-openid.redirect_page'),
                 ])

--- a/config/services.php
+++ b/config/services.php
@@ -41,6 +41,12 @@ return [
         'client_id' => env('LINKEDIN_CLIENT_ID'),
         'client_secret' => env('LINKEDIN_CLIENT_SECRET'),
         'redirect' => env('LINKEDIN_CLIENT_REDIRECT'),
+        // Comma-separated list of OAuth scopes to request beyond the defaults
+        // (openid, profile, email, w_member_social). Useful for apps with
+        // legacy or enterprise products approved — e.g. set
+        // `LINKEDIN_EXTRA_SCOPES=r_basicprofile` to re-enable vanityName
+        // lookup via /v2/me.
+        'extra_scopes' => env('LINKEDIN_EXTRA_SCOPES'),
     ],
 
     'linkedin-openid' => [

--- a/config/services.php
+++ b/config/services.php
@@ -41,12 +41,6 @@ return [
         'client_id' => env('LINKEDIN_CLIENT_ID'),
         'client_secret' => env('LINKEDIN_CLIENT_SECRET'),
         'redirect' => env('LINKEDIN_CLIENT_REDIRECT'),
-        // Comma-separated list of OAuth scopes to request beyond the defaults
-        // (openid, profile, email, w_member_social). Useful for apps with
-        // legacy or enterprise products approved — e.g. set
-        // `LINKEDIN_EXTRA_SCOPES=r_basicprofile` to re-enable vanityName
-        // lookup via /v2/me.
-        'extra_scopes' => env('LINKEDIN_EXTRA_SCOPES'),
     ],
 
     'linkedin-openid' => [

--- a/config/trypost.php
+++ b/config/trypost.php
@@ -80,6 +80,18 @@ return [
             'api' => env('LINKEDIN_API', 'https://api.linkedin.com'),
             // OAuth host is different from the data API (api.linkedin.com).
             'oauth_api' => env('LINKEDIN_OAUTH_API', 'https://www.linkedin.com'),
+            // Default OAuth scopes requested on /connect/linkedin. Covers the
+            // two products auto-approved for new apps: Sign In with LinkedIn
+            // (openid, profile, email) + Share on LinkedIn (w_member_social).
+            // `r_basicprofile` is intentionally omitted — it's a 2018-deprecated
+            // legacy scope that new apps can't grant, and requesting it makes
+            // LinkedIn reject the whole authorize request.
+            'scopes' => ['openid', 'profile', 'email', 'w_member_social'],
+            // Comma-separated extra scopes merged onto the defaults above, for
+            // apps with legacy/enterprise products approved — e.g.
+            // `LINKEDIN_EXTRA_SCOPES=r_basicprofile` to re-enable the vanityName
+            // lookup via /v2/me.
+            'extra_scopes' => env('LINKEDIN_EXTRA_SCOPES'),
         ],
         'linkedin-page' => [
             'enabled' => env('LINKEDIN_PAGE_ENABLED', true),

--- a/config/trypost.php
+++ b/config/trypost.php
@@ -80,22 +80,23 @@ return [
             'api' => env('LINKEDIN_API', 'https://api.linkedin.com'),
             // OAuth host is different from the data API (api.linkedin.com).
             'oauth_api' => env('LINKEDIN_OAUTH_API', 'https://www.linkedin.com'),
-            // Default OAuth scopes requested on /connect/linkedin. Covers the
-            // two products auto-approved for new apps: Sign In with LinkedIn
-            // (openid, profile, email) + Share on LinkedIn (w_member_social).
-            // `r_basicprofile` is intentionally omitted — it's a 2018-deprecated
-            // legacy scope that new apps can't grant, and requesting it makes
-            // LinkedIn reject the whole authorize request.
-            'scopes' => ['openid', 'profile', 'email', 'w_member_social'],
-            // Comma-separated extra scopes merged onto the defaults above, for
-            // apps with legacy/enterprise products approved — e.g.
-            // `LINKEDIN_EXTRA_SCOPES=r_basicprofile` to re-enable the vanityName
-            // lookup via /v2/me.
-            'extra_scopes' => env('LINKEDIN_EXTRA_SCOPES'),
+            // Comma-separated OAuth scopes requested on /connect/linkedin.
+            // Default covers the two products auto-approved for new apps: Sign
+            // In with LinkedIn (openid, profile, email) + Share on LinkedIn
+            // (w_member_social). The 2018-deprecated `r_basicprofile` is
+            // intentionally absent — new apps can't grant it, and requesting it
+            // makes LinkedIn reject the whole authorize request. Override via
+            // LINKEDIN_SCOPES if your app has legacy/enterprise products
+            // approved (e.g. add `r_basicprofile` to re-enable the vanityName
+            // lookup via /v2/me).
+            'scopes' => array_values(array_filter(array_map('trim', explode(',', (string) env('LINKEDIN_SCOPES', 'openid,profile,email,w_member_social'))))),
         ],
         'linkedin-page' => [
             'enabled' => env('LINKEDIN_PAGE_ENABLED', true),
             'api' => env('LINKEDIN_PAGE_API', 'https://api.linkedin.com'),
+            // Comma-separated OAuth scopes requested on the LinkedIn Company
+            // Page connect flow. Override via LINKEDIN_PAGE_SCOPES.
+            'scopes' => array_values(array_filter(array_map('trim', explode(',', (string) env('LINKEDIN_PAGE_SCOPES', 'openid,profile,email,w_organization_social,r_organization_social,rw_organization_admin,w_member_social'))))),
         ],
         'x' => [
             'enabled' => env('X_ENABLED', true),

--- a/config/trypost.php
+++ b/config/trypost.php
@@ -80,22 +80,13 @@ return [
             'api' => env('LINKEDIN_API', 'https://api.linkedin.com'),
             // OAuth host is different from the data API (api.linkedin.com).
             'oauth_api' => env('LINKEDIN_OAUTH_API', 'https://www.linkedin.com'),
-            // Comma-separated OAuth scopes requested on /connect/linkedin.
-            // Default covers the two products auto-approved for new apps: Sign
-            // In with LinkedIn (openid, profile, email) + Share on LinkedIn
-            // (w_member_social). The 2018-deprecated `r_basicprofile` is
-            // intentionally absent — new apps can't grant it, and requesting it
-            // makes LinkedIn reject the whole authorize request. Override via
-            // LINKEDIN_SCOPES if your app has legacy/enterprise products
-            // approved (e.g. add `r_basicprofile` to re-enable the vanityName
-            // lookup via /v2/me).
+            // Scopes for LinkedIn authentication
             'scopes' => array_values(array_filter(array_map('trim', explode(',', (string) env('LINKEDIN_SCOPES', 'openid,profile,email,w_member_social'))))),
         ],
         'linkedin-page' => [
             'enabled' => env('LINKEDIN_PAGE_ENABLED', true),
             'api' => env('LINKEDIN_PAGE_API', 'https://api.linkedin.com'),
-            // Comma-separated OAuth scopes requested on the LinkedIn Company
-            // Page connect flow. Override via LINKEDIN_PAGE_SCOPES.
+            // Scopes for LinkedIn Page authentication
             'scopes' => array_values(array_filter(array_map('trim', explode(',', (string) env('LINKEDIN_PAGE_SCOPES', 'openid,profile,email,w_organization_social,r_organization_social,rw_organization_admin,w_member_social'))))),
         ],
         'x' => [

--- a/docker/.env.docker.example
+++ b/docker/.env.docker.example
@@ -89,12 +89,8 @@ R2_URL=
 LINKEDIN_CLIENT_ID=
 LINKEDIN_CLIENT_SECRET=
 LINKEDIN_CLIENT_REDIRECT="${APP_URL}/accounts/linkedin/callback"
-LINKEDIN_PAGE_CLIENT_REDIRECT="${APP_URL}/accounts/linkedin-page/callback"
-# Optional: comma-separated OAuth scopes for each LinkedIn connect flow.
-# Override these only if your LinkedIn dev app has legacy/enterprise products
-# approved — e.g. add `r_basicprofile` to the personal set to re-enable the
-# vanityName lookup via /v2/me. Leave unset to use the safe defaults.
 # LINKEDIN_SCOPES="openid,profile,email,w_member_social"
+LINKEDIN_PAGE_CLIENT_REDIRECT="${APP_URL}/accounts/linkedin-page/callback"
 # LINKEDIN_PAGE_SCOPES="openid,profile,email,w_organization_social,r_organization_social,rw_organization_admin,w_member_social"
 
 X_CLIENT_ID=

--- a/docker/.env.docker.example
+++ b/docker/.env.docker.example
@@ -90,11 +90,12 @@ LINKEDIN_CLIENT_ID=
 LINKEDIN_CLIENT_SECRET=
 LINKEDIN_CLIENT_REDIRECT="${APP_URL}/accounts/linkedin/callback"
 LINKEDIN_PAGE_CLIENT_REDIRECT="${APP_URL}/accounts/linkedin-page/callback"
-# Optional: comma-separated extra OAuth scopes appended to the personal
-# LinkedIn connect flow. Use this if your LinkedIn dev app has legacy or
-# enterprise products approved — e.g. `r_basicprofile` re-enables
-# vanityName lookup via /v2/me. Leave empty for the safe default set.
-# LINKEDIN_EXTRA_SCOPES=r_basicprofile
+# Optional: comma-separated OAuth scopes for each LinkedIn connect flow.
+# Override these only if your LinkedIn dev app has legacy/enterprise products
+# approved — e.g. add `r_basicprofile` to the personal set to re-enable the
+# vanityName lookup via /v2/me. Leave unset to use the safe defaults.
+# LINKEDIN_SCOPES="openid,profile,email,w_member_social"
+# LINKEDIN_PAGE_SCOPES="openid,profile,email,w_organization_social,r_organization_social,rw_organization_admin,w_member_social"
 
 X_CLIENT_ID=
 X_CLIENT_SECRET=

--- a/docker/.env.docker.example
+++ b/docker/.env.docker.example
@@ -90,6 +90,11 @@ LINKEDIN_CLIENT_ID=
 LINKEDIN_CLIENT_SECRET=
 LINKEDIN_CLIENT_REDIRECT="${APP_URL}/accounts/linkedin/callback"
 LINKEDIN_PAGE_CLIENT_REDIRECT="${APP_URL}/accounts/linkedin-page/callback"
+# Optional: comma-separated extra OAuth scopes appended to the personal
+# LinkedIn connect flow. Use this if your LinkedIn dev app has legacy or
+# enterprise products approved — e.g. `r_basicprofile` re-enables
+# vanityName lookup via /v2/me. Leave empty for the safe default set.
+# LINKEDIN_EXTRA_SCOPES=r_basicprofile
 
 X_CLIENT_ID=
 X_CLIENT_SECRET=

--- a/tests/Feature/Social/LinkedInControllerTest.php
+++ b/tests/Feature/Social/LinkedInControllerTest.php
@@ -71,22 +71,22 @@ $captureConnectScopes = function (object $test): array {
     return $captured;
 };
 
-test('linkedin connect requests the default scope set when LINKEDIN_EXTRA_SCOPES is unset', function () use ($captureConnectScopes) {
-    config(['trypost.platforms.linkedin.extra_scopes' => null]);
+test('linkedin connect requests the default scope set', function () use ($captureConnectScopes) {
+    config(['trypost.platforms.linkedin.scopes' => ['openid', 'profile', 'email', 'w_member_social']]);
 
     expect($captureConnectScopes($this))->toEqualCanonicalizing([
         'openid', 'profile', 'email', 'w_member_social',
     ]);
 });
 
-test('linkedin connect appends LINKEDIN_EXTRA_SCOPES to the default scope set', function () use ($captureConnectScopes) {
-    // Backward-compatibility: ops who have legacy products approved on
-    // their LinkedIn app (e.g. r_basicprofile) opt back in via env.
-    config(['trypost.platforms.linkedin.extra_scopes' => 'r_basicprofile, r_emailaddress']);
+test('linkedin connect requests the scopes configured via LINKEDIN_SCOPES', function () use ($captureConnectScopes) {
+    // Operators whose LinkedIn app has legacy/enterprise products approved
+    // override the default set via LINKEDIN_SCOPES (exploded into the config
+    // array), e.g. re-adding r_basicprofile to restore the vanityName lookup.
+    config(['trypost.platforms.linkedin.scopes' => ['openid', 'profile', 'email', 'w_member_social', 'r_basicprofile']]);
 
     expect($captureConnectScopes($this))->toEqualCanonicalizing([
-        'openid', 'profile', 'email', 'w_member_social',
-        'r_basicprofile', 'r_emailaddress',
+        'openid', 'profile', 'email', 'w_member_social', 'r_basicprofile',
     ]);
 });
 

--- a/tests/Feature/Social/LinkedInControllerTest.php
+++ b/tests/Feature/Social/LinkedInControllerTest.php
@@ -40,7 +40,7 @@ test('linkedin connect redirects to oauth provider', function () {
 });
 
 test('linkedin connect requests the default scope set when LINKEDIN_EXTRA_SCOPES is unset', function () {
-    config(['services.linkedin.extra_scopes' => null]);
+    config(['trypost.platforms.linkedin.extra_scopes' => null]);
 
     $captured = [];
 
@@ -72,7 +72,7 @@ test('linkedin connect requests the default scope set when LINKEDIN_EXTRA_SCOPES
 test('linkedin connect appends LINKEDIN_EXTRA_SCOPES to the default scope set', function () {
     // Backward-compatibility: ops who have legacy products approved on
     // their LinkedIn app (e.g. r_basicprofile) opt back in via env.
-    config(['services.linkedin.extra_scopes' => 'r_basicprofile, r_emailaddress']);
+    config(['trypost.platforms.linkedin.extra_scopes' => 'r_basicprofile, r_emailaddress']);
 
     $captured = [];
 

--- a/tests/Feature/Social/LinkedInControllerTest.php
+++ b/tests/Feature/Social/LinkedInControllerTest.php
@@ -39,9 +39,13 @@ test('linkedin connect redirects to oauth provider', function () {
     expect(session('social_connect_workspace'))->toBe($this->workspace->id);
 });
 
-test('linkedin connect requests the default scope set when LINKEDIN_EXTRA_SCOPES is unset', function () {
-    config(['trypost.platforms.linkedin.extra_scopes' => null]);
-
+/**
+ * Mock the LinkedIn Socialite driver, hit /connect, and return the scopes
+ * the controller requested.
+ *
+ * @return array<int, string>
+ */
+$captureConnectScopes = function (object $test): array {
     $captured = [];
 
     $driverMock = Mockery::mock();
@@ -60,43 +64,27 @@ test('linkedin connect requests the default scope set when LINKEDIN_EXTRA_SCOPES
         ->with('linkedin')
         ->andReturn($driverMock);
 
-    $this->actingAs($this->user)
+    $test->actingAs($test->user)
         ->withHeader('X-Inertia', 'true')
         ->get(route('app.social.linkedin.connect'));
 
-    expect($captured)->toEqualCanonicalizing([
+    return $captured;
+};
+
+test('linkedin connect requests the default scope set when LINKEDIN_EXTRA_SCOPES is unset', function () use ($captureConnectScopes) {
+    config(['trypost.platforms.linkedin.extra_scopes' => null]);
+
+    expect($captureConnectScopes($this))->toEqualCanonicalizing([
         'openid', 'profile', 'email', 'w_member_social',
     ]);
 });
 
-test('linkedin connect appends LINKEDIN_EXTRA_SCOPES to the default scope set', function () {
+test('linkedin connect appends LINKEDIN_EXTRA_SCOPES to the default scope set', function () use ($captureConnectScopes) {
     // Backward-compatibility: ops who have legacy products approved on
     // their LinkedIn app (e.g. r_basicprofile) opt back in via env.
     config(['trypost.platforms.linkedin.extra_scopes' => 'r_basicprofile, r_emailaddress']);
 
-    $captured = [];
-
-    $driverMock = Mockery::mock();
-    $driverMock->shouldReceive('scopes')
-        ->withArgs(function (array $scopes) use (&$captured) {
-            $captured = $scopes;
-
-            return true;
-        })
-        ->andReturnSelf();
-    $driverMock->shouldReceive('redirect')->andReturn(Mockery::mock([
-        'getTargetUrl' => 'https://www.linkedin.com/oauth/v2/authorization?test=1',
-    ]));
-
-    Socialite::shouldReceive('driver')
-        ->with('linkedin')
-        ->andReturn($driverMock);
-
-    $this->actingAs($this->user)
-        ->withHeader('X-Inertia', 'true')
-        ->get(route('app.social.linkedin.connect'));
-
-    expect($captured)->toEqualCanonicalizing([
+    expect($captureConnectScopes($this))->toEqualCanonicalizing([
         'openid', 'profile', 'email', 'w_member_social',
         'r_basicprofile', 'r_emailaddress',
     ]);

--- a/tests/Feature/Social/LinkedInControllerTest.php
+++ b/tests/Feature/Social/LinkedInControllerTest.php
@@ -39,6 +39,69 @@ test('linkedin connect redirects to oauth provider', function () {
     expect(session('social_connect_workspace'))->toBe($this->workspace->id);
 });
 
+test('linkedin connect requests the default scope set when LINKEDIN_EXTRA_SCOPES is unset', function () {
+    config(['services.linkedin.extra_scopes' => null]);
+
+    $captured = [];
+
+    $driverMock = Mockery::mock();
+    $driverMock->shouldReceive('scopes')
+        ->withArgs(function (array $scopes) use (&$captured) {
+            $captured = $scopes;
+
+            return true;
+        })
+        ->andReturnSelf();
+    $driverMock->shouldReceive('redirect')->andReturn(Mockery::mock([
+        'getTargetUrl' => 'https://www.linkedin.com/oauth/v2/authorization?test=1',
+    ]));
+
+    Socialite::shouldReceive('driver')
+        ->with('linkedin')
+        ->andReturn($driverMock);
+
+    $this->actingAs($this->user)
+        ->withHeader('X-Inertia', 'true')
+        ->get(route('app.social.linkedin.connect'));
+
+    expect($captured)->toEqualCanonicalizing([
+        'openid', 'profile', 'email', 'w_member_social',
+    ]);
+});
+
+test('linkedin connect appends LINKEDIN_EXTRA_SCOPES to the default scope set', function () {
+    // Backward-compatibility: ops who have legacy products approved on
+    // their LinkedIn app (e.g. r_basicprofile) opt back in via env.
+    config(['services.linkedin.extra_scopes' => 'r_basicprofile, r_emailaddress']);
+
+    $captured = [];
+
+    $driverMock = Mockery::mock();
+    $driverMock->shouldReceive('scopes')
+        ->withArgs(function (array $scopes) use (&$captured) {
+            $captured = $scopes;
+
+            return true;
+        })
+        ->andReturnSelf();
+    $driverMock->shouldReceive('redirect')->andReturn(Mockery::mock([
+        'getTargetUrl' => 'https://www.linkedin.com/oauth/v2/authorization?test=1',
+    ]));
+
+    Socialite::shouldReceive('driver')
+        ->with('linkedin')
+        ->andReturn($driverMock);
+
+    $this->actingAs($this->user)
+        ->withHeader('X-Inertia', 'true')
+        ->get(route('app.social.linkedin.connect'));
+
+    expect($captured)->toEqualCanonicalizing([
+        'openid', 'profile', 'email', 'w_member_social',
+        'r_basicprofile', 'r_emailaddress',
+    ]);
+});
+
 test('linkedin oauth callback creates account', function () {
     session([
         'social_connect_workspace' => $this->workspace->id,
@@ -99,7 +162,7 @@ test('linkedin oauth callback splits comma-separated approvedScopes before savin
     // splits on space (the OAuth 2.0 default), so approvedScopes lands as
     // a single-element array with the whole CSV inside. The save path
     // must normalize back to individual tokens.
-    $socialiteUser->approvedScopes = ['email,openid,profile,r_basicprofile,w_member_social'];
+    $socialiteUser->approvedScopes = ['email,openid,profile,w_member_social'];
 
     Socialite::shouldReceive('driver')
         ->with('linkedin')
@@ -116,7 +179,7 @@ test('linkedin oauth callback splits comma-separated approvedScopes before savin
 
     $account = SocialAccount::where('platform_user_id', 'abc123xyz')->first();
     expect($account->scopes)->toEqualCanonicalizing([
-        'email', 'openid', 'profile', 'r_basicprofile', 'w_member_social',
+        'email', 'openid', 'profile', 'w_member_social',
     ]);
 });
 


### PR DESCRIPTION
## Summary

LinkedIn rejects OAuth authorize requests with a generic *"Bummer, something went wrong"* page when an app asks for a scope it can't grant. `r_basicprofile` is a legacy scope deprecated in 2018 — new LinkedIn developer apps don't have it, so **every self-hosted user hits the rejection immediately** on `/connect/linkedin`.

This PR removes `r_basicprofile` from the **default** scope set and adds a `LINKEDIN_EXTRA_SCOPES` env var so ops who DO have legacy or enterprise products approved keep working unchanged.

## Reproducer (before this PR)

1. Fresh LinkedIn dev app with the standard self-hosted products: *Sign In with LinkedIn using OpenID Connect* + *Share on LinkedIn*.
2. `services.linkedin.client_id` / `_secret` filled in.
3. Connect LinkedIn from the trypost UI → LinkedIn auth page → generic *"Bummer"* error.

The OAuth URL trypost emits includes `scope=openid+profile+email+r_basicprofile+w_member_social`. LinkedIn refuses to issue an auth code because `r_basicprofile` is not covered by the app's approved products.

## Default scope set after this PR

| Product | Granted scopes |
| --- | --- |
| Sign In with LinkedIn using OpenID Connect | `openid`, `profile`, `email` |
| Share on LinkedIn | `w_member_social` |

That's what trypost requests by default. Both products are auto-approved for new apps — no review form needed.

## Backward compatibility — opt back in to legacy scopes

Ops whose LinkedIn app has legacy/enterprise products approved (so they DO have `r_basicprofile`, `r_emailaddress`, etc.) can re-add scopes via env:

```env
LINKEDIN_EXTRA_SCOPES=r_basicprofile
```

`LinkedInController::resolveScopes()` merges this comma-separated list into the default scope array. The connect flow's `Socialite::scopes()` call then includes the legacy scope, preserving pre-PR behaviour end-to-end — including the `/v2/me?projection=(vanityName)` lookup and the pretty `linkedin.com/in/<slug>` URLs.

## Impact on users without `r_basicprofile`

| What | Before | After |
| --- | --- | --- |
| `/connect/linkedin` | LinkedIn 400 / "Bummer" page | OAuth completes ✓ |
| Post publishing | Worked once you got past connect | Works ✓ |
| Connected account `username` | `vanityName` from `/v2/me` | `null` (graceful — `fetchVanityName()` already returns null on HTTP failure) |
| `LinkedInPagePublisher` post URL | `linkedin.com/company/<vanity>/posts/` | `linkedin.com/feed/update/<id>` (the publisher already falls back when `$account->username` is null) |

## Files

- `app/Http/Controllers/Auth/LinkedInController.php` — remove `r_basicprofile` from the default `$scopes`, add `resolveScopes()` that appends `LINKEDIN_EXTRA_SCOPES`.
- `config/services.php` — add `extra_scopes` key to the `linkedin` provider config.
- `.env.example`, `docker/.env.docker.example` — document `LINKEDIN_EXTRA_SCOPES` (commented out by default).
- `tests/Feature/Social/LinkedInControllerTest.php`
  - New: `requests the default scope set when LINKEDIN_EXTRA_SCOPES is unset`
  - New: `appends LINKEDIN_EXTRA_SCOPES to the default scope set` (uses `r_basicprofile, r_emailaddress` to verify the comma-split-and-trim path)
  - Updated: the existing `splits comma-separated approvedScopes` fixture's scope list now matches the new default.

## Test plan

- [ ] CI: \`composer lint\` (pint) passes
- [ ] CI: \`composer test\` (Pest) passes
- [ ] Manual A — default: fresh LinkedIn app with only OpenID Connect + Share-on-LinkedIn → `/connect/linkedin` completes, account row created, `username` is null, post URLs use the `/feed/update/<id>` form.
- [ ] Manual B — legacy: app that has `r_basicprofile` approved, `LINKEDIN_EXTRA_SCOPES=r_basicprofile` set → connect completes with the legacy scope in the consent screen, `username` is populated from `/v2/me`, post URLs use the vanity slug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)