### PR TITLE
Fix workspace name-only update rejected by required brand fields

### DIFF
--- a/app/Http/Requests/App/Workspace/UpdateWorkspaceRequest.php
+++ b/app/Http/Requests/App/Workspace/UpdateWorkspaceRequest.php
@@ -29,8 +29,8 @@ class UpdateWorkspaceRequest extends FormRequest
             'brand_color' => $hex,
             'background_color' => $hex,
             'text_color' => $hex,
-            'brand_font' => ['required', 'string', Rule::in(BrandFont::values())],
-            'image_style' => ['required', 'string', Rule::in(ImageStyle::values())],
+            'brand_font' => ['sometimes', 'required', 'string', Rule::in(BrandFont::values())],
+            'image_style' => ['sometimes', 'required', 'string', Rule::in(ImageStyle::values())],
             'content_language' => ['sometimes', 'string', 'in:en,pt-BR,es'],
         ];
     }

--- a/tests/Feature/WorkspaceControllerTest.php
+++ b/tests/Feature/WorkspaceControllerTest.php
@@ -232,6 +232,27 @@ test('update workspace settings persists the image_style choice', function () {
     expect($this->workspace->refresh()->image_style->value)->toBe('minimalist');
 });
 
+test('update workspace settings updates the name when only the name is submitted', function () {
+    $this->actingAs($this->user)
+        ->from(route('app.workspace.settings'))
+        ->put(route('app.workspace.settings.update'), [
+            'name' => 'Name Only Update',
+        ])
+        ->assertRedirect(route('app.workspace.settings'))
+        ->assertSessionHasNoErrors();
+
+    expect($this->workspace->refresh()->name)->toBe('Name Only Update');
+});
+
+test('update workspace settings still requires brand_font and image_style when submitted empty', function () {
+    $this->actingAs($this->user)
+        ->put(route('app.workspace.settings.update'), [
+            'name' => $this->workspace->name,
+            'brand_font' => '',
+            'image_style' => '',
+        ])->assertSessionHasErrors(['brand_font', 'image_style']);
+});
+
 test('update workspace settings rejects unknown image_style values', function () {
     $this->actingAs($this->user)
         ->put(route('app.workspace.settings.update'), [


### PR DESCRIPTION
## Summary

Fixes #74 — renaming a workspace from **Settings → Workspace** silently failed: the request was rejected by validation but the form showed no error.

### Root cause

The Workspace tab and the Brand tab both submit to the same endpoint (`WorkspaceController::updateSettings` → `UpdateWorkspaceRequest`):

- `BrandTab.vue` submits the full brand payload, including `brand_font` and `image_style`.
- `WorkspaceTab.vue` submits **only** `name`.

`UpdateWorkspaceRequest` marked `brand_font` and `image_style` as `required` on every request, so the name-only submission failed validation. The Workspace form only renders `errors.name`, so the brand-field errors were invisible — the rename appeared to save but nothing changed.

### Fix

Mark both brand fields as `sometimes|required` (consistent with how `content_language` already behaves in the same request):

```php
'brand_font' => ['sometimes', 'required', 'string', Rule::in(BrandFont::values())],
'image_style' => ['sometimes', 'required', 'string', Rule::in(ImageStyle::values())],
```

`sometimes` only runs the rule when the field is present, so a name-only update succeeds while the Brand tab still validates both fields as required.

### Tests

- `update workspace settings updates the name when only the name is submitted` — reproduces the bug (red before the fix, green after).
- `update workspace settings still requires brand_font and image_style when submitted empty` — guards against loosening validation too far.
- Full `WorkspaceControllerTest` suite: **41 passed**.