### PR TITLE
Fix calendar showing "no content" for every post

### DIFF
--- a/resources/js/pages/posts/Calendar.vue
+++ b/resources/js/pages/posts/Calendar.vue
@@ -18,7 +18,6 @@ import { PostStatus } from '@/types/post';
 interface PostPlatform {
     id: string;
     platform: string;
-    content: string;
     status: string;
     social_account: {
         id: string;
@@ -31,6 +30,7 @@ interface PostPlatform {
 interface Post {
     id: string;
     status: string;
+    content: string | null;
     scheduled_at: string;
     post_platforms: PostPlatform[];
 }
@@ -297,7 +297,7 @@ const formatTime = (scheduledAt: string): string => {
                     <div v-if="dayPosts.length > 0" class="space-y-3">
                         <Link v-for="post in dayPosts" :key="post.id" :href="getPostUrl(post)" class="block">
                             <div
-                                class="rounded-xl border-2 border-foreground p-4 shadow-2xs transition-all hover:-translate-y-0.5 hover:shadow-md"
+                                class="rounded-xl border-2 border-foreground p-4 shadow-2xs transition-all hover:shadow-md"
                                 :class="getStatusColor(post.status)"
                             >
                                 <div class="flex items-start justify-between gap-3">
@@ -334,7 +334,7 @@ const formatTime = (scheduledAt: string): string => {
 
                                         <!-- Content Preview -->
                                         <p class="line-clamp-2 text-sm font-medium text-foreground/80">
-                                            {{ post.post_platforms[0]?.content || $t('calendar.no_content') }}
+                                            {{ post.content?.trim() || $t('calendar.no_content') }}
                                         </p>
                                     </div>
                                 </div>
@@ -383,7 +383,7 @@ const formatTime = (scheduledAt: string): string => {
                         <!-- Posts -->
                         <Link v-for="post in getPostsForDay(day)" :key="post.id" :href="getPostUrl(post)" class="block">
                             <div
-                                class="rounded-lg border-2 border-foreground p-2 text-sm shadow-2xs transition-all hover:-translate-y-0.5 hover:shadow-sm"
+                                class="rounded-lg border-2 border-foreground p-2 text-sm shadow-2xs transition-all hover:shadow-sm"
                                 :class="getStatusColor(post.status)"
                             >
                                 <!-- Time -->
@@ -418,7 +418,7 @@ const formatTime = (scheduledAt: string): string => {
 
                                 <!-- Content Preview -->
                                 <p class="line-clamp-2 text-xs font-medium text-foreground/80">
-                                    {{ post.post_platforms[0]?.content || $t('calendar.no_content') }}
+                                    {{ post.content?.trim() || $t('calendar.no_content') }}
                                 </p>
                             </div>
                         </Link>
@@ -479,12 +479,13 @@ const formatTime = (scheduledAt: string): string => {
                             </div>
 
                             <!-- Posts -->
-                            <div class="min-h-0 flex-1 space-y-1 overflow-y-auto">
+                            <div class="min-h-0 flex-1 space-y-1 overflow-y-auto px-1">
                                 <Link v-for="post in getPostsForDay(day).slice(0, 3)" :key="post.id" :href="getPostUrl(post)" class="block">
                                     <div
-                                        class="flex items-center justify-between gap-1.5 rounded-md border-2 border-foreground px-2 py-1 text-xs shadow-2xs transition-all hover:-translate-y-0.5 hover:shadow-sm"
+                                        class="flex flex-col gap-1 rounded-md border-2 border-foreground px-2 py-1 text-xs shadow-2xs transition-all hover:shadow-sm"
                                         :class="getStatusColor(post.status)"
                                     >
+                                        <div class="flex items-center justify-between gap-1.5">
                                         <span class="shrink-0 font-bold">{{ formatTime(post.scheduled_at) }}</span>
                                         <div class="flex shrink-0 -space-x-1">
                                             <TooltipProvider
@@ -513,6 +514,10 @@ const formatTime = (scheduledAt: string): string => {
                                                 +{{ post.post_platforms.length - 3 }}
                                             </span>
                                         </div>
+                                        </div>
+                                        <p class="line-clamp-1 font-medium text-foreground/80">
+                                            {{ post.content?.trim() || $t('calendar.no_content') }}
+                                        </p>
                                     </div>
                                 </Link>
                                 <div

--- a/tests/Feature/PostControllerTest.php
+++ b/tests/Feature/PostControllerTest.php
@@ -176,6 +176,27 @@ test('calendar supports month view', function () {
     );
 });
 
+test('calendar payload exposes post content for rendering', function () {
+    $scheduledAt = now('UTC')->startOfWeek()->addDays(2)->setTime(12, 0);
+
+    Post::factory()->create([
+        'workspace_id' => $this->workspace->id,
+        'user_id' => $this->user->id,
+        'content' => 'Caption visible in the calendar',
+        'status' => PostStatus::Scheduled,
+        'scheduled_at' => $scheduledAt,
+    ]);
+
+    $dateKey = $scheduledAt->format('Y-m-d');
+
+    $response = $this->actingAs($this->user)->get(route('app.calendar'));
+
+    $response->assertOk();
+    $response->assertInertia(fn ($page) => $page
+        ->where("posts.{$dateKey}.0.content", 'Caption visible in the calendar')
+    );
+});
+
 // Create tests
 test('create requires authentication', function () {
     $response = $this->get(route('app.posts.create'));


### PR DESCRIPTION
## Summary

Fixes #70 — the calendar rendered the "No content" placeholder for every post instead of the caption, even when content existed.

### Root cause

`Calendar.vue` read each post's caption from `post.post_platforms[0]?.content`, but `post_platforms` has **no `content` column** (only `content_type` and `enabled`). The caption lives on `posts.content`. So the per-platform field was always `undefined` and every cell fell back to `calendar.no_content`. The list view (`Index.vue`) was already correct — it reads `post.content`.

### Changes

- Read `post.content` in the day and week views (matching the list view), and drop the phantom `content` field from the `PostPlatform` TS interface so it can't be misused again.
- **Month view:** surface the caption — it previously showed only the time and platform icons, never any text.
- **Month view:** add horizontal padding to the post list so the bordered card isn't clipped on the right inside the `overflow-y-auto` scroll container (setting `overflow-y` forces `overflow-x` to clip, and the card was flush against the edge).
- Standardise the hover effect across day/week/month to a shadow-only highlight (removed the `-translate-y` lift, which clipped cards inside the tight month cells).

### Tests

- Added `calendar payload exposes post content for rendering` — guards the data contract the frontend relies on (the calendar payload exposes `posts.{date}.0.content`).
- Full `PostControllerTest` suite: **62 passed**. ESLint clean.

### Note on coverage

The bug itself was a frontend template reading the wrong field; the backend already supplied `content`. The project has no browser-test infra (Dusk / Pest 4 browser), so the render itself isn't covered by an automated test — the added test locks the data contract, and the template change was verified visually.