### PR TITLE
Post platform meta (aspect ratio) parity across API and MCP

### DIFF
--- a/app/Actions/Post/CreatePost.php
+++ b/app/Actions/Post/CreatePost.php
@@ -62,6 +62,10 @@ class CreatePost
                     $updates['content_type'] = $contentType;
                 }
 
+                if (($meta = data_get($platformData, 'meta')) !== null) {
+                    $updates['meta'] = $meta;
+                }
+
                 $post->postPlatforms()
                     ->where('social_account_id', $accountId)
                     ->update($updates);

--- a/app/Enums/PostPlatform/AspectRatio.php
+++ b/app/Enums/PostPlatform/AspectRatio.php
@@ -10,4 +10,18 @@ enum AspectRatio: string
     case Portrait = '4:5';
     case Landscape = '16:9';
     case Original = 'original';
+
+    /**
+     * Width-to-height ratio used to center-crop an image. `Original` means "no
+     * crop", so it resolves to a square (1.0) only as a safe fallback — callers
+     * should bypass cropping entirely for `Original`.
+     */
+    public function toFloat(): float
+    {
+        return match ($this) {
+            self::Portrait => 4 / 5,
+            self::Landscape => 16 / 9,
+            self::Square, self::Original => 1.0,
+        };
+    }
 }

--- a/app/Enums/PostPlatform/AspectRatio.php
+++ b/app/Enums/PostPlatform/AspectRatio.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Enums\PostPlatform;
+
+enum AspectRatio: string
+{
+    case Square = '1:1';
+    case Portrait = '4:5';
+    case Landscape = '16:9';
+    case Original = 'original';
+}

--- a/app/Http/Controllers/Api/PostController.php
+++ b/app/Http/Controllers/Api/PostController.php
@@ -75,7 +75,10 @@ class PostController extends Controller
             );
         }
 
-        return new PostResource(data_get($result, 'post'));
+        $updated = data_get($result, 'post');
+        $updated->load(['postPlatforms.socialAccount']);
+
+        return new PostResource($updated);
     }
 
     public function destroy(Request $request, Post $post): JsonResponse

--- a/app/Http/Requests/Api/Post/StorePostRequest.php
+++ b/app/Http/Requests/Api/Post/StorePostRequest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Http\Requests\Api\Post;
 
+use App\Enums\PostPlatform\AspectRatio;
 use App\Enums\PostPlatform\ContentType;
 use App\Enums\SocialAccount\Platform;
 use App\Models\SocialAccount;
@@ -49,6 +50,8 @@ class StorePostRequest extends FormRequest
                 Rule::in(array_column(ContentType::cases(), 'value')),
                 new ContentTypeMatchesPlatform,
             ],
+            'platforms.*.meta' => ['sometimes', 'nullable', 'array'],
+            'platforms.*.meta.aspect_ratio' => ['sometimes', 'nullable', 'string', Rule::enum(AspectRatio::class)],
             'scheduled_at' => ['nullable', 'date', 'after:now'],
             'label_ids' => ['sometimes', 'array'],
             'label_ids.*' => [

--- a/app/Http/Requests/Api/Post/UpdatePostRequest.php
+++ b/app/Http/Requests/Api/Post/UpdatePostRequest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Http\Requests\Api\Post;
 
 use App\Enums\Post\Status;
+use App\Enums\PostPlatform\AspectRatio;
 use App\Enums\PostPlatform\ContentType;
 use App\Enums\SocialAccount\Platform;
 use App\Models\Post;
@@ -51,6 +52,7 @@ class UpdatePostRequest extends FormRequest
                 new ContentTypeMatchesPostPlatform,
             ],
             'platforms.*.meta' => ['nullable', 'array'],
+            'platforms.*.meta.aspect_ratio' => ['sometimes', 'nullable', 'string', Rule::enum(AspectRatio::class)],
             'scheduled_at' => [
                 'nullable',
                 'date',

--- a/app/Http/Requests/App/Post/UpdatePostRequest.php
+++ b/app/Http/Requests/App/Post/UpdatePostRequest.php
@@ -6,6 +6,7 @@ namespace App\Http\Requests\App\Post;
 
 use App\Enums\Media\Source;
 use App\Enums\Post\Status;
+use App\Enums\PostPlatform\AspectRatio;
 use App\Enums\PostPlatform\ContentType;
 use App\Enums\SocialAccount\Platform;
 use App\Rules\ContentFitsPlatformLimits;
@@ -70,7 +71,7 @@ class UpdatePostRequest extends FormRequest
                 Rule::when($enforcesMediaCompatibility, [new ContentTypeCompatibleWithMedia]),
             ],
             'platforms.*.meta' => ['nullable', 'array'],
-            'platforms.*.meta.aspect_ratio' => ['sometimes', 'nullable', 'string', Rule::in(['1:1', '4:5', '16:9', 'original'])],
+            'platforms.*.meta.aspect_ratio' => ['sometimes', 'nullable', 'string', Rule::enum(AspectRatio::class)],
             'platforms.*.meta.privacy_level' => ['sometimes', 'nullable', 'string', Rule::in(['PUBLIC_TO_EVERYONE', 'MUTUAL_FOLLOW_FRIENDS', 'FOLLOWER_OF_CREATOR', 'SELF_ONLY'])],
             'platforms.*.meta.auto_add_music' => ['sometimes', 'boolean'],
             'platforms.*.meta.allow_comments' => ['sometimes', 'boolean'],

--- a/app/Http/Resources/Api/PostPlatformResource.php
+++ b/app/Http/Resources/Api/PostPlatformResource.php
@@ -18,6 +18,7 @@ class PostPlatformResource extends JsonResource
             'id' => $this->id,
             'platform' => $this->platform?->value,
             'content_type' => $this->content_type?->value,
+            'meta' => $this->meta,
             'status' => $this->status?->value,
             'enabled' => $this->enabled,
             'platform_url' => $this->platform_url,

--- a/app/Mcp/Tools/Post/CreatePostTool.php
+++ b/app/Mcp/Tools/Post/CreatePostTool.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Mcp\Tools\Post;
 
 use App\Actions\Post\CreatePost;
+use App\Enums\PostPlatform\AspectRatio;
 use App\Enums\PostPlatform\ContentType;
 use App\Http\Resources\Api\PostResource;
 use App\Rules\ContentTypeMatchesPlatform;
@@ -37,6 +38,8 @@ class CreatePostTool extends Tool
                     ->where('is_active', true),
             ],
             'platforms.*.content_type' => ['required', 'string', Rule::in(array_column(ContentType::cases(), 'value')), new ContentTypeMatchesPlatform],
+            'platforms.*.meta' => ['sometimes', 'array'],
+            'platforms.*.meta.aspect_ratio' => ['sometimes', 'nullable', 'string', Rule::enum(AspectRatio::class)],
         ]);
 
         $post = CreatePost::execute($workspace, $request->user(), $validated);
@@ -58,6 +61,7 @@ class CreatePostTool extends Tool
                 ->items($schema->object(fn ($p) => [
                     'social_account_id' => $p->string()->required()->description('UUID of the connected social account.'),
                     'content_type' => $p->string()->required()->description('Format for this platform (e.g. linkedin_post, x_post, instagram_feed).'),
+                    'meta' => $p->object()->description('Per-platform metadata (e.g. aspect_ratio: 1:1|4:5|16:9|original for Instagram/Facebook feed images).'),
                 ]))
                 ->description('Platforms to publish on. Accounts not listed remain available but disabled.'),
         ];

--- a/app/Mcp/Tools/Post/UpdatePostTool.php
+++ b/app/Mcp/Tools/Post/UpdatePostTool.php
@@ -7,6 +7,7 @@ namespace App\Mcp\Tools\Post;
 use App\Actions\Post\UpdatePost;
 use App\Enums\Post\Action as PostAction;
 use App\Enums\Post\Status;
+use App\Enums\PostPlatform\AspectRatio;
 use App\Enums\PostPlatform\ContentType;
 use App\Http\Resources\Api\PostResource;
 use App\Models\Post;
@@ -49,6 +50,7 @@ class UpdatePostTool extends Tool
             ],
             'platforms.*.content_type' => ['sometimes', 'string', Rule::in(array_column(ContentType::cases(), 'value')), new ContentTypeMatchesPostPlatform],
             'platforms.*.meta' => ['sometimes', 'array'],
+            'platforms.*.meta.aspect_ratio' => ['sometimes', 'nullable', 'string', Rule::enum(AspectRatio::class)],
         ]);
 
         $payload = collect($validated)->except('post_id')->all();

--- a/app/Services/Social/Concerns/CropsImageForAspectRatio.php
+++ b/app/Services/Social/Concerns/CropsImageForAspectRatio.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Services\Social\Concerns;
 
+use App\Enums\PostPlatform\AspectRatio;
 use App\Exceptions\Social\SocialPublishException;
 use App\Services\Media\MediaOptimizer;
 use Illuminate\Support\Facades\Http;
@@ -51,11 +52,7 @@ trait CropsImageForAspectRatio
 
     protected function aspectRatioToFloat(string $ratio): float
     {
-        return match ($ratio) {
-            '4:5' => 4 / 5,
-            '16:9' => 16 / 9,
-            default => 1.0,
-        };
+        return AspectRatio::tryFrom($ratio)?->toFloat() ?? 1.0;
     }
 
     /**

--- a/tests/Feature/Api/PostApiTest.php
+++ b/tests/Feature/Api/PostApiTest.php
@@ -577,3 +577,50 @@ it('show post returns correct structure', function () {
         ->assertOk()
         ->assertJsonStructure(['id', 'status', 'scheduled_at', 'published_at']);
 });
+
+it('creates a post with platform meta (aspect_ratio) and returns it', function () {
+    $this->withHeaders(['Authorization' => 'Bearer '.$this->plainToken])
+        ->postJson(route('api.posts.store'), [
+            'platforms' => [
+                ['social_account_id' => $this->socialAccount->id, 'content_type' => 'linkedin_post', 'meta' => ['aspect_ratio' => '4:5']],
+            ],
+        ])
+        ->assertCreated()
+        ->assertJsonPath('platforms.0.meta.aspect_ratio', '4:5');
+
+    $platform = Post::where('workspace_id', $this->workspace->id)->first()
+        ->postPlatforms()->where('social_account_id', $this->socialAccount->id)->first();
+    expect($platform->meta['aspect_ratio'])->toBe('4:5');
+});
+
+it('rejects creating a post with an invalid aspect_ratio', function () {
+    $this->withHeaders(['Authorization' => 'Bearer '.$this->plainToken])
+        ->postJson(route('api.posts.store'), [
+            'platforms' => [
+                ['social_account_id' => $this->socialAccount->id, 'content_type' => 'linkedin_post', 'meta' => ['aspect_ratio' => '3:2']],
+            ],
+        ])
+        ->assertJsonValidationErrors(['platforms.0.meta.aspect_ratio']);
+});
+
+it('rejects updating a post with an invalid aspect_ratio', function () {
+    $post = Post::factory()->create([
+        'workspace_id' => $this->workspace->id,
+        'user_id' => $this->user->id,
+        'status' => PostStatus::Draft,
+    ]);
+    $postPlatform = PostPlatform::factory()->linkedin()->create([
+        'post_id' => $post->id,
+        'social_account_id' => $this->socialAccount->id,
+        'enabled' => true,
+    ]);
+
+    $this->withHeaders(['Authorization' => 'Bearer '.$this->plainToken])
+        ->putJson(route('api.posts.update', $post), [
+            'status' => 'draft',
+            'platforms' => [
+                ['id' => $postPlatform->id, 'content_type' => 'linkedin_post', 'meta' => ['aspect_ratio' => '3:2']],
+            ],
+        ])
+        ->assertJsonValidationErrors(['platforms.0.meta.aspect_ratio']);
+});

--- a/tests/Feature/Api/PostApiTest.php
+++ b/tests/Feature/Api/PostApiTest.php
@@ -624,3 +624,42 @@ it('rejects updating a post with an invalid aspect_ratio', function () {
         ])
         ->assertJsonValidationErrors(['platforms.0.meta.aspect_ratio']);
 });
+
+it('accepts a valid aspect_ratio on update and persists it', function () {
+    $post = Post::factory()->create([
+        'workspace_id' => $this->workspace->id,
+        'user_id' => $this->user->id,
+        'status' => PostStatus::Draft,
+    ]);
+    $postPlatform = PostPlatform::factory()->linkedin()->create([
+        'post_id' => $post->id,
+        'social_account_id' => $this->socialAccount->id,
+        'enabled' => true,
+    ]);
+
+    $this->withHeaders(['Authorization' => 'Bearer '.$this->plainToken])
+        ->putJson(route('api.posts.update', $post), [
+            'status' => 'draft',
+            'platforms' => [
+                ['id' => $postPlatform->id, 'content_type' => 'linkedin_post', 'meta' => ['aspect_ratio' => '16:9']],
+            ],
+        ])
+        ->assertOk()
+        ->assertJsonPath('platforms.0.meta.aspect_ratio', '16:9');
+
+    expect($postPlatform->fresh()->meta['aspect_ratio'])->toBe('16:9');
+});
+
+it('accepts the original aspect_ratio (no crop) on create', function () {
+    $this->withHeaders(['Authorization' => 'Bearer '.$this->plainToken])
+        ->postJson(route('api.posts.store'), [
+            'platforms' => [
+                ['social_account_id' => $this->socialAccount->id, 'content_type' => 'linkedin_post', 'meta' => ['aspect_ratio' => 'original']],
+            ],
+        ])
+        ->assertCreated();
+
+    $platform = Post::where('workspace_id', $this->workspace->id)->first()
+        ->postPlatforms()->where('social_account_id', $this->socialAccount->id)->first();
+    expect($platform->meta['aspect_ratio'])->toBe('original');
+});

--- a/tests/Feature/Mcp/PostToolTest.php
+++ b/tests/Feature/Mcp/PostToolTest.php
@@ -276,3 +276,50 @@ test('delete post validates post_id required', function () {
 
     $response->assertHasErrors();
 });
+
+test('create post persists platform meta (aspect_ratio)', function () {
+    $response = TryPostServer::actingAs($this->user)
+        ->tool(CreatePostTool::class, [
+            'platforms' => [
+                ['social_account_id' => $this->socialAccount->id, 'content_type' => 'linkedin_post', 'meta' => ['aspect_ratio' => '4:5']],
+            ],
+        ]);
+
+    $response->assertOk();
+
+    $platform = Post::where('workspace_id', $this->workspace->id)->first()
+        ->postPlatforms()->where('social_account_id', $this->socialAccount->id)->first();
+    expect($platform->meta['aspect_ratio'])->toBe('4:5');
+});
+
+test('create post rejects an invalid aspect_ratio', function () {
+    $response = TryPostServer::actingAs($this->user)
+        ->tool(CreatePostTool::class, [
+            'platforms' => [
+                ['social_account_id' => $this->socialAccount->id, 'content_type' => 'linkedin_post', 'meta' => ['aspect_ratio' => '3:2']],
+            ],
+        ]);
+
+    $response->assertHasErrors();
+});
+
+test('update post rejects an invalid aspect_ratio', function () {
+    $post = Post::factory()->create([
+        'workspace_id' => $this->workspace->id,
+        'user_id' => $this->user->id,
+    ]);
+    $platform = PostPlatform::factory()->create([
+        'post_id' => $post->id,
+        'social_account_id' => $this->socialAccount->id,
+    ]);
+
+    $response = TryPostServer::actingAs($this->user)
+        ->tool(UpdatePostTool::class, [
+            'post_id' => $post->id,
+            'platforms' => [
+                ['id' => $platform->id, 'meta' => ['aspect_ratio' => '3:2']],
+            ],
+        ]);
+
+    $response->assertHasErrors();
+});

--- a/tests/Feature/Mcp/PostToolTest.php
+++ b/tests/Feature/Mcp/PostToolTest.php
@@ -323,3 +323,36 @@ test('update post rejects an invalid aspect_ratio', function () {
 
     $response->assertHasErrors();
 });
+
+test('create post returns the platform meta in the response (read-back)', function () {
+    TryPostServer::actingAs($this->user)
+        ->tool(CreatePostTool::class, [
+            'platforms' => [
+                ['social_account_id' => $this->socialAccount->id, 'content_type' => 'linkedin_post', 'meta' => ['aspect_ratio' => '4:5']],
+            ],
+        ])
+        ->assertOk()
+        ->assertStructuredContent(fn (AssertableJson $json) => $json->where('platforms.0.meta.aspect_ratio', '4:5')->etc());
+});
+
+test('update post accepts a valid aspect_ratio and persists it', function () {
+    $post = Post::factory()->create([
+        'workspace_id' => $this->workspace->id,
+        'user_id' => $this->user->id,
+    ]);
+    $platform = PostPlatform::factory()->create([
+        'post_id' => $post->id,
+        'social_account_id' => $this->socialAccount->id,
+    ]);
+
+    TryPostServer::actingAs($this->user)
+        ->tool(UpdatePostTool::class, [
+            'post_id' => $post->id,
+            'platforms' => [
+                ['id' => $platform->id, 'meta' => ['aspect_ratio' => '16:9']],
+            ],
+        ])
+        ->assertOk();
+
+    expect($platform->fresh()->meta['aspect_ratio'])->toBe('16:9');
+});

--- a/tests/Unit/Enums/AspectRatioTest.php
+++ b/tests/Unit/Enums/AspectRatioTest.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Enums\PostPlatform\AspectRatio;
+
+test('aspect ratio has the expected cases and values', function () {
+    expect(array_column(AspectRatio::cases(), 'value'))
+        ->toEqualCanonicalizing(['1:1', '4:5', '16:9', 'original']);
+});
+
+test('aspect ratio maps to the correct crop float', function (string $value, float $expected) {
+    expect(AspectRatio::from($value)->toFloat())->toBe($expected);
+})->with([
+    '1:1' => ['1:1', 1.0],
+    '4:5' => ['4:5', 4 / 5],
+    '16:9' => ['16:9', 16 / 9],
+    'original' => ['original', 1.0],
+]);


### PR DESCRIPTION
Follow-up to #82. That PR made `meta.aspect_ratio` crop Facebook (and already Instagram) feed images at publish time, but the **API** and **MCP** surfaces only half-supported it. This closes the three gaps so the feature behaves the same on every creation path.

## Gaps closed

1. **Couldn't set `meta` on create.** `Api\StorePostRequest` and MCP `CreatePostTool` accepted only `social_account_id` + `content_type` — you could only set aspect ratio via *update*. They now accept `platforms.*.meta`, and `CreatePost` persists it.
2. **Value wasn't validated.** API/MCP accepted `meta` as a free-form array, so an invalid `aspect_ratio` (e.g. `3:2`) slipped through and the publisher silently center-cropped to square. Now validated everywhere.
3. **No read-back.** `Api\PostPlatformResource` (used by both API and MCP responses) exposed `content_type` but not `meta`, so clients never got the aspect ratio back. It now returns `meta`.

## How

- New **`App\Enums\PostPlatform\AspectRatio`** backed enum (`1:1`, `4:5`, `16:9`, `original`) — single source of truth.
- App `UpdatePostRequest`, API `Store`/`Update`, and MCP `Create`/`Update` tools all validate via `Rule::enum(AspectRatio::class)` (replacing the inline `Rule::in([...])`).
- `CreatePost` persists `platforms.*.meta`; MCP create documents `meta` in its schema.
- `Api\PostPlatformResource` exposes `meta`.

No behavior change for the App editor (already worked); this brings API + MCP to the same place.

## Tests

- API: create with `meta.aspect_ratio` persists + is returned in the response; invalid ratio rejected on create and update.
- MCP: `create-post` persists meta; invalid ratio rejected on create and update.

Full suite: **1703 passed, 2 skipped**. Pint clean.