### PR TITLE
Rename post editor 'Schedule' tab to 'Channels'

### DIFF
--- a/lang/en/posts.php
+++ b/lang/en/posts.php
@@ -320,7 +320,7 @@ return [
 
         'tabs' => [
             'preview' => 'Preview',
-            'schedule' => 'Schedule',
+            'channels' => 'Channels',
             'comments' => 'Comments',
             'comments_empty' => 'No comments yet.',
         ],

--- a/lang/es/posts.php
+++ b/lang/es/posts.php
@@ -320,7 +320,7 @@ return [
 
         'tabs' => [
             'preview' => 'Vista previa',
-            'schedule' => 'Programación',
+            'channels' => 'Canales',
             'comments' => 'Comentarios',
             'comments_empty' => 'Todavía no hay comentarios.',
         ],

--- a/lang/pt-BR/posts.php
+++ b/lang/pt-BR/posts.php
@@ -320,7 +320,7 @@ return [
 
         'tabs' => [
             'preview' => 'Pré-visualização',
-            'schedule' => 'Agendamento',
+            'channels' => 'Canais',
             'comments' => 'Comentários',
             'comments_empty' => 'Nenhum comentário ainda.',
         ],

--- a/resources/js/components/posts/editor/PostEditorTabs.vue
+++ b/resources/js/components/posts/editor/PostEditorTabs.vue
@@ -93,7 +93,7 @@ defineExpose({
     <Tabs v-model="activeTab" class="h-full flex flex-col">
         <TabsList class="mx-4 mt-4 w-fit shrink-0 self-start">
             <TabsTrigger value="preview">{{ $t('posts.edit.tabs.preview') }}</TabsTrigger>
-            <TabsTrigger value="schedule">{{ $t('posts.edit.tabs.schedule') }}</TabsTrigger>
+            <TabsTrigger value="schedule">{{ $t('posts.edit.tabs.channels') }}</TabsTrigger>
             <TabsTrigger value="comments">{{ $t('posts.edit.tabs.comments') }}</TabsTrigger>
         </TabsList>
 


### PR DESCRIPTION
The post editor's second tab was labeled **Schedule**, but its content is the publish targets ("Publish to"), per-platform settings (Facebook/Instagram/etc.), and labels — **not** scheduling. The actual date/time scheduling lives in the editor header. "Channels" matches the content (and the common social-tool vocabulary) and removes the confusion.

## Change

- i18n key `posts.edit.tabs.schedule` → `posts.edit.tabs.channels` in all three locales: **Channels / Canais / Canales**.
- Updated the single reference (`PostEditorTabs.vue`).

## Scope / safety

- The key was used in exactly one place (verified), so the rename is isolated.
- The **scheduling button** string (`posts.edit.schedule`) is untouched — that's the real schedule action.
- The tab's internal `value="schedule"` identifier is unchanged (not user-visible); only the label text changed.