### PR TITLE
Harden BlueskyPublisher: link facets, conventions, NSID lexicon, tests

### DIFF
--- a/app/Http/Controllers/Auth/BlueskyController.php
+++ b/app/Http/Controllers/Auth/BlueskyController.php
@@ -6,6 +6,7 @@ namespace App\Http\Controllers\Auth;
 
 use App\Enums\SocialAccount\Platform as SocialPlatform;
 use App\Enums\SocialAccount\Status;
+use App\Services\Social\BlueskyLexicon;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Http;
@@ -57,7 +58,7 @@ class BlueskyController extends SocialController
 
         try {
             // Authenticate with Bluesky
-            $response = Http::post("{$service}/xrpc/com.atproto.server.createSession", [
+            $response = Http::post("{$service}/xrpc/".BlueskyLexicon::CREATE_SESSION, [
                 'identifier' => $request->identifier,
                 'password' => $request->password,
             ]);
@@ -81,7 +82,7 @@ class BlueskyController extends SocialController
 
             // Get profile
             $profileResponse = Http::withToken(data_get($data, 'accessJwt'))
-                ->get("{$service}/xrpc/app.bsky.actor.getProfile", [
+                ->get("{$service}/xrpc/".BlueskyLexicon::GET_PROFILE, [
                     'actor' => data_get($data, 'did'),
                 ]);
 

--- a/app/Services/Social/BlueskyAnalytics.php
+++ b/app/Services/Social/BlueskyAnalytics.php
@@ -21,7 +21,7 @@ class BlueskyAnalytics
         }
 
         $did = $account->platform_user_id;
-        $atUri = "at://{$did}/app.bsky.feed.post/{$postPlatform->platform_post_id}";
+        $atUri = "at://{$did}/".BlueskyLexicon::FEED_POST."/{$postPlatform->platform_post_id}";
 
         // Read counts (likes, reposts, replies, quotes) live on the AT
         // Protocol AppView, not the PDS. The user's PDS requires Bearer auth
@@ -29,7 +29,7 @@ class BlueskyAnalytics
         $appView = (string) config('trypost.platforms.bluesky.public_appview');
 
         $response = $this->socialHttp()
-            ->get("{$appView}/xrpc/app.bsky.feed.getPosts", [
+            ->get("{$appView}/xrpc/".BlueskyLexicon::GET_POSTS, [
                 'uris' => [$atUri],
             ]);
 

--- a/app/Services/Social/BlueskyLexicon.php
+++ b/app/Services/Social/BlueskyLexicon.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Social;
+
+/**
+ * AT Protocol / Bluesky lexicon identifiers (NSIDs) used across the Bluesky
+ * services. Centralized so a typo surfaces as an undefined-constant error
+ * instead of a silent runtime "Invalid request" from the API.
+ */
+final class BlueskyLexicon
+{
+    public const RESOLVE_HANDLE = 'com.atproto.identity.resolveHandle';
+
+    public const CREATE_RECORD = 'com.atproto.repo.createRecord';
+
+    public const UPLOAD_BLOB = 'com.atproto.repo.uploadBlob';
+
+    public const CREATE_SESSION = 'com.atproto.server.createSession';
+
+    public const REFRESH_SESSION = 'com.atproto.server.refreshSession';
+
+    public const FEED_POST = 'app.bsky.feed.post';
+
+    public const GET_POSTS = 'app.bsky.feed.getPosts';
+
+    public const GET_PROFILE = 'app.bsky.actor.getProfile';
+
+    public const EMBED_IMAGES = 'app.bsky.embed.images';
+
+    public const FACET_LINK = 'app.bsky.richtext.facet#link';
+
+    public const FACET_MENTION = 'app.bsky.richtext.facet#mention';
+
+    public const FACET_TAG = 'app.bsky.richtext.facet#tag';
+}

--- a/app/Services/Social/BlueskyPublisher.php
+++ b/app/Services/Social/BlueskyPublisher.php
@@ -10,6 +10,7 @@ use App\Models\PostPlatform;
 use App\Models\SocialAccount;
 use App\Services\Media\MediaOptimizer;
 use App\Services\Social\Concerns\HasSocialHttpClient;
+use Exception;
 use Illuminate\Http\Client\Response;
 use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Log;
@@ -114,7 +115,7 @@ class BlueskyPublisher
             $downloadResponse = Http::withOptions(['sink' => $tempFile])->timeout(600)->get($url);
 
             if ($downloadResponse->failed()) {
-                throw new \Exception('Failed to download media: HTTP '.$downloadResponse->status());
+                throw new Exception('Failed to download media: HTTP '.$downloadResponse->status());
             }
 
             $fileSize = filesize($tempFile);
@@ -154,8 +155,8 @@ class BlueskyPublisher
                 return null;
             }
 
-            return $response->json()['blob'];
-        } catch (\Exception $e) {
+            return data_get($response->json(), 'blob');
+        } catch (Exception $e) {
             Log::error('Bluesky blob upload exception', [
                 'error' => $e->getMessage(),
                 'url' => $url,
@@ -181,7 +182,7 @@ class BlueskyPublisher
 
         foreach ($urlMatches[0] as $match) {
             $url = $this->trimTrailingUrlPunctuation($match[0]);
-            $start = $this->getUtf8ByteOffset($text, (int) $match[1]);
+            $start = (int) $match[1];
             $end = $start + strlen($url);
 
             $facets[] = [
@@ -221,7 +222,7 @@ class BlueskyPublisher
                 continue;
             }
 
-            $start = $this->getUtf8ByteOffset($text, (int) $match[1]);
+            $start = (int) $match[1];
             $end = $start + strlen($mention);
 
             $facets[] = [
@@ -249,7 +250,7 @@ class BlueskyPublisher
         foreach ($hashtagMatches[0] as $match) {
             $hashtag = $match[0];
             $tag = substr($hashtag, 1); // Remove #
-            $start = $this->getUtf8ByteOffset($text, (int) $match[1]);
+            $start = (int) $match[1];
             $end = $start + strlen($hashtag);
 
             $facets[] = [
@@ -294,11 +295,6 @@ class BlueskyPublisher
         }
     }
 
-    private function getUtf8ByteOffset(string $text, int $charOffset): int
-    {
-        return strlen(substr($text, 0, $charOffset));
-    }
-
     /**
      * Trailing sentence punctuation and an unmatched closing paren are almost
      * never part of a URL (e.g. "see https://x.com)."). Mirrors the official
@@ -319,7 +315,9 @@ class BlueskyPublisher
 
     private function buildPostUrl(string $handle, string $postId): string
     {
-        return "https://bsky.app/profile/{$handle}/post/{$postId}";
+        $webApp = (string) config('trypost.platforms.bluesky.web_app');
+
+        return "{$webApp}/profile/{$handle}/post/{$postId}";
     }
 
     private function handleApiError(Response $response): never

--- a/app/Services/Social/BlueskyPublisher.php
+++ b/app/Services/Social/BlueskyPublisher.php
@@ -180,7 +180,7 @@ class BlueskyPublisher
         );
 
         foreach ($urlMatches[0] as $match) {
-            $url = $match[0];
+            $url = $this->trimTrailingUrlPunctuation($match[0]);
             $start = $this->getUtf8ByteOffset($text, (int) $match[1]);
             $end = $start + strlen($url);
 
@@ -297,6 +297,24 @@ class BlueskyPublisher
     private function getUtf8ByteOffset(string $text, int $charOffset): int
     {
         return strlen(substr($text, 0, $charOffset));
+    }
+
+    /**
+     * Trailing sentence punctuation and an unmatched closing paren are almost
+     * never part of a URL (e.g. "see https://x.com)."). Mirrors the official
+     * atproto link tokenizer so the link facet doesn't over-extend past the URL.
+     */
+    private function trimTrailingUrlPunctuation(string $url): string
+    {
+        if (preg_match('/[.,;:!?]$/', $url)) {
+            $url = substr($url, 0, -1);
+        }
+
+        if (str_ends_with($url, ')') && ! str_contains($url, '(')) {
+            $url = substr($url, 0, -1);
+        }
+
+        return $url;
     }
 
     private function buildPostUrl(string $handle, string $postId): string

--- a/app/Services/Social/BlueskyPublisher.php
+++ b/app/Services/Social/BlueskyPublisher.php
@@ -54,7 +54,7 @@ class BlueskyPublisher
 
             if (count($images) > 0) {
                 $embed = [
-                    '$type' => 'app.bsky.embed.images',
+                    '$type' => BlueskyLexicon::EMBED_IMAGES,
                     'images' => $images,
                 ];
             }
@@ -66,7 +66,7 @@ class BlueskyPublisher
 
         // Create post record
         $record = [
-            '$type' => 'app.bsky.feed.post',
+            '$type' => BlueskyLexicon::FEED_POST,
             'text' => $text,
             'createdAt' => now()->toIso8601ZuluString(),
         ];
@@ -80,9 +80,9 @@ class BlueskyPublisher
         }
 
         $response = $this->socialHttp()->withToken($account->access_token)
-            ->post("{$service}/xrpc/com.atproto.repo.createRecord", [
+            ->post("{$service}/xrpc/".BlueskyLexicon::CREATE_RECORD, [
                 'repo' => $account->platform_user_id,
-                'collection' => 'app.bsky.feed.post',
+                'collection' => BlueskyLexicon::FEED_POST,
                 'record' => $record,
             ]);
 
@@ -140,7 +140,7 @@ class BlueskyPublisher
             $response = $this->socialHttp()->withToken($account->access_token)
                 ->withHeaders(['Content-Type' => $mimeType])
                 ->withBody($stream, $mimeType)
-                ->post("{$service}/xrpc/com.atproto.repo.uploadBlob");
+                ->post("{$service}/xrpc/".BlueskyLexicon::UPLOAD_BLOB);
 
             if (is_resource($stream)) {
                 fclose($stream);
@@ -192,7 +192,7 @@ class BlueskyPublisher
                 ],
                 'features' => [
                     [
-                        '$type' => 'app.bsky.richtext.facet#link',
+                        '$type' => BlueskyLexicon::FACET_LINK,
                         'uri' => $url,
                     ],
                 ],
@@ -232,7 +232,7 @@ class BlueskyPublisher
                 ],
                 'features' => [
                     [
-                        '$type' => 'app.bsky.richtext.facet#mention',
+                        '$type' => BlueskyLexicon::FACET_MENTION,
                         'did' => $did,
                     ],
                 ],
@@ -260,7 +260,7 @@ class BlueskyPublisher
                 ],
                 'features' => [
                     [
-                        '$type' => 'app.bsky.richtext.facet#tag',
+                        '$type' => BlueskyLexicon::FACET_TAG,
                         'tag' => $tag,
                     ],
                 ],
@@ -283,7 +283,7 @@ class BlueskyPublisher
 
         try {
             $response = $this->socialHttp()->get(
-                "{$appView}/xrpc/com.atproto.identity.resolveHandle",
+                "{$appView}/xrpc/".BlueskyLexicon::RESOLVE_HANDLE,
                 ['handle' => $handle],
             );
 

--- a/app/Services/Social/ConnectionVerifier.php
+++ b/app/Services/Social/ConnectionVerifier.php
@@ -167,7 +167,7 @@ class ConnectionVerifier
 
         try {
             $response = $client->send(fn () => Http::withToken($account->refresh_token)
-                ->post("{$service}/xrpc/com.atproto.server.refreshSession"));
+                ->post("{$service}/xrpc/".BlueskyLexicon::REFRESH_SESSION));
 
             $data = $response->json();
             $account->update([
@@ -185,7 +185,7 @@ class ConnectionVerifier
 
         if (isset($account->meta['password'])) {
             try {
-                $reauth = $client->send(fn () => Http::post("{$service}/xrpc/com.atproto.server.createSession", [
+                $reauth = $client->send(fn () => Http::post("{$service}/xrpc/".BlueskyLexicon::CREATE_SESSION, [
                     'identifier' => $account->meta['identifier'],
                     'password' => decrypt($account->meta['password']),
                 ]));
@@ -490,7 +490,7 @@ class ConnectionVerifier
         $service = $account->meta['service'] ?? config('trypost.platforms.bluesky.default_service');
 
         $response = Http::withToken($account->access_token)
-            ->get("{$service}/xrpc/app.bsky.actor.getProfile", [
+            ->get("{$service}/xrpc/".BlueskyLexicon::GET_PROFILE, [
                 'actor' => $account->platform_user_id,
             ]);
 

--- a/config/trypost.php
+++ b/config/trypost.php
@@ -145,6 +145,8 @@ return [
             'public_appview' => env('BLUESKY_PUBLIC_APPVIEW', 'https://public.api.bsky.app'),
             // Default PDS used when the account has no `meta.service` override.
             'default_service' => env('BLUESKY_DEFAULT_SERVICE', 'https://bsky.social'),
+            // Web client where published posts are viewed (profile/post URLs).
+            'web_app' => env('BLUESKY_WEB_APP', 'https://bsky.app'),
         ],
         'mastodon' => [
             'enabled' => env('MASTODON_ENABLED', true),

--- a/tests/Feature/Services/Social/BlueskyPublisherTest.php
+++ b/tests/Feature/Services/Social/BlueskyPublisherTest.php
@@ -285,8 +285,7 @@ test('bluesky publisher resolves a repeated handle only once', function () {
     });
 });
 
-test('bluesky publisher uploads images', function () {
-    // Create a media item through the PostPlatform's media() relation
+test('bluesky publisher attaches an uploaded image as an embed', function () {
     $this->post->update([
         'media' => [
             [
@@ -299,27 +298,40 @@ test('bluesky publisher uploads images', function () {
         ],
     ]);
 
-    Http::fake([
-        'https://bsky.social/xrpc/com.atproto.repo.uploadBlob' => Http::response([
-            'blob' => [
-                '$type' => 'blob',
-                'ref' => ['$link' => 'bafkreiabc123'],
-                'mimeType' => 'image/jpeg',
-                'size' => 12345,
-            ],
-        ], 200),
-        'https://bsky.social/xrpc/com.atproto.repo.createRecord' => Http::response([
-            'uri' => 'at://did:plc:testuser123/app.bsky.feed.post/3abc123xyz',
-            'cid' => 'bafyreiabc123',
-        ], 200),
-    ]);
+    $this->mock(MediaOptimizer::class)
+        ->shouldReceive('optimizeImage')
+        ->andReturnUsing(fn () => tap(tempnam(sys_get_temp_dir(), 'bsky_test_'), fn ($f) => file_put_contents($f, str_repeat('x', 1024))));
 
-    // We need to mock file_get_contents since we don't have actual media files
-    // For now, let's skip the upload part and test the post creation
+    Http::fake(function ($request) {
+        if (str_contains($request->url(), 'uploadBlob')) {
+            return Http::response([
+                'blob' => ['$type' => 'blob', 'ref' => ['$link' => 'bafkreiabc123'], 'mimeType' => 'image/jpeg', 'size' => 1024],
+            ], 200);
+        }
+
+        if (str_contains($request->url(), 'createRecord')) {
+            return Http::response([
+                'uri' => 'at://did:plc:testuser123/app.bsky.feed.post/3abc123xyz',
+                'cid' => 'bafyreiabc123',
+            ], 200);
+        }
+
+        return Http::response(str_repeat('x', 1024), 200); // media download
+    });
+
     $this->publisher->publish($this->postPlatform);
 
     Http::assertSent(function ($request) {
-        return str_contains($request->url(), 'createRecord');
+        if (! str_contains($request->url(), 'createRecord')) {
+            return false;
+        }
+
+        $embed = $request['record']['embed'] ?? null;
+
+        return $embed
+            && $embed['$type'] === 'app.bsky.embed.images'
+            && count($embed['images']) === 1
+            && data_get($embed, 'images.0.image.ref.$link') === 'bafkreiabc123';
     });
 });
 
@@ -482,26 +494,35 @@ test('bluesky publisher limits images to 4', function () {
     }
     $this->post->update(['media' => $mediaItems]);
 
-    Http::fake([
-        'https://bsky.social/xrpc/com.atproto.repo.uploadBlob' => Http::response([
-            'blob' => [
-                '$type' => 'blob',
-                'ref' => ['$link' => 'bafkreiabc123'],
-                'mimeType' => 'image/jpeg',
-                'size' => 12345,
-            ],
-        ], 200),
-        'https://bsky.social/xrpc/com.atproto.repo.createRecord' => Http::response([
-            'uri' => 'at://did:plc:testuser123/app.bsky.feed.post/3abc123xyz',
-            'cid' => 'bafyreiabc123',
-        ], 200),
-    ]);
+    $this->mock(MediaOptimizer::class)
+        ->shouldReceive('optimizeImage')
+        ->andReturnUsing(fn () => tap(tempnam(sys_get_temp_dir(), 'bsky_test_'), fn ($f) => file_put_contents($f, str_repeat('x', 1024))));
+
+    Http::fake(function ($request) {
+        if (str_contains($request->url(), 'uploadBlob')) {
+            return Http::response([
+                'blob' => ['$type' => 'blob', 'ref' => ['$link' => 'bafkreiabc123'], 'mimeType' => 'image/jpeg', 'size' => 1024],
+            ], 200);
+        }
+
+        if (str_contains($request->url(), 'createRecord')) {
+            return Http::response([
+                'uri' => 'at://did:plc:testuser123/app.bsky.feed.post/3abc123xyz',
+                'cid' => 'bafyreiabc123',
+            ], 200);
+        }
+
+        return Http::response(str_repeat('x', 1024), 200); // media download
+    });
 
     $this->publisher->publish($this->postPlatform);
 
-    // Bluesky only allows 4 images, so uploadBlob should be called at most 4 times
-    // (In practice it depends on file_get_contents succeeding, but the logic is there)
+    // Six images provided, but Bluesky caps at 4: only 4 blobs upload and the embed carries 4.
+    $uploads = Http::recorded(fn ($request) => str_contains($request->url(), 'uploadBlob'))->count();
+    expect($uploads)->toBe(4);
+
     Http::assertSent(function ($request) {
-        return str_contains($request->url(), 'createRecord');
+        return str_contains($request->url(), 'createRecord')
+            && count($request['record']['embed']['images'] ?? []) === 4;
     });
 });

--- a/tests/Feature/Services/Social/BlueskyPublisherTest.php
+++ b/tests/Feature/Services/Social/BlueskyPublisherTest.php
@@ -101,6 +101,52 @@ test('bluesky publisher parses hashtags as facets', function () {
     });
 });
 
+test('bluesky publisher strips trailing punctuation from URL facets', function () {
+    $this->post->update(['content' => 'see https://example.com).']);
+
+    Http::fake([
+        config('trypost.platforms.bluesky.default_service').'/xrpc/com.atproto.repo.createRecord' => Http::response([
+            'uri' => 'at://did:plc:testuser123/app.bsky.feed.post/3abc123xyz',
+            'cid' => 'bafyreiabc123',
+        ], 200),
+    ]);
+
+    $this->publisher->publish($this->postPlatform);
+
+    Http::assertSent(function ($request) {
+        $link = collect($request['record']['facets'] ?? [])
+            ->first(fn ($facet) => $facet['features'][0]['$type'] === 'app.bsky.richtext.facet#link');
+
+        return $link
+            && $link['features'][0]['uri'] === 'https://example.com'
+            && $link['index']['byteEnd'] === $link['index']['byteStart'] + strlen('https://example.com');
+    });
+});
+
+test('bluesky publisher computes byte offsets after multibyte characters', function () {
+    $this->post->update(['content' => 'Olá 🎉 #café']);
+
+    Http::fake([
+        config('trypost.platforms.bluesky.default_service').'/xrpc/com.atproto.repo.createRecord' => Http::response([
+            'uri' => 'at://did:plc:testuser123/app.bsky.feed.post/3abc123xyz',
+            'cid' => 'bafyreiabc123',
+        ], 200),
+    ]);
+
+    $this->publisher->publish($this->postPlatform);
+
+    Http::assertSent(function ($request) {
+        $text = $request['record']['text'];
+        $tag = collect($request['record']['facets'] ?? [])
+            ->first(fn ($facet) => $facet['features'][0]['$type'] === 'app.bsky.richtext.facet#tag');
+
+        // byteStart must be the UTF-8 byte position of '#café', not its character index.
+        return $tag
+            && $tag['index']['byteStart'] === strpos($text, '#café')
+            && $tag['index']['byteEnd'] === strpos($text, '#café') + strlen('#café');
+    });
+});
+
 test('bluesky publisher resolves mentions to DIDs as facets', function () {
     $this->post->update(['content' => 'Shout out to @friend.bsky.social']);
 

--- a/tests/Feature/Services/Social/BlueskyPublisherTest.php
+++ b/tests/Feature/Services/Social/BlueskyPublisherTest.php
@@ -12,6 +12,7 @@ use App\Models\User;
 use App\Models\Workspace;
 use App\Services\Media\MediaOptimizer;
 use App\Services\Social\BlueskyPublisher;
+use Illuminate\Http\Client\ConnectionException;
 use Illuminate\Support\Facades\Http;
 
 beforeEach(function () {
@@ -234,6 +235,52 @@ test('bluesky publisher skips mention facet when handle cannot be resolved', fun
 
         return str_contains($record['text'], '@ghost.bsky.social') && ! $hasMentionFacet;
     });
+});
+
+test('bluesky publisher publishes as plain text when handle resolution errors', function () {
+    $this->post->update(['content' => 'hi @friend.bsky.social']);
+
+    Http::fake(function ($request) {
+        if (str_contains($request->url(), 'resolveHandle')) {
+            throw new ConnectionException('connection refused');
+        }
+
+        return Http::response([
+            'uri' => 'at://did:plc:testuser123/app.bsky.feed.post/3abc123xyz',
+            'cid' => 'bafyreiabc123',
+        ], 200);
+    });
+
+    // A network error resolving the handle must degrade to plain text, not fail the post.
+    $result = $this->publisher->publish($this->postPlatform);
+
+    expect($result['id'])->toBe('3abc123xyz');
+
+    Http::assertSent(function ($request) {
+        if (! str_contains($request->url(), 'createRecord')) {
+            return false;
+        }
+
+        $hasMention = collect($request['record']['facets'] ?? [])
+            ->contains(fn ($facet) => $facet['features'][0]['$type'] === 'app.bsky.richtext.facet#mention');
+
+        return str_contains($request['record']['text'], '@friend.bsky.social') && ! $hasMention;
+    });
+});
+
+test('bluesky publisher builds the post url from the configured web app host', function () {
+    config(['trypost.platforms.bluesky.web_app' => 'https://custom.bsky.example']);
+
+    Http::fake([
+        config('trypost.platforms.bluesky.default_service').'/xrpc/com.atproto.repo.createRecord' => Http::response([
+            'uri' => 'at://did:plc:testuser123/app.bsky.feed.post/3abc123xyz',
+            'cid' => 'bafyreiabc123',
+        ], 200),
+    ]);
+
+    $result = $this->publisher->publish($this->postPlatform);
+
+    expect($result['url'])->toBe('https://custom.bsky.example/profile/testuser.bsky.social/post/3abc123xyz');
 });
 
 test('bluesky publisher resolves some mentions and skips the unresolvable ones', function () {

--- a/tests/Feature/Services/Social/BlueskyPublisherTest.php
+++ b/tests/Feature/Services/Social/BlueskyPublisherTest.php
@@ -123,6 +123,27 @@ test('bluesky publisher strips trailing punctuation from URL facets', function (
     });
 });
 
+test('bluesky publisher keeps a closing paren that has a matching open paren', function () {
+    $this->post->update(['content' => 'see https://en.wikipedia.org/wiki/Foo_(bar)']);
+
+    Http::fake([
+        config('trypost.platforms.bluesky.default_service').'/xrpc/com.atproto.repo.createRecord' => Http::response([
+            'uri' => 'at://did:plc:testuser123/app.bsky.feed.post/3abc123xyz',
+            'cid' => 'bafyreiabc123',
+        ], 200),
+    ]);
+
+    $this->publisher->publish($this->postPlatform);
+
+    Http::assertSent(function ($request) {
+        $link = collect($request['record']['facets'] ?? [])
+            ->first(fn ($facet) => $facet['features'][0]['$type'] === 'app.bsky.richtext.facet#link');
+
+        // The trailing ')' is part of the URL because it has a matching '('.
+        return $link && $link['features'][0]['uri'] === 'https://en.wikipedia.org/wiki/Foo_(bar)';
+    });
+});
+
 test('bluesky publisher computes byte offsets after multibyte characters', function () {
     $this->post->update(['content' => 'Olá 🎉 #café']);
 

--- a/tests/Unit/Services/Social/BlueskyLexiconTest.php
+++ b/tests/Unit/Services/Social/BlueskyLexiconTest.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Services\Social\BlueskyLexicon;
+
+test('bluesky lexicon constants match their AT Protocol NSIDs', function (string $constant, string $nsid) {
+    expect($constant)->toBe($nsid);
+})->with([
+    [BlueskyLexicon::RESOLVE_HANDLE, 'com.atproto.identity.resolveHandle'],
+    [BlueskyLexicon::CREATE_RECORD, 'com.atproto.repo.createRecord'],
+    [BlueskyLexicon::UPLOAD_BLOB, 'com.atproto.repo.uploadBlob'],
+    [BlueskyLexicon::CREATE_SESSION, 'com.atproto.server.createSession'],
+    [BlueskyLexicon::REFRESH_SESSION, 'com.atproto.server.refreshSession'],
+    [BlueskyLexicon::FEED_POST, 'app.bsky.feed.post'],
+    [BlueskyLexicon::GET_POSTS, 'app.bsky.feed.getPosts'],
+    [BlueskyLexicon::GET_PROFILE, 'app.bsky.actor.getProfile'],
+    [BlueskyLexicon::EMBED_IMAGES, 'app.bsky.embed.images'],
+    [BlueskyLexicon::FACET_LINK, 'app.bsky.richtext.facet#link'],
+    [BlueskyLexicon::FACET_MENTION, 'app.bsky.richtext.facet#mention'],
+    [BlueskyLexicon::FACET_TAG, 'app.bsky.richtext.facet#tag'],
+]);


### PR DESCRIPTION
Follow-up to #93. Hardens `BlueskyPublisher` (and the sibling Bluesky services) — one real bug, convention cleanup, a shared NSID lexicon, and stronger tests.

## Bug fix
- **Link facets swallowed trailing punctuation.** The URL regex captured trailing sentence punctuation and an unmatched closing paren (`see https://x.com).`) into the link facet, so Bluesky rendered a malformed/over-long link. Now trimmed like the official atproto tokenizer.

## Conventions / cleanup
- Import `Exception` instead of inline `\Exception`.
- Read the upload blob via `data_get` instead of direct array access.
- Source the web-app host from a new `config('trypost.platforms.bluesky.web_app')` key instead of hardcoding `bsky.app`.
- Remove the `getUtf8ByteOffset` no-op — `PREG_OFFSET_CAPTURE` with `/u` already returns byte offsets, so call sites use them directly.

## BlueskyLexicon
- Centralize the AT Protocol lexicon identifiers (NSIDs: `createRecord`, `createSession`, `feed.post`, facet types, etc.) into `App\Services\Social\BlueskyLexicon`. They were repeated as magic strings across `BlueskyPublisher`, `BlueskyAnalytics`, `ConnectionVerifier` and `BlueskyController`, where a typo fails silently at runtime as "Invalid request" (the same class of bug #93 fixed). A typo is now an undefined-constant error. Tests keep the literal NSIDs as the independent contract.

## Tests
- Add coverage for the URL trailing-punctuation trim and for byte-offset correctness after multibyte characters (emoji/accents).
- Strengthen the image tests to actually assert an `app.bsky.embed.images` embed is attached and that six images upload exactly four (they previously only checked `createRecord` was sent).

Full suite green (1970 passed, 2 skipped).

## Out of scope
- Image `alt` text — the `Media` model has no alt field; needs a migration + UI (separate feature).