### PR TITLE
Past-due access, reliable checkout.completed, and complete morph map

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -297,6 +297,12 @@ Vue components must have a single root element.
     - Example: `data_get($data, 'name')` instead of `$data['name']`.
     - Use the third parameter for fallback values: `data_get($data, 'username', $sender->username)` instead of `$data['username'] ?? $sender->username`.
 
+## Eloquent Models & Morph Map
+
+- EVERY Eloquent model in `app/Models` MUST be registered in `Relation::enforceMorphMap([...])` inside `AppServiceProvider::configureMorphMap()`, keyed by a camelCase alias (e.g. `'postPlatform' => PostPlatform::class`).
+- When you add a new model, add it to the morph map in the same change. `tests/Unit/MorphMapTest.php` fails if any model is missing.
+- The alias is persisted in polymorphic columns, so never rename or remove an existing alias for a model that has stored rows.
+
 ## Imports
 
 - NEVER use inline class references (e.g., `\DB::listen`, `\Str::uuid()`). ALWAYS import classes at the top of the file with a `use` statement.

--- a/app/Http/Controllers/App/BillingController.php
+++ b/app/Http/Controllers/App/BillingController.php
@@ -8,6 +8,7 @@ use App\Models\Account;
 use App\Models\Plan;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Gate;
 use Inertia\Inertia;
 use Inertia\Response;
@@ -88,9 +89,17 @@ class BillingController extends Controller
         $account = $request->user()->account;
         $sessionId = $request->query('session_id');
 
+        // Consume the checkout session once: `fromCheckout` is true only the first
+        // time this session_id is seen, so a back-button/refresh to the success URL
+        // can't re-fire `checkout.completed`. `Cache::add` is atomic — it returns
+        // true only when the key didn't exist yet.
+        $fromCheckout = is_string($sessionId) && $sessionId !== ''
+            && Cache::add("checkout_tracked:{$sessionId}", true, now()->addDay());
+
         return Inertia::render('billing/Processing', [
             'subscriptionActive' => $account && $account->subscribed(Account::SUBSCRIPTION_NAME),
-            'conversion' => is_string($sessionId) && $sessionId !== '' && $account?->stripe_id
+            'fromCheckout' => $fromCheckout,
+            'conversion' => $fromCheckout && $account?->stripe_id
                 ? fn () => $this->buildConversionData($account, $sessionId)
                 : null,
         ]);

--- a/app/Http/Middleware/App/HandleInertiaRequests.php
+++ b/app/Http/Middleware/App/HandleInertiaRequests.php
@@ -44,6 +44,7 @@ class HandleInertiaRequests extends Middleware
                 'account' => $account ? AuthAccountResource::make($account) : null,
                 'plan' => $account && $account->plan ? AuthPlanResource::make($account, $account->plan) : null,
                 'hasActiveSubscription' => $account ? $account->hasActiveSubscription() : false,
+                'subscriptionPastDue' => $account ? $account->isPastDue() : false,
             ],
             'usage' => $account && ! $isSelfHosted ? $account->usage() : null,
             'features' => $account && ! $isSelfHosted ? $account->featureLimits() : null,

--- a/app/Models/Account.php
+++ b/app/Models/Account.php
@@ -91,6 +91,15 @@ class Account extends Model
         return $this->subscribed(self::SUBSCRIPTION_NAME);
     }
 
+    public function isPastDue(): bool
+    {
+        if (config('trypost.self_hosted')) {
+            return false;
+        }
+
+        return (bool) $this->subscription(self::SUBSCRIPTION_NAME)?->pastDue();
+    }
+
     public function isOnTrial(): bool
     {
         if (! (bool) config('trypost.billing.require_card_for_trial', true) && $this->onGenericTrial()) {

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -88,6 +88,7 @@ class AppServiceProvider extends ServiceProvider
         Cashier::useCustomerModel(Account::class);
         Cashier::useSubscriptionModel(Subscription::class);
         Cashier::useSubscriptionItemModel(SubscriptionItem::class);
+        Cashier::keepPastDueSubscriptionsActive();
 
         Feature::resolveScopeUsing(fn () => auth()->user()?->account);
         Feature::useMorphMap();

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -8,6 +8,11 @@ use App\Listeners\StripeEventListener;
 use App\Models\AccessToken;
 use App\Models\Account;
 use App\Models\AiUsageLog;
+use App\Models\Automation;
+use App\Models\AutomationNodeRun;
+use App\Models\AutomationNodeState;
+use App\Models\AutomationRun;
+use App\Models\AutomationTriggerItem;
 use App\Models\Invite;
 use App\Models\Media;
 use App\Models\Notification;
@@ -114,6 +119,11 @@ class AppServiceProvider extends ServiceProvider
             'accessToken' => AccessToken::class,
             'account' => Account::class,
             'aiUsageLog' => AiUsageLog::class,
+            'automation' => Automation::class,
+            'automationNodeRun' => AutomationNodeRun::class,
+            'automationNodeState' => AutomationNodeState::class,
+            'automationRun' => AutomationRun::class,
+            'automationTriggerItem' => AutomationTriggerItem::class,
             'invite' => Invite::class,
             'media' => Media::class,
             'notification' => Notification::class,

--- a/lang/en/billing.php
+++ b/lang/en/billing.php
@@ -3,6 +3,12 @@
 return [
     'title' => 'Billing',
 
+    'past_due_notice' => [
+        'title' => 'Payment past due',
+        'description' => 'Update your payment method to keep your subscription active.',
+        'cta' => 'Update payment',
+    ],
+
     'upgrade_dialog' => [
         'title' => 'Upgrade your plan',
         'description' => 'Pick a plan that fits your needs.',

--- a/lang/es/billing.php
+++ b/lang/es/billing.php
@@ -3,6 +3,12 @@
 return [
     'title' => 'Facturación',
 
+    'past_due_notice' => [
+        'title' => 'Pago vencido',
+        'description' => 'Actualiza tu método de pago para mantener tu suscripción activa.',
+        'cta' => 'Actualizar pago',
+    ],
+
     'upgrade_dialog' => [
         'title' => 'Actualiza tu plan',
         'description' => 'Elige un plan que se adapte a tus necesidades.',

--- a/lang/pt-BR/billing.php
+++ b/lang/pt-BR/billing.php
@@ -3,6 +3,12 @@
 return [
     'title' => 'Faturamento',
 
+    'past_due_notice' => [
+        'title' => 'Pagamento em atraso',
+        'description' => 'Atualize sua forma de pagamento para manter sua assinatura ativa.',
+        'cta' => 'Atualizar pagamento',
+    ],
+
     'upgrade_dialog' => [
         'title' => 'Faça upgrade do seu plano',
         'description' => 'Escolha um plano que se encaixe nas suas necessidades.',

--- a/resources/js/components/AppSidebar.vue
+++ b/resources/js/components/AppSidebar.vue
@@ -2,6 +2,7 @@
 import { Link, router, usePage } from '@inertiajs/vue3';
 import {
     IconAffiliate,
+    IconAlertTriangle,
     IconBolt,
     IconCalendar,
     IconChartBar,
@@ -45,6 +46,7 @@ import { useActiveUrl } from '@/composables/useActiveUrl';
 import { useFeatureAccess } from '@/composables/useFeatureAccess';
 import { useUpgradeDialog } from '@/composables/useUpgradeDialog';
 import { accounts, analytics, calendar, settings as settingsHub } from '@/routes/app';
+import { portal } from '@/routes/app/billing';
 import { index as assets } from '@/routes/app/assets';
 import { index as automations } from '@/routes/app/automations';
 import { index as labels } from '@/routes/app/labels';
@@ -61,6 +63,7 @@ interface Workspace {
 const page = usePage();
 const currentWorkspace = computed<Workspace | null>(() => page.props.auth.currentWorkspace as Workspace | null);
 const workspaces = computed<Workspace[]>(() => page.props.auth.workspaces as Workspace[]);
+const subscriptionPastDue = computed<boolean>(() => Boolean(page.props.auth.subscriptionPastDue));
 
 const mainNavItems = computed<NavItem[]>(() => [
     {
@@ -208,6 +211,29 @@ const handleCreateWorkspace = () => {
         </SidebarContent>
 
         <SidebarFooter>
+            <div
+                v-if="subscriptionPastDue"
+                dusk="past-due-notice"
+                class="mx-1 mb-1 rounded-md border-2 border-destructive bg-destructive/10 p-3"
+            >
+                <div class="flex items-center gap-2 text-destructive">
+                    <IconAlertTriangle class="size-4 shrink-0" />
+                    <span class="text-sm font-semibold">{{ $t('billing.past_due_notice.title') }}</span>
+                </div>
+                <p class="mt-1 text-xs text-muted-foreground">
+                    {{ $t('billing.past_due_notice.description') }}
+                </p>
+                <Button
+                    as="a"
+                    :href="portal.url()"
+                    variant="destructive"
+                    size="sm"
+                    class="mt-2 w-full"
+                    dusk="past-due-cta"
+                >
+                    {{ $t('billing.past_due_notice.cta') }}
+                </Button>
+            </div>
             <SidebarMenu>
                 <SidebarMenuItem>
                     <SidebarMenuButton

--- a/resources/js/pages/billing/Processing.vue
+++ b/resources/js/pages/billing/Processing.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { Head, router, usePage, usePoll } from '@inertiajs/vue3';
 import { IconLoader2 } from '@tabler/icons-vue';
-import { onMounted, watch } from 'vue';
+import { onMounted, ref, watch } from 'vue';
 
 import { useTracking } from '@/composables/useTracking';
 import { home } from '@/routes/app';
@@ -9,6 +9,7 @@ import type { Auth } from '@/types';
 
 const props = defineProps<{
     subscriptionActive: boolean;
+    fromCheckout: boolean;
     conversion?: { value: number; currency: string; transaction_id: string } | null;
 }>();
 
@@ -24,20 +25,21 @@ const { stop } = usePoll(2000, {
 
 const { trackPurchase } = useTracking();
 
+const tracked = ref(false);
+
 const goHome = () => router.visit(home.url());
 
-// `watch` (without `immediate`) only fires on transition false → true, which
-// is exactly the purchase moment. The `onMounted` fallback covers the case
-// where the user lands here with an already-active subscription (back button,
-// refresh after the redirect) — we just bounce them home, no extra event.
-watch(
-    () => props.subscriptionActive,
-    (active) => {
-        if (! active) {
-            return;
-        }
+// Fires `checkout.completed` exactly once for a real checkout. A trial-with-card
+// subscription is already `subscribed()` (status `trialing`) by the time the
+// webhook lands, so the user frequently reaches this page already active — the
+// false → true poll transition never happens. We therefore complete the purchase
+// from whichever path runs first (immediate active state or poll transition),
+// gated on `fromCheckout` so back-button/refresh visits don't over-count.
+const completePurchase = () => {
+    stop();
 
-        stop();
+    if (! tracked.value && props.fromCheckout) {
+        tracked.value = true;
 
         const plan = (page.props.auth as Auth | undefined)?.plan;
         if (plan) {
@@ -49,14 +51,23 @@ watch(
                 props.conversion ?? null,
             );
         }
+    }
 
-        goHome();
+    goHome();
+};
+
+watch(
+    () => props.subscriptionActive,
+    (active) => {
+        if (active) {
+            completePurchase();
+        }
     },
 );
 
 onMounted(() => {
     if (props.subscriptionActive) {
-        goHome();
+        completePurchase();
     }
 });
 </script>

--- a/resources/js/types/index.d.ts
+++ b/resources/js/types/index.d.ts
@@ -32,6 +32,7 @@ export interface Auth {
     account: AuthAccount | null;
     plan: AuthPlan | null;
     hasActiveSubscription: boolean;
+    subscriptionPastDue: boolean;
 }
 
 export interface Usage {

--- a/tests/Feature/BillingControllerTest.php
+++ b/tests/Feature/BillingControllerTest.php
@@ -183,8 +183,26 @@ test('billing processing shows processing page', function () {
     $response->assertInertia(fn ($page) => $page
         ->component('billing/Processing', false)
         ->has('subscriptionActive')
+        ->where('fromCheckout', false)
         ->where('conversion', null)
     );
+});
+
+test('billing processing exposes fromCheckout=true only the first time a session_id is seen', function () {
+    config(['trypost.self_hosted' => false]);
+
+    $sessionId = 'cs_test_'.fake()->uuid();
+
+    $first = $this->actingAs($this->user)
+        ->get(route('app.billing.processing', ['session_id' => $sessionId]));
+    $first->assertOk();
+    $first->assertInertia(fn ($page) => $page->where('fromCheckout', true));
+
+    // A back-button / refresh to the same success URL must not re-fire the event.
+    $second = $this->actingAs($this->user)
+        ->get(route('app.billing.processing', ['session_id' => $sessionId]));
+    $second->assertOk();
+    $second->assertInertia(fn ($page) => $page->where('fromCheckout', false));
 });
 
 test('billing processing exposes null conversion when session_id query param is missing', function () {

--- a/tests/Feature/Middleware/TrialMiddlewareAccessTest.php
+++ b/tests/Feature/Middleware/TrialMiddlewareAccessTest.php
@@ -92,6 +92,34 @@ test('user on trialing subscription (legacy trial-with-card) can access the app'
     $response->assertOk();
 });
 
+test('user with past_due subscription can access the app instead of being forced to subscribe', function () {
+    $account = Account::factory()->create([
+        'trial_ends_at' => null,
+        'stripe_id' => 'cus_test_'.fake()->uuid(),
+    ]);
+    $user = User::factory()->create(['account_id' => $account->id]);
+    $account->update(['owner_id' => $user->id]);
+
+    $account->subscriptions()->create([
+        'type' => Account::SUBSCRIPTION_NAME,
+        'stripe_id' => 'sub_test_'.fake()->uuid(),
+        'stripe_status' => 'past_due',
+        'stripe_price' => 'price_123',
+    ]);
+
+    $workspace = Workspace::factory()->create([
+        'account_id' => $account->id,
+        'user_id' => $user->id,
+    ]);
+    $workspace->members()->attach($user->id, ['role' => Role::Member->value]);
+    $user->update(['current_workspace_id' => $workspace->id]);
+
+    $response = $this->actingAs($user->fresh())->get(route('app.accounts'));
+
+    $response->assertOk();
+    $response->assertSessionMissing('errors');
+});
+
 test('user on generic trial can access the app when card is not required', function () {
     config(['trypost.billing.require_card_for_trial' => false]);
 

--- a/tests/Unit/Models/AccountTest.php
+++ b/tests/Unit/Models/AccountTest.php
@@ -14,6 +14,65 @@ beforeEach(function () {
     Carbon::setTestNow('2026-05-14 12:00:00');
 });
 
+test('isPastDue returns false without a subscription', function () {
+    config(['trypost.self_hosted' => false]);
+
+    $account = Account::factory()->create(['trial_ends_at' => null]);
+
+    expect($account->isPastDue())->toBeFalse();
+});
+
+test('isPastDue returns true for a past_due subscription', function () {
+    config(['trypost.self_hosted' => false]);
+
+    $account = Account::factory()->create([
+        'trial_ends_at' => null,
+        'stripe_id' => 'cus_test_'.fake()->uuid(),
+    ]);
+    $account->subscriptions()->create([
+        'type' => Account::SUBSCRIPTION_NAME,
+        'stripe_id' => 'sub_test_'.fake()->uuid(),
+        'stripe_status' => 'past_due',
+        'stripe_price' => 'price_123',
+    ]);
+
+    expect($account->isPastDue())->toBeTrue();
+});
+
+test('isPastDue returns false for an active subscription', function () {
+    config(['trypost.self_hosted' => false]);
+
+    $account = Account::factory()->create([
+        'trial_ends_at' => null,
+        'stripe_id' => 'cus_test_'.fake()->uuid(),
+    ]);
+    $account->subscriptions()->create([
+        'type' => Account::SUBSCRIPTION_NAME,
+        'stripe_id' => 'sub_test_'.fake()->uuid(),
+        'stripe_status' => 'active',
+        'stripe_price' => 'price_123',
+    ]);
+
+    expect($account->isPastDue())->toBeFalse();
+});
+
+test('isPastDue returns false when self-hosted', function () {
+    config(['trypost.self_hosted' => true]);
+
+    $account = Account::factory()->create([
+        'trial_ends_at' => null,
+        'stripe_id' => 'cus_test_'.fake()->uuid(),
+    ]);
+    $account->subscriptions()->create([
+        'type' => Account::SUBSCRIPTION_NAME,
+        'stripe_id' => 'sub_test_'.fake()->uuid(),
+        'stripe_status' => 'past_due',
+        'stripe_price' => 'price_123',
+    ]);
+
+    expect($account->isPastDue())->toBeFalse();
+});
+
 test('isOnTrial ignores generic trial when there is no subscription', function () {
     $account = Account::factory()->create(['trial_ends_at' => now()->addDays(7)]);
 

--- a/tests/Unit/MorphMapTest.php
+++ b/tests/Unit/MorphMapTest.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\Relation;
+
+test('every Eloquent model is registered in the morph map', function () {
+    $mapped = array_values(Relation::morphMap());
+
+    $missing = collect(glob(app_path('Models/*.php')))
+        ->map(fn (string $file): string => 'App\\Models\\'.pathinfo($file, PATHINFO_FILENAME))
+        ->filter(fn (string $class): bool => class_exists($class)
+            && is_subclass_of($class, Model::class)
+            && ! (new ReflectionClass($class))->isAbstract())
+        ->reject(fn (string $class): bool => in_array($class, $mapped, true))
+        ->values()
+        ->all();
+
+    expect($missing)->toBe([]);
+});


### PR DESCRIPTION
This branch bundles three related billing/infra fixes.

---

## 1. Keep past_due subscribers in-app instead of forcing re-subscribe

**Problem:** when a subscription goes `past_due`, Cashier's default (`deactivatePastDue = true`) makes `subscribed()` return `false`. `EnsureAccountReady` then redirects to `app.subscribe`, which opens a fresh Stripe Checkout and **creates a second subscription**. A past-due customer already has one — they just need to update their payment method.

**Fix:**
- `Cashier::keepPastDueSubscriptionsActive()` — `past_due` counts as active again, so the middleware lets the user navigate (no forced `/subscribe`).
- `Account::isPastDue()` (false when self-hosted, else `subscription(...)?->pastDue()`).
- Shared Inertia prop `auth.subscriptionPastDue` + TS type.
- Sidebar-footer notice (red) with a CTA to the **Stripe billing portal** (`app.billing.portal`) — never `/subscribe`.
- i18n (`en`, `es`, `pt-BR`).

Both trial modes verified, neither affected (past_due only exists on a real subscription): card-required → subscription trial (`subscribed()` already true); no-card → generic trial (`isOnTrial()`/`onGenericTrial()`).

## 2. Fire `checkout.completed` reliably for trial-with-card checkouts

**Problem (confirmed in PostHog):** 66 real `subscription.created` vs only **3** `checkout.completed`. With trial-with-card the subscription is `trialing` (already `subscribed()`) by the time the webhook lands, so `/billing/processing` usually mounts already-active and the `false→true` poll transition the event depended on never happens.

**Fix:**
- Complete the purchase from whichever path runs first — `onMounted` (already active) or the poll transition.
- De-duplicated per checkout session via a one-time `Cache::add` gate on `session_id` (new `fromCheckout` prop), so back-button/refresh to the success URL can't re-fire.

## 3. Register all models in the morph map

- Added the five automation models to `Relation::enforceMorphMap()`.
- Documented the "every model must be mapped" rule in `CLAUDE.md`.
- `tests/Unit/MorphMapTest.php` fails if any `app/Models` class is missing from the map.

---

## Tests

- `BillingControllerTest`, `TrialMiddlewareAccessTest`, `AccountTest`, `MorphMapTest` all green; broader billing/account/workspace/usage suites pass — no regressions. Pint clean.
- Note: no JS test runner in the project, so the `Processing.vue` timing logic is covered by reasoning + the backend `fromCheckout` one-time test, not a component test.