### PR TITLE
feat(discord): global floating Discord widget

### DIFF
--- a/lang/en/common.php
+++ b/lang/en/common.php
@@ -3,6 +3,12 @@
 declare(strict_types=1);
 
 return [
+
+    'discord' => [
+        'label' => 'Discord',
+        'join' => 'Join our Discord community',
+    ],
+
     'back' => 'Back',
 
     'confirm_modal' => [

--- a/lang/es/common.php
+++ b/lang/es/common.php
@@ -3,6 +3,12 @@
 declare(strict_types=1);
 
 return [
+
+    'discord' => [
+        'label' => 'Discord',
+        'join' => 'Unite a nuestra comunidad en Discord',
+    ],
+
     'back' => 'Volver',
 
     'confirm_modal' => [

--- a/lang/pt-BR/common.php
+++ b/lang/pt-BR/common.php
@@ -3,6 +3,12 @@
 declare(strict_types=1);
 
 return [
+
+    'discord' => [
+        'label' => 'Discord',
+        'join' => 'Entre na nossa comunidade no Discord',
+    ],
+
     'back' => 'Voltar',
 
     'confirm_modal' => [

--- a/resources/js/components/DiscordWidget.vue
+++ b/resources/js/components/DiscordWidget.vue
@@ -1,0 +1,27 @@
+<script setup lang="ts">
+import { IconBrandDiscord } from '@tabler/icons-vue';
+
+import { captureEvent } from '@/posthog';
+
+const DISCORD_URL = 'https://trypost.it/discord';
+
+// Distinct from the marketing site's site_discord_clicked, following the
+// app's noun.verb event convention.
+const trackClick = () => {
+    captureEvent('discord.clicked', { placement: 'floating_widget' });
+};
+</script>
+
+<template>
+    <a
+        :href="DISCORD_URL"
+        target="_blank"
+        rel="noopener noreferrer"
+        :aria-label="$t('common.discord.join')"
+        class="group fixed bottom-5 right-5 z-50 inline-flex items-center gap-2 rounded-full border-2 border-foreground bg-[#5865F2] py-2.5 pl-3 pr-4 text-sm font-bold text-white shadow-md transition-all hover:-translate-y-0.5 hover:shadow-lg"
+        @click="trackClick"
+    >
+        <IconBrandDiscord class="size-5 shrink-0" stroke-width="2" />
+        <span>{{ $t('common.discord.label') }}</span>
+    </a>
+</template>

--- a/resources/js/layouts/app/AppSidebarLayout.vue
+++ b/resources/js/layouts/app/AppSidebarLayout.vue
@@ -4,6 +4,7 @@ import { onBeforeUnmount, onMounted } from 'vue';
 
 import AppHeader from '@/components/AppHeader.vue';
 import AppSidebar from '@/components/AppSidebar.vue';
+import DiscordWidget from '@/components/DiscordWidget.vue';
 import Toast from '@/components/Toast.vue';
 import { SidebarInset, SidebarProvider, SidebarTrigger } from '@/components/ui/sidebar';
 import UpgradeDialog from '@/components/UpgradeDialog.vue';
@@ -76,4 +77,5 @@ onBeforeUnmount(() => {
     </SidebarProvider>
     <UpgradeDialog />
     <Toast />
+    <DiscordWidget />
 </template>


### PR DESCRIPTION
## Summary

Adds a global floating **Join our Discord** button (bottom-right, chat-widget style), mirroring the one on the marketing site, so users can jump into the community from anywhere in the app.

### Changes
- New `resources/js/components/DiscordWidget.vue` — indies-club pill (ink border, solid offset shadow, hover lift), Discord blurple, `IconBrandDiscord` + label, links to `https://trypost.it/discord` in a new tab.
- Mounted globally in `resources/js/layouts/app/AppSidebarLayout.vue` (alongside `UpgradeDialog` and `Toast`), so it shows on all authenticated app screens.
- i18n `common.discord.label` / `common.discord.join` in `lang/en`, `lang/es`, `lang/pt-BR`.

### Tracking
- Captures `discord.clicked` with `{ placement: 'floating_widget' }` via `captureEvent` (app's `noun.verb` convention). Distinct from the site's `site_discord_clicked`, so site vs. app clicks can be separated in PostHog. Enables a `$pageview → discord.clicked` funnel.

### Notes
- Mounted on the authenticated layout only. Happy to also add it to the guest/login layout if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)