### PR TITLE
Full per-platform meta parity for posts (API + MCP)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -277,6 +277,14 @@ Vue components must have a single root element.
 - Validation rules always live in a dedicated `Illuminate\Foundation\Http\FormRequest` subclass under `app/Http/Requests/App/<Group>/`. Controller actions must type-hint the FormRequest as the parameter — NEVER call `$request->validate([...])` inline in the controller.
 - Naming: `<Verb><Resource>Request.php` (e.g. `StorePostRequest`, `ApplyPostTemplateRequest`, `IndexPostTemplateRequest`).
 
+## Per-Platform Post Meta (`PostPlatform.meta`)
+
+- All `platforms.*.meta` validation (the parent array rule AND every per-platform sub-key: `aspect_ratio`, TikTok `privacy_level`/flags, Pinterest `board_id`, Discord `channel_id`/`mentions`/`embeds`, etc.) lives in ONE place: `App\Support\PostPlatformMetaRules`.
+    - Every post create/update entry point — web (`App\Http\Requests\App\Post\UpdatePostRequest`), public API (`App\Http\Requests\Api\Post\{Store,Update}PostRequest`), and MCP (`App\Mcp\Tools\Post\{Create,Update}PostTool`) — spreads `...PostPlatformMetaRules::rules()`. NEVER add a per-platform meta rule inline to a single request/tool.
+    - Why: `FormRequest::validated()` (and MCP `$request->validate()`) STRIPS any key without a rule. A meta field defined in only one entry point is silently dropped everywhere else — which is exactly how Discord/Pinterest/TikTok meta was lost via API/MCP before this was centralized.
+- Required-on-publish (meta a platform needs to publish, e.g. Discord `channel_id`) also lives there: `addRequiredOnPublishErrors()` for request-driven flows (web/API update `withValidator`), `assertStoredPostPublishable()` for flows that publish stored state without resubmitting platforms (MCP `PublishPostTool`). Add new required-meta rules to `requiredMetaViolation()`, not inline.
+- When adding a new platform's meta field, add it (and any publish requirement) to `PostPlatformMetaRules` ONLY, and cover it in `tests/Feature/Api/PostApiPlatformMetaTest.php` + `tests/Feature/Mcp/PostPlatformMetaToolTest.php`.
+
 ## Pest / Feature Tests
 
 - ALWAYS use named routes via the `route()` helper in feature tests. NEVER hardcode URL strings like `'/posts/ai/create'`.

--- a/app/Http/Requests/Api/Post/StorePostRequest.php
+++ b/app/Http/Requests/Api/Post/StorePostRequest.php
@@ -50,7 +50,6 @@ class StorePostRequest extends FormRequest
                 Rule::in(array_column(ContentType::cases(), 'value')),
                 new ContentTypeMatchesPlatform,
             ],
-            'platforms.*.meta' => ['sometimes', 'nullable', 'array'],
             ...PostPlatformMetaRules::rules(),
             'scheduled_at' => ['nullable', 'date', 'after:now'],
             'label_ids' => ['sometimes', 'array'],

--- a/app/Http/Requests/Api/Post/StorePostRequest.php
+++ b/app/Http/Requests/Api/Post/StorePostRequest.php
@@ -4,12 +4,12 @@ declare(strict_types=1);
 
 namespace App\Http\Requests\Api\Post;
 
-use App\Enums\PostPlatform\AspectRatio;
 use App\Enums\PostPlatform\ContentType;
 use App\Enums\SocialAccount\Platform;
 use App\Models\SocialAccount;
 use App\Rules\ContentFitsPlatformLimits;
 use App\Rules\ContentTypeMatchesPlatform;
+use App\Support\PostPlatformMetaRules;
 use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Support\Collection;
 use Illuminate\Validation\Rule;
@@ -51,7 +51,7 @@ class StorePostRequest extends FormRequest
                 new ContentTypeMatchesPlatform,
             ],
             'platforms.*.meta' => ['sometimes', 'nullable', 'array'],
-            'platforms.*.meta.aspect_ratio' => ['sometimes', 'nullable', 'string', Rule::enum(AspectRatio::class)],
+            ...PostPlatformMetaRules::rules(),
             'scheduled_at' => ['nullable', 'date', 'after:now'],
             'label_ids' => ['sometimes', 'array'],
             'label_ids.*' => [

--- a/app/Http/Requests/Api/Post/UpdatePostRequest.php
+++ b/app/Http/Requests/Api/Post/UpdatePostRequest.php
@@ -68,7 +68,7 @@ class UpdatePostRequest extends FormRequest
 
     public function withValidator(Validator $validator): void
     {
-        $validator->after(function ($validator): void {
+        $validator->after(function (Validator $validator): void {
             if (! in_array($this->input('status'), [Status::Scheduled->value, Status::Publishing->value], true)) {
                 return;
             }

--- a/app/Http/Requests/Api/Post/UpdatePostRequest.php
+++ b/app/Http/Requests/Api/Post/UpdatePostRequest.php
@@ -5,16 +5,17 @@ declare(strict_types=1);
 namespace App\Http\Requests\Api\Post;
 
 use App\Enums\Post\Status;
-use App\Enums\PostPlatform\AspectRatio;
 use App\Enums\PostPlatform\ContentType;
 use App\Enums\SocialAccount\Platform;
 use App\Models\Post;
 use App\Models\PostPlatform;
 use App\Rules\ContentFitsPlatformLimits;
 use App\Rules\ContentTypeMatchesPostPlatform;
+use App\Support\PostPlatformMetaRules;
 use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Support\Collection;
 use Illuminate\Validation\Rule;
+use Illuminate\Validation\Validator;
 
 class UpdatePostRequest extends FormRequest
 {
@@ -52,7 +53,7 @@ class UpdatePostRequest extends FormRequest
                 new ContentTypeMatchesPostPlatform,
             ],
             'platforms.*.meta' => ['nullable', 'array'],
-            'platforms.*.meta.aspect_ratio' => ['sometimes', 'nullable', 'string', Rule::enum(AspectRatio::class)],
+            ...PostPlatformMetaRules::rules(),
             'scheduled_at' => [
                 'nullable',
                 'date',
@@ -64,6 +65,23 @@ class UpdatePostRequest extends FormRequest
             'label_ids' => ['sometimes', 'array'],
             'label_ids.*' => ['uuid', Rule::exists('workspace_labels', 'id')->where('workspace_id', $this->user()->currentWorkspace->id)],
         ];
+    }
+
+    public function withValidator(Validator $validator): void
+    {
+        $validator->after(function ($validator): void {
+            if (! in_array($this->input('status'), [Status::Scheduled->value, Status::Publishing->value], true)) {
+                return;
+            }
+
+            $platformsById = $this->resolveSelectedPlatforms();
+
+            PostPlatformMetaRules::addRequiredOnPublishErrors(
+                $validator,
+                $this->input('platforms', []),
+                fn ($platform) => $platformsById[data_get($platform, 'id')] ?? null,
+            );
+        });
     }
 
     /**

--- a/app/Http/Requests/Api/Post/UpdatePostRequest.php
+++ b/app/Http/Requests/Api/Post/UpdatePostRequest.php
@@ -52,7 +52,6 @@ class UpdatePostRequest extends FormRequest
                 Rule::in(array_column(ContentType::cases(), 'value')),
                 new ContentTypeMatchesPostPlatform,
             ],
-            'platforms.*.meta' => ['nullable', 'array'],
             ...PostPlatformMetaRules::rules(),
             'scheduled_at' => [
                 'nullable',

--- a/app/Http/Requests/App/Post/UpdatePostRequest.php
+++ b/app/Http/Requests/App/Post/UpdatePostRequest.php
@@ -6,11 +6,11 @@ namespace App\Http\Requests\App\Post;
 
 use App\Enums\Media\Source;
 use App\Enums\Post\Status;
-use App\Enums\PostPlatform\AspectRatio;
 use App\Enums\PostPlatform\ContentType;
 use App\Enums\SocialAccount\Platform;
 use App\Rules\ContentFitsPlatformLimits;
 use App\Rules\ContentTypeCompatibleWithMedia;
+use App\Support\PostPlatformMetaRules;
 use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Support\Collection;
 use Illuminate\Validation\Rule;
@@ -71,28 +71,7 @@ class UpdatePostRequest extends FormRequest
                 Rule::when($enforcesMediaCompatibility, [new ContentTypeCompatibleWithMedia]),
             ],
             'platforms.*.meta' => ['nullable', 'array'],
-            'platforms.*.meta.aspect_ratio' => ['sometimes', 'nullable', 'string', Rule::enum(AspectRatio::class)],
-            'platforms.*.meta.privacy_level' => ['sometimes', 'nullable', 'string', Rule::in(['PUBLIC_TO_EVERYONE', 'MUTUAL_FOLLOW_FRIENDS', 'FOLLOWER_OF_CREATOR', 'SELF_ONLY'])],
-            'platforms.*.meta.auto_add_music' => ['sometimes', 'boolean'],
-            'platforms.*.meta.allow_comments' => ['sometimes', 'boolean'],
-            'platforms.*.meta.allow_duet' => ['sometimes', 'boolean'],
-            'platforms.*.meta.allow_stitch' => ['sometimes', 'boolean'],
-            'platforms.*.meta.is_aigc' => ['sometimes', 'boolean'],
-            'platforms.*.meta.disclose' => ['sometimes', 'boolean'],
-            'platforms.*.meta.brand_content_toggle' => ['sometimes', 'boolean'],
-            'platforms.*.meta.brand_organic_toggle' => ['sometimes', 'boolean'],
-            'platforms.*.meta.board_id' => ['sometimes', 'nullable', 'string'],
-            'platforms.*.meta.channel_id' => ['sometimes', 'nullable', 'string'],
-            'platforms.*.meta.channel_name' => ['sometimes', 'nullable', 'string'],
-            'platforms.*.meta.mentions' => ['sometimes', 'nullable', 'array'],
-            'platforms.*.meta.mentions.*.token' => ['required', 'string'],
-            'platforms.*.meta.mentions.*.label' => ['sometimes', 'nullable', 'string'],
-            'platforms.*.meta.embeds' => ['sometimes', 'nullable', 'array', 'max:10'],
-            'platforms.*.meta.embeds.*.title' => ['sometimes', 'nullable', 'string', 'max:256'],
-            'platforms.*.meta.embeds.*.description' => ['sometimes', 'nullable', 'string', 'max:4096'],
-            'platforms.*.meta.embeds.*.url' => ['sometimes', 'nullable', 'url'],
-            'platforms.*.meta.embeds.*.image' => ['sometimes', 'nullable', 'url'],
-            'platforms.*.meta.embeds.*.color' => ['sometimes', 'nullable', 'string', 'regex:/^#?[0-9A-Fa-f]{6}$/'],
+            ...PostPlatformMetaRules::rules(),
             'label_ids' => ['sometimes', 'array'],
             'label_ids.*' => ['uuid', Rule::exists('workspace_labels', 'id')->where('workspace_id', $this->user()->currentWorkspace->id)],
         ];
@@ -113,32 +92,11 @@ class UpdatePostRequest extends FormRequest
                 ->whereIn('id', $ids)
                 ->pluck('platform', 'id');
 
-            foreach ($platforms as $i => $platform) {
-                $platformEnum = $platformsById[data_get($platform, 'id')] ?? null;
-                if ($platformEnum === Platform::TikTok
-                    && blank(data_get($platform, 'meta.privacy_level'))) {
-                    $validator->errors()->add(
-                        "platforms.{$i}.meta.privacy_level",
-                        trans('posts.form.tiktok.privacy_required'),
-                    );
-                }
-
-                if ($platformEnum === Platform::Pinterest
-                    && blank(data_get($platform, 'meta.board_id'))) {
-                    $validator->errors()->add(
-                        "platforms.{$i}.meta.board_id",
-                        trans('posts.form.pinterest.board_required'),
-                    );
-                }
-
-                if ($platformEnum === Platform::Discord
-                    && blank(data_get($platform, 'meta.channel_id'))) {
-                    $validator->errors()->add(
-                        "platforms.{$i}.meta.channel_id",
-                        trans('posts.form.discord.channel_required'),
-                    );
-                }
-            }
+            PostPlatformMetaRules::addRequiredOnPublishErrors(
+                $validator,
+                $platforms,
+                fn ($platform) => $platformsById[data_get($platform, 'id')] ?? null,
+            );
         });
     }
 

--- a/app/Http/Requests/App/Post/UpdatePostRequest.php
+++ b/app/Http/Requests/App/Post/UpdatePostRequest.php
@@ -70,7 +70,6 @@ class UpdatePostRequest extends FormRequest
                 Rule::in(array_column(ContentType::cases(), 'value')),
                 Rule::when($enforcesMediaCompatibility, [new ContentTypeCompatibleWithMedia]),
             ],
-            'platforms.*.meta' => ['nullable', 'array'],
             ...PostPlatformMetaRules::rules(),
             'label_ids' => ['sometimes', 'array'],
             'label_ids.*' => ['uuid', Rule::exists('workspace_labels', 'id')->where('workspace_id', $this->user()->currentWorkspace->id)],

--- a/app/Mcp/Tools/Post/CreatePostTool.php
+++ b/app/Mcp/Tools/Post/CreatePostTool.php
@@ -5,10 +5,10 @@ declare(strict_types=1);
 namespace App\Mcp\Tools\Post;
 
 use App\Actions\Post\CreatePost;
-use App\Enums\PostPlatform\AspectRatio;
 use App\Enums\PostPlatform\ContentType;
 use App\Http\Resources\Api\PostResource;
 use App\Rules\ContentTypeMatchesPlatform;
+use App\Support\PostPlatformMetaRules;
 use Illuminate\Contracts\JsonSchema\JsonSchema;
 use Illuminate\Validation\Rule;
 use Laravel\Mcp\Request;
@@ -39,7 +39,7 @@ class CreatePostTool extends Tool
             ],
             'platforms.*.content_type' => ['required', 'string', Rule::in(array_column(ContentType::cases(), 'value')), new ContentTypeMatchesPlatform],
             'platforms.*.meta' => ['sometimes', 'array'],
-            'platforms.*.meta.aspect_ratio' => ['sometimes', 'nullable', 'string', Rule::enum(AspectRatio::class)],
+            ...PostPlatformMetaRules::rules(),
         ]);
 
         $post = CreatePost::execute($workspace, $request->user(), $validated);
@@ -61,7 +61,7 @@ class CreatePostTool extends Tool
                 ->items($schema->object(fn ($p) => [
                     'social_account_id' => $p->string()->required()->description('UUID of the connected social account.'),
                     'content_type' => $p->string()->required()->description('Format for this platform (e.g. linkedin_post, x_post, instagram_feed).'),
-                    'meta' => $p->object()->description('Per-platform metadata (e.g. aspect_ratio: 1:1|4:5|16:9|original for Instagram/Facebook feed images).'),
+                    'meta' => $p->object()->description('Per-platform metadata. Instagram/Facebook: aspect_ratio (1:1|4:5|16:9|original). TikTok: privacy_level (required to publish) + flags (allow_comments, allow_duet, allow_stitch, disclose, brand_content_toggle, brand_organic_toggle, is_aigc, auto_add_music). Pinterest: board_id (required to publish). Discord: channel_id (required to publish), mentions ([{token,label}]), embeds ([{title,description,url,image,color}]).'),
                 ]))
                 ->description('Platforms to publish on. Accounts not listed remain available but disabled.'),
         ];

--- a/app/Mcp/Tools/Post/CreatePostTool.php
+++ b/app/Mcp/Tools/Post/CreatePostTool.php
@@ -38,7 +38,6 @@ class CreatePostTool extends Tool
                     ->where('is_active', true),
             ],
             'platforms.*.content_type' => ['required', 'string', Rule::in(array_column(ContentType::cases(), 'value')), new ContentTypeMatchesPlatform],
-            'platforms.*.meta' => ['sometimes', 'array'],
             ...PostPlatformMetaRules::rules(),
         ]);
 

--- a/app/Mcp/Tools/Post/PublishPostTool.php
+++ b/app/Mcp/Tools/Post/PublishPostTool.php
@@ -9,6 +9,7 @@ use App\Enums\Post\Action as PostAction;
 use App\Enums\Post\Status;
 use App\Http\Resources\Api\PostResource;
 use App\Models\Post;
+use App\Support\PostPlatformMetaRules;
 use App\Support\PostStatusRules;
 use Illuminate\Contracts\JsonSchema\JsonSchema;
 use Laravel\Mcp\Request;
@@ -40,6 +41,8 @@ class PublishPostTool extends Tool
         if (! $post->postPlatforms()->where('enabled', true)->exists()) {
             return Response::error('Post has no enabled platforms. Use update-post-tool to enable at least one platform first.');
         }
+
+        PostPlatformMetaRules::assertStoredPostPublishable($post);
 
         $scheduledAt = data_get($validated, 'scheduled_at');
 

--- a/app/Mcp/Tools/Post/UpdatePostTool.php
+++ b/app/Mcp/Tools/Post/UpdatePostTool.php
@@ -7,11 +7,11 @@ namespace App\Mcp\Tools\Post;
 use App\Actions\Post\UpdatePost;
 use App\Enums\Post\Action as PostAction;
 use App\Enums\Post\Status;
-use App\Enums\PostPlatform\AspectRatio;
 use App\Enums\PostPlatform\ContentType;
 use App\Http\Resources\Api\PostResource;
 use App\Models\Post;
 use App\Rules\ContentTypeMatchesPostPlatform;
+use App\Support\PostPlatformMetaRules;
 use App\Support\PostStatusRules;
 use Illuminate\Contracts\JsonSchema\JsonSchema;
 use Illuminate\Validation\Rule;
@@ -50,7 +50,7 @@ class UpdatePostTool extends Tool
             ],
             'platforms.*.content_type' => ['sometimes', 'string', Rule::in(array_column(ContentType::cases(), 'value')), new ContentTypeMatchesPostPlatform],
             'platforms.*.meta' => ['sometimes', 'array'],
-            'platforms.*.meta.aspect_ratio' => ['sometimes', 'nullable', 'string', Rule::enum(AspectRatio::class)],
+            ...PostPlatformMetaRules::rules(),
         ]);
 
         $payload = collect($validated)->except('post_id')->all();
@@ -84,7 +84,7 @@ class UpdatePostTool extends Tool
                 ->items($schema->object(fn ($p) => [
                     'id' => $p->string()->required()->description('UUID of the post_platform row (from get-post-tool / list-posts-tool).'),
                     'content_type' => $p->string()->description('New content_type for this platform.'),
-                    'meta' => $p->object()->description('Per-platform metadata override (e.g. aspect_ratio, board_id for Pinterest).'),
+                    'meta' => $p->object()->description('Per-platform metadata override. Instagram/Facebook: aspect_ratio. TikTok: privacy_level (required to publish) + flags. Pinterest: board_id (required to publish). Discord: channel_id (required to publish), mentions, embeds. Merged with existing meta.'),
                 ]))
                 ->description('Platforms to enable for publishing. Any platform NOT listed will be disabled. Pass an empty array to disable all.'),
         ];

--- a/app/Mcp/Tools/Post/UpdatePostTool.php
+++ b/app/Mcp/Tools/Post/UpdatePostTool.php
@@ -49,7 +49,6 @@ class UpdatePostTool extends Tool
                 Rule::exists('post_platforms', 'id')->where('post_id', $post->id),
             ],
             'platforms.*.content_type' => ['sometimes', 'string', Rule::in(array_column(ContentType::cases(), 'value')), new ContentTypeMatchesPostPlatform],
-            'platforms.*.meta' => ['sometimes', 'array'],
             ...PostPlatformMetaRules::rules(),
         ]);
 

--- a/app/Support/PostPlatformMetaRules.php
+++ b/app/Support/PostPlatformMetaRules.php
@@ -1,0 +1,138 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Support;
+
+use App\Enums\PostPlatform\AspectRatio;
+use App\Enums\SocialAccount\Platform;
+use App\Models\Post;
+use Illuminate\Validation\Rule;
+use Illuminate\Validation\ValidationException;
+use Illuminate\Validation\Validator;
+
+/**
+ * Single source of truth for per-platform `PostPlatform.meta` validation, shared
+ * by the web, public REST API, and MCP post create/update flows so every entry
+ * point accepts the same per-platform settings and enforces the same
+ * required-on-publish rules.
+ */
+class PostPlatformMetaRules
+{
+    /**
+     * TikTok content visibility options.
+     *
+     * @var array<int, string>
+     */
+    public const TIKTOK_PRIVACY_LEVELS = [
+        'PUBLIC_TO_EVERYONE',
+        'MUTUAL_FOLLOW_FRIENDS',
+        'FOLLOWER_OF_CREATOR',
+        'SELF_ONLY',
+    ];
+
+    /**
+     * Validation rules for the `platforms.*.meta.*` keys. The caller keeps its own
+     * `platforms.*.meta` (array) parent rule; these are the per-platform sub-keys.
+     *
+     * @return array<string, mixed>
+     */
+    public static function rules(): array
+    {
+        return [
+            // Instagram / Facebook
+            'platforms.*.meta.aspect_ratio' => ['sometimes', 'nullable', 'string', Rule::enum(AspectRatio::class)],
+
+            // TikTok
+            'platforms.*.meta.privacy_level' => ['sometimes', 'nullable', 'string', Rule::in(self::TIKTOK_PRIVACY_LEVELS)],
+            'platforms.*.meta.auto_add_music' => ['sometimes', 'boolean'],
+            'platforms.*.meta.allow_comments' => ['sometimes', 'boolean'],
+            'platforms.*.meta.allow_duet' => ['sometimes', 'boolean'],
+            'platforms.*.meta.allow_stitch' => ['sometimes', 'boolean'],
+            'platforms.*.meta.is_aigc' => ['sometimes', 'boolean'],
+            'platforms.*.meta.disclose' => ['sometimes', 'boolean'],
+            'platforms.*.meta.brand_content_toggle' => ['sometimes', 'boolean'],
+            'platforms.*.meta.brand_organic_toggle' => ['sometimes', 'boolean'],
+
+            // Pinterest
+            'platforms.*.meta.board_id' => ['sometimes', 'nullable', 'string'],
+
+            // Discord
+            'platforms.*.meta.channel_id' => ['sometimes', 'nullable', 'string'],
+            'platforms.*.meta.channel_name' => ['sometimes', 'nullable', 'string'],
+            'platforms.*.meta.mentions' => ['sometimes', 'nullable', 'array'],
+            'platforms.*.meta.mentions.*.token' => ['required', 'string'],
+            'platforms.*.meta.mentions.*.label' => ['sometimes', 'nullable', 'string'],
+            'platforms.*.meta.embeds' => ['sometimes', 'nullable', 'array', 'max:10'],
+            'platforms.*.meta.embeds.*.title' => ['sometimes', 'nullable', 'string', 'max:256'],
+            'platforms.*.meta.embeds.*.description' => ['sometimes', 'nullable', 'string', 'max:4096'],
+            'platforms.*.meta.embeds.*.url' => ['sometimes', 'nullable', 'url'],
+            'platforms.*.meta.embeds.*.image' => ['sometimes', 'nullable', 'url'],
+            'platforms.*.meta.embeds.*.color' => ['sometimes', 'nullable', 'string', 'regex:/^#?[0-9A-Fa-f]{6}$/'],
+        ];
+    }
+
+    /**
+     * Adds validation errors for per-platform meta that becomes mandatory once a
+     * post is published or scheduled (TikTok privacy, Pinterest board, Discord
+     * channel), based on the submitted request platforms. The caller resolves each
+     * platform row to its Platform enum, since that lookup differs between create
+     * (by social account) and update (by post platform).
+     *
+     * @param  array<int, mixed>  $platforms
+     * @param  callable(mixed, int): ?Platform  $resolvePlatform
+     */
+    public static function addRequiredOnPublishErrors(Validator $validator, array $platforms, callable $resolvePlatform): void
+    {
+        foreach ($platforms as $index => $platform) {
+            $violation = self::requiredMetaViolation($resolvePlatform($platform, $index), data_get($platform, 'meta'));
+
+            if ($violation !== null) {
+                [$field, $message] = $violation;
+                $validator->errors()->add("platforms.{$index}.meta.{$field}", $message);
+            }
+        }
+    }
+
+    /**
+     * Asserts that every ENABLED platform already stored on a post has the meta it
+     * needs to publish. Used by entry points that publish a post's stored state
+     * without resubmitting platforms (e.g. the MCP publish tool), so a misconfigured
+     * post fails fast with a clear message instead of only at publish time.
+     *
+     * @throws ValidationException
+     */
+    public static function assertStoredPostPublishable(Post $post): void
+    {
+        $errors = [];
+
+        foreach ($post->postPlatforms()->where('enabled', true)->get()->values() as $index => $postPlatform) {
+            $violation = self::requiredMetaViolation($postPlatform->platform, $postPlatform->meta);
+
+            if ($violation !== null) {
+                [$field, $message] = $violation;
+                $errors["platforms.{$index}.meta.{$field}"] = $message;
+            }
+        }
+
+        if ($errors !== []) {
+            throw ValidationException::withMessages($errors);
+        }
+    }
+
+    /**
+     * The missing required meta field for a platform about to publish, or null when
+     * nothing is missing. Single source of "what each platform requires to publish".
+     *
+     * @return array{0: string, 1: string}|null [field, message]
+     */
+    private static function requiredMetaViolation(?Platform $platform, mixed $meta): ?array
+    {
+        return match (true) {
+            $platform === Platform::TikTok && blank(data_get($meta, 'privacy_level')) => ['privacy_level', trans('posts.form.tiktok.privacy_required')],
+            $platform === Platform::Pinterest && blank(data_get($meta, 'board_id')) => ['board_id', trans('posts.form.pinterest.board_required')],
+            $platform === Platform::Discord && blank(data_get($meta, 'channel_id')) => ['channel_id', trans('posts.form.discord.channel_required')],
+            default => null,
+        };
+    }
+}

--- a/app/Support/PostPlatformMetaRules.php
+++ b/app/Support/PostPlatformMetaRules.php
@@ -32,14 +32,16 @@ class PostPlatformMetaRules
     ];
 
     /**
-     * Validation rules for the `platforms.*.meta.*` keys. The caller keeps its own
-     * `platforms.*.meta` (array) parent rule; these are the per-platform sub-keys.
+     * Validation rules for `platforms.*.meta` and all its per-platform sub-keys.
+     * Spread into a FormRequest/MCP tool rule set as the complete meta contract.
      *
      * @return array<string, mixed>
      */
     public static function rules(): array
     {
         return [
+            'platforms.*.meta' => ['sometimes', 'nullable', 'array'],
+
             // Instagram / Facebook
             'platforms.*.meta.aspect_ratio' => ['sometimes', 'nullable', 'string', Rule::enum(AspectRatio::class)],
 

--- a/database/factories/PostPlatformFactory.php
+++ b/database/factories/PostPlatformFactory.php
@@ -155,6 +155,14 @@ class PostPlatformFactory extends Factory
         ]);
     }
 
+    public function discord(): static
+    {
+        return $this->state(fn (array $attributes) => [
+            'platform' => Platform::Discord,
+            'content_type' => ContentType::DiscordMessage,
+        ]);
+    }
+
     public function facebookReel(): static
     {
         return $this->state(fn (array $attributes) => [

--- a/tests/Feature/Api/PostApiPlatformMetaTest.php
+++ b/tests/Feature/Api/PostApiPlatformMetaTest.php
@@ -43,9 +43,12 @@ it('persists Discord channel, mentions and embeds meta on store', function () {
 
     $meta = PostPlatform::where('social_account_id', $this->discordAccount->id)->sole()->meta;
 
-    expect($meta['channel_id'])->toBe('444555666')
-        ->and($meta['mentions'])->toHaveCount(1)
-        ->and($meta['embeds.0.title'] ?? data_get($meta, 'embeds.0.title'))->toBe('Release');
+    // Assert nested keys survive validated() — the exact stripping bug this PR fixes.
+    expect(data_get($meta, 'channel_id'))->toBe('444555666')
+        ->and(data_get($meta, 'mentions.0.token'))->toBe('@everyone')
+        ->and(data_get($meta, 'mentions.0.label'))->toBe('@everyone')
+        ->and(data_get($meta, 'embeds.0.title'))->toBe('Release')
+        ->and(data_get($meta, 'embeds.0.color'))->toBe('#5865F2');
 });
 
 it('persists per-platform meta across networks on store', function () {
@@ -107,7 +110,7 @@ it('rejects publishing without TikTok privacy and Pinterest board', function () 
                 ['id' => $tiktokPlatform->id],
             ],
         ])
-        ->assertStatus(422)
+        ->assertUnprocessable()
         ->assertJsonValidationErrors([
             'platforms.0.meta.board_id',
             'platforms.1.meta.privacy_level',
@@ -128,7 +131,7 @@ it('rejects publishing a Discord post without a channel', function () {
             'status' => PostStatus::Publishing->value,
             'platforms' => [['id' => $platform->id]],
         ])
-        ->assertStatus(422)
+        ->assertUnprocessable()
         ->assertJsonValidationErrors(['platforms.0.meta.channel_id']);
 });
 

--- a/tests/Feature/Api/PostApiPlatformMetaTest.php
+++ b/tests/Feature/Api/PostApiPlatformMetaTest.php
@@ -48,7 +48,8 @@ it('persists Discord channel, mentions and embeds meta on store', function () {
         ->and($meta['embeds.0.title'] ?? data_get($meta, 'embeds.0.title'))->toBe('Release');
 });
 
-it('persists Pinterest board and TikTok privacy meta on store', function () {
+it('persists per-platform meta across networks on store', function () {
+    $instagram = SocialAccount::factory()->create(['workspace_id' => $this->workspace->id, 'platform' => Platform::Instagram]);
     $pinterest = SocialAccount::factory()->create(['workspace_id' => $this->workspace->id, 'platform' => Platform::Pinterest]);
     $tiktok = SocialAccount::factory()->create(['workspace_id' => $this->workspace->id, 'platform' => Platform::TikTok]);
 
@@ -56,14 +57,61 @@ it('persists Pinterest board and TikTok privacy meta on store', function () {
         ->postJson(route('api.posts.store'), [
             'content' => 'Cross-platform',
             'platforms' => [
+                ['social_account_id' => $instagram->id, 'content_type' => ContentType::InstagramFeed->value, 'meta' => ['aspect_ratio' => '4:5']],
                 ['social_account_id' => $pinterest->id, 'content_type' => ContentType::PinterestPin->value, 'meta' => ['board_id' => 'board-99']],
-                ['social_account_id' => $tiktok->id, 'content_type' => ContentType::TikTokVideo->value, 'meta' => ['privacy_level' => 'SELF_ONLY']],
+                ['social_account_id' => $tiktok->id, 'content_type' => ContentType::TikTokVideo->value, 'meta' => ['privacy_level' => 'SELF_ONLY', 'allow_comments' => true]],
             ],
         ])
         ->assertCreated();
 
-    expect(PostPlatform::where('social_account_id', $pinterest->id)->sole()->meta['board_id'])->toBe('board-99')
-        ->and(PostPlatform::where('social_account_id', $tiktok->id)->sole()->meta['privacy_level'])->toBe('SELF_ONLY');
+    expect(PostPlatform::where('social_account_id', $instagram->id)->sole()->meta['aspect_ratio'])->toBe('4:5')
+        ->and(PostPlatform::where('social_account_id', $pinterest->id)->sole()->meta['board_id'])->toBe('board-99')
+        ->and(PostPlatform::where('social_account_id', $tiktok->id)->sole()->meta['privacy_level'])->toBe('SELF_ONLY')
+        ->and(PostPlatform::where('social_account_id', $tiktok->id)->sole()->meta['allow_comments'])->toBeTrue();
+});
+
+it('allows saving a Discord draft without a channel', function () {
+    $post = Post::factory()->create(['workspace_id' => $this->workspace->id, 'user_id' => $this->user->id]);
+    $platform = PostPlatform::factory()->discord()->create([
+        'post_id' => $post->id,
+        'social_account_id' => $this->discordAccount->id,
+        'enabled' => true,
+        'meta' => [],
+    ]);
+
+    $this->withHeaders($this->headers)
+        ->putJson(route('api.posts.update', $post), [
+            'status' => PostStatus::Draft->value,
+            'platforms' => [['id' => $platform->id]],
+        ])
+        ->assertOk();
+});
+
+it('rejects publishing without TikTok privacy and Pinterest board', function () {
+    $pinterest = SocialAccount::factory()->create(['workspace_id' => $this->workspace->id, 'platform' => Platform::Pinterest]);
+    $tiktok = SocialAccount::factory()->create(['workspace_id' => $this->workspace->id, 'platform' => Platform::TikTok]);
+
+    $post = Post::factory()->create(['workspace_id' => $this->workspace->id, 'user_id' => $this->user->id]);
+    $pinterestPlatform = PostPlatform::factory()->pinterest()->create([
+        'post_id' => $post->id, 'social_account_id' => $pinterest->id, 'enabled' => true, 'meta' => [],
+    ]);
+    $tiktokPlatform = PostPlatform::factory()->tiktok()->create([
+        'post_id' => $post->id, 'social_account_id' => $tiktok->id, 'enabled' => true, 'meta' => [],
+    ]);
+
+    $this->withHeaders($this->headers)
+        ->putJson(route('api.posts.update', $post), [
+            'status' => PostStatus::Publishing->value,
+            'platforms' => [
+                ['id' => $pinterestPlatform->id],
+                ['id' => $tiktokPlatform->id],
+            ],
+        ])
+        ->assertStatus(422)
+        ->assertJsonValidationErrors([
+            'platforms.0.meta.board_id',
+            'platforms.1.meta.privacy_level',
+        ]);
 });
 
 it('rejects publishing a Discord post without a channel', function () {

--- a/tests/Feature/Api/PostApiPlatformMetaTest.php
+++ b/tests/Feature/Api/PostApiPlatformMetaTest.php
@@ -1,0 +1,107 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Enums\Post\Status as PostStatus;
+use App\Enums\PostPlatform\ContentType;
+use App\Enums\SocialAccount\Platform;
+use App\Jobs\PublishPost;
+use App\Models\Post;
+use App\Models\PostPlatform;
+use App\Models\SocialAccount;
+use Illuminate\Support\Facades\Queue;
+
+beforeEach(function () {
+    $result = createApiTestToken();
+    $this->user = $result['user'];
+    $this->workspace = $result['workspace'];
+    $this->plainToken = $result['plain_token'];
+
+    $this->headers = ['Authorization' => 'Bearer '.$this->plainToken];
+
+    $this->discordAccount = SocialAccount::factory()->discord()->create([
+        'workspace_id' => $this->workspace->id,
+        'platform_user_id' => '111222333',
+    ]);
+});
+
+it('persists Discord channel, mentions and embeds meta on store', function () {
+    $this->withHeaders($this->headers)
+        ->postJson(route('api.posts.store'), [
+            'content' => 'Hello Discord',
+            'platforms' => [[
+                'social_account_id' => $this->discordAccount->id,
+                'content_type' => ContentType::DiscordMessage->value,
+                'meta' => [
+                    'channel_id' => '444555666',
+                    'mentions' => [['token' => '@everyone', 'label' => '@everyone']],
+                    'embeds' => [['title' => 'Release', 'color' => '#5865F2']],
+                ],
+            ]],
+        ])
+        ->assertCreated();
+
+    $meta = PostPlatform::where('social_account_id', $this->discordAccount->id)->sole()->meta;
+
+    expect($meta['channel_id'])->toBe('444555666')
+        ->and($meta['mentions'])->toHaveCount(1)
+        ->and($meta['embeds.0.title'] ?? data_get($meta, 'embeds.0.title'))->toBe('Release');
+});
+
+it('persists Pinterest board and TikTok privacy meta on store', function () {
+    $pinterest = SocialAccount::factory()->create(['workspace_id' => $this->workspace->id, 'platform' => Platform::Pinterest]);
+    $tiktok = SocialAccount::factory()->create(['workspace_id' => $this->workspace->id, 'platform' => Platform::TikTok]);
+
+    $this->withHeaders($this->headers)
+        ->postJson(route('api.posts.store'), [
+            'content' => 'Cross-platform',
+            'platforms' => [
+                ['social_account_id' => $pinterest->id, 'content_type' => ContentType::PinterestPin->value, 'meta' => ['board_id' => 'board-99']],
+                ['social_account_id' => $tiktok->id, 'content_type' => ContentType::TikTokVideo->value, 'meta' => ['privacy_level' => 'SELF_ONLY']],
+            ],
+        ])
+        ->assertCreated();
+
+    expect(PostPlatform::where('social_account_id', $pinterest->id)->sole()->meta['board_id'])->toBe('board-99')
+        ->and(PostPlatform::where('social_account_id', $tiktok->id)->sole()->meta['privacy_level'])->toBe('SELF_ONLY');
+});
+
+it('rejects publishing a Discord post without a channel', function () {
+    $post = Post::factory()->create(['workspace_id' => $this->workspace->id, 'user_id' => $this->user->id]);
+    $platform = PostPlatform::factory()->discord()->create([
+        'post_id' => $post->id,
+        'social_account_id' => $this->discordAccount->id,
+        'enabled' => true,
+        'meta' => [],
+    ]);
+
+    $this->withHeaders($this->headers)
+        ->putJson(route('api.posts.update', $post), [
+            'status' => PostStatus::Publishing->value,
+            'platforms' => [['id' => $platform->id]],
+        ])
+        ->assertStatus(422)
+        ->assertJsonValidationErrors(['platforms.0.meta.channel_id']);
+});
+
+it('publishes a Discord post when the channel is set', function () {
+    Queue::fake();
+
+    $post = Post::factory()->create(['workspace_id' => $this->workspace->id, 'user_id' => $this->user->id]);
+    $platform = PostPlatform::factory()->discord()->create([
+        'post_id' => $post->id,
+        'social_account_id' => $this->discordAccount->id,
+        'enabled' => true,
+        'meta' => [],
+    ]);
+
+    $this->withHeaders($this->headers)
+        ->putJson(route('api.posts.update', $post), [
+            'status' => PostStatus::Publishing->value,
+            'platforms' => [['id' => $platform->id, 'meta' => ['channel_id' => '444555666']]],
+        ])
+        ->assertOk();
+
+    expect($platform->fresh()->meta['channel_id'])->toBe('444555666');
+    Queue::assertPushed(PublishPost::class);
+});

--- a/tests/Feature/Mcp/PostPlatformMetaToolTest.php
+++ b/tests/Feature/Mcp/PostPlatformMetaToolTest.php
@@ -4,11 +4,13 @@ declare(strict_types=1);
 
 use App\Enums\Post\Status as PostStatus;
 use App\Enums\PostPlatform\ContentType;
+use App\Enums\SocialAccount\Platform;
 use App\Enums\UserWorkspace\Role;
 use App\Jobs\PublishPost;
 use App\Mcp\Servers\TryPostServer;
 use App\Mcp\Tools\Post\CreatePostTool;
 use App\Mcp\Tools\Post\PublishPostTool;
+use App\Mcp\Tools\Post\UpdatePostTool;
 use App\Models\Post;
 use App\Models\PostPlatform;
 use App\Models\SocialAccount;
@@ -48,6 +50,65 @@ test('create post persists Discord channel + embeds meta', function () {
 
     expect($meta['channel_id'])->toBe('444555666')
         ->and(data_get($meta, 'embeds.0.title'))->toBe('Release');
+});
+
+test('update post merges per-platform meta', function () {
+    $post = Post::factory()->create([
+        'workspace_id' => $this->workspace->id,
+        'user_id' => $this->user->id,
+        'status' => PostStatus::Draft,
+    ]);
+    $platform = PostPlatform::factory()->discord()->create([
+        'post_id' => $post->id,
+        'social_account_id' => $this->discordAccount->id,
+        'enabled' => true,
+        'meta' => ['channel_name' => 'general'],
+    ]);
+
+    $response = TryPostServer::actingAs($this->user)
+        ->tool(UpdatePostTool::class, [
+            'post_id' => $post->id,
+            'platforms' => [[
+                'id' => $platform->id,
+                'meta' => ['channel_id' => '444555666'],
+            ]],
+        ]);
+
+    $response->assertOk();
+
+    $meta = $platform->fresh()->meta;
+    expect($meta['channel_id'])->toBe('444555666')
+        ->and($meta['channel_name'])->toBe('general'); // merged, not overwritten
+});
+
+test('publish guard ignores disabled platforms missing meta', function () {
+    Queue::fake();
+
+    $linkedin = SocialAccount::factory()->create(['workspace_id' => $this->workspace->id, 'platform' => Platform::LinkedIn]);
+
+    $post = Post::factory()->create([
+        'workspace_id' => $this->workspace->id,
+        'user_id' => $this->user->id,
+        'status' => PostStatus::Draft,
+    ]);
+    PostPlatform::factory()->linkedin()->create([
+        'post_id' => $post->id,
+        'social_account_id' => $linkedin->id,
+        'enabled' => true,
+    ]);
+    // Disabled Discord with no channel must not block the publish.
+    PostPlatform::factory()->discord()->create([
+        'post_id' => $post->id,
+        'social_account_id' => $this->discordAccount->id,
+        'enabled' => false,
+        'meta' => [],
+    ]);
+
+    $response = TryPostServer::actingAs($this->user)
+        ->tool(PublishPostTool::class, ['post_id' => $post->id]);
+
+    $response->assertOk();
+    Queue::assertPushed(PublishPost::class);
 });
 
 test('publish post rejects a Discord platform without a channel', function () {

--- a/tests/Feature/Mcp/PostPlatformMetaToolTest.php
+++ b/tests/Feature/Mcp/PostPlatformMetaToolTest.php
@@ -130,6 +130,33 @@ test('publish post rejects a Discord platform without a channel', function () {
     $response->assertHasErrors([__('posts.form.discord.channel_required')]);
 });
 
+test('publish guard enforces required meta for TikTok and Pinterest', function (string $factoryState, string $field, string $messageKey) {
+    $account = SocialAccount::factory()->create([
+        'workspace_id' => $this->workspace->id,
+        'platform' => $factoryState === 'tiktok' ? Platform::TikTok : Platform::Pinterest,
+    ]);
+
+    $post = Post::factory()->create([
+        'workspace_id' => $this->workspace->id,
+        'user_id' => $this->user->id,
+        'status' => PostStatus::Draft,
+    ]);
+    PostPlatform::factory()->{$factoryState}()->create([
+        'post_id' => $post->id,
+        'social_account_id' => $account->id,
+        'enabled' => true,
+        'meta' => [],
+    ]);
+
+    $response = TryPostServer::actingAs($this->user)
+        ->tool(PublishPostTool::class, ['post_id' => $post->id]);
+
+    $response->assertHasErrors([__($messageKey)]);
+})->with([
+    'tiktok' => ['tiktok', 'privacy_level', 'posts.form.tiktok.privacy_required'],
+    'pinterest' => ['pinterest', 'board_id', 'posts.form.pinterest.board_required'],
+]);
+
 test('publish post succeeds for a Discord platform with a channel', function () {
     Queue::fake();
 

--- a/tests/Feature/Mcp/PostPlatformMetaToolTest.php
+++ b/tests/Feature/Mcp/PostPlatformMetaToolTest.php
@@ -1,0 +1,92 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Enums\Post\Status as PostStatus;
+use App\Enums\PostPlatform\ContentType;
+use App\Enums\UserWorkspace\Role;
+use App\Jobs\PublishPost;
+use App\Mcp\Servers\TryPostServer;
+use App\Mcp\Tools\Post\CreatePostTool;
+use App\Mcp\Tools\Post\PublishPostTool;
+use App\Models\Post;
+use App\Models\PostPlatform;
+use App\Models\SocialAccount;
+use App\Models\User;
+use App\Models\Workspace;
+use Illuminate\Support\Facades\Queue;
+
+beforeEach(function () {
+    $this->user = User::factory()->create();
+    $this->workspace = Workspace::factory()->create(['user_id' => $this->user->id]);
+    $this->workspace->members()->attach($this->user->id, ['role' => Role::Member->value]);
+    $this->user->update(['current_workspace_id' => $this->workspace->id]);
+
+    $this->discordAccount = SocialAccount::factory()->discord()->create([
+        'workspace_id' => $this->workspace->id,
+        'platform_user_id' => '111222333',
+    ]);
+});
+
+test('create post persists Discord channel + embeds meta', function () {
+    $response = TryPostServer::actingAs($this->user)
+        ->tool(CreatePostTool::class, [
+            'content' => 'Hello Discord',
+            'platforms' => [[
+                'social_account_id' => $this->discordAccount->id,
+                'content_type' => ContentType::DiscordMessage->value,
+                'meta' => [
+                    'channel_id' => '444555666',
+                    'embeds' => [['title' => 'Release']],
+                ],
+            ]],
+        ]);
+
+    $response->assertOk();
+
+    $meta = PostPlatform::where('social_account_id', $this->discordAccount->id)->sole()->meta;
+
+    expect($meta['channel_id'])->toBe('444555666')
+        ->and(data_get($meta, 'embeds.0.title'))->toBe('Release');
+});
+
+test('publish post rejects a Discord platform without a channel', function () {
+    $post = Post::factory()->create([
+        'workspace_id' => $this->workspace->id,
+        'user_id' => $this->user->id,
+        'status' => PostStatus::Draft,
+    ]);
+    PostPlatform::factory()->discord()->create([
+        'post_id' => $post->id,
+        'social_account_id' => $this->discordAccount->id,
+        'enabled' => true,
+        'meta' => [],
+    ]);
+
+    $response = TryPostServer::actingAs($this->user)
+        ->tool(PublishPostTool::class, ['post_id' => $post->id]);
+
+    $response->assertHasErrors([__('posts.form.discord.channel_required')]);
+});
+
+test('publish post succeeds for a Discord platform with a channel', function () {
+    Queue::fake();
+
+    $post = Post::factory()->create([
+        'workspace_id' => $this->workspace->id,
+        'user_id' => $this->user->id,
+        'status' => PostStatus::Draft,
+    ]);
+    PostPlatform::factory()->discord()->create([
+        'post_id' => $post->id,
+        'social_account_id' => $this->discordAccount->id,
+        'enabled' => true,
+        'meta' => ['channel_id' => '444555666'],
+    ]);
+
+    $response = TryPostServer::actingAs($this->user)
+        ->tool(PublishPostTool::class, ['post_id' => $post->id]);
+
+    $response->assertOk();
+    Queue::assertPushed(PublishPost::class);
+});


### PR DESCRIPTION
## Why

The public REST API and MCP tools only validated `aspect_ratio` in `PostPlatform.meta`. Because `validated()` strips keys without rules, every other per-platform setting (`channel_id`, `board_id`, `privacy_level`, `mentions`, `embeds`, TikTok flags) was **silently dropped**. As a result Discord, Pinterest and TikTok could not be configured or published via API/MCP — only via the web UI.

## What

- **`app/Support/PostPlatformMetaRules.php`** — single source of truth for per-platform meta:
  - `rules()` — all `meta.*` validation rules.
  - `addRequiredOnPublishErrors()` — required-on-publish from submitted request platforms (web + API update).
  - `assertStoredPostPublishable()` — required-on-publish from a post's stored state (MCP publish, which doesn't resubmit platforms).
  - `requiredMetaViolation()` — one definition of what each platform requires to publish.
- **Web `UpdatePostRequest`** refactored to use the shared source (DRY, no behavior change).
- **API `StorePostRequest` / `UpdatePostRequest`** now accept all per-platform meta; update enforces required-on-publish (TikTok privacy, Pinterest board, Discord channel).
- **MCP `CreatePostTool` / `UpdatePostTool`** accept all per-platform meta, with documented schemas.
- **MCP `PublishPostTool`** guards a post's stored meta before dispatching, so a misconfigured post fails fast with a clear message instead of only at publish time.

## Tests

- `tests/Feature/Api/PostApiPlatformMetaTest.php` — API persists Discord/Pinterest/TikTok meta, rejects publishing Discord without a channel, publishes with a channel.
- `tests/Feature/Mcp/PostPlatformMetaToolTest.php` — MCP create persists meta, publish guards/permits based on the channel.
- `PostPlatform::factory()->discord()` state added.

Full suite green (2092 passed).