### PR TITLE
chore(release): add v1.0.4 changelog artifacts

### DIFF
--- a/releases/v1.0.4/changelog.md
+++ b/releases/v1.0.4/changelog.md
@@ -1,0 +1,9 @@
+## What's Changed
+* chore(release): add v1.0.3 changelog artifacts by @paulocastellano in https://github.com/trypostit/trypost/pull/102
+* feat: AI template gallery + tweet-card by @paulocastellano in https://github.com/trypostit/trypost/pull/104
+* feat: per-workspace pricing, onboarding, and billing overhaul by @paulocastellano in https://github.com/trypostit/trypost/pull/106
+* chore: remove legacy plan tiers (starter/plus/pro/max) by @paulocastellano in https://github.com/trypostit/trypost/pull/107
+* fix(permissions): enforce workspace roles across backend and UI by @paulocastellano in https://github.com/trypostit/trypost/pull/108
+
+
+**Full Changelog**: https://github.com/trypostit/trypost/compare/v1.0.3...v1.0.4

--- a/releases/v1.0.4/email.md
+++ b/releases/v1.0.4/email.md
@@ -1,0 +1,38 @@
+---
+subject: "Changelog v1.0.4 — Team roles & client review, AI templates, smoother onboarding"
+---
+
+# Changelog v1.0.4 — Team roles & client review, AI templates, smoother onboarding
+
+By TryPost Product Team • [Release v1.0.4](https://github.com/trypostit/trypost/releases/tag/v1.0.4)
+
+Hey — here's what shipped this week.
+
+## Team roles & client review
+
+You can now invite people into a workspace with a role that fits: Admin, Member, or Viewer. Viewers are read-only, but they can open any post and leave comments. This is the one I'm most excited about — hand a client or a manager a Viewer seat, let them review what's scheduled, and collect their feedback right on the post, with no risk of them changing something. Members handle the day-to-day (posts, labels, signatures); connecting social accounts and managing the team stays with Admins and the owner.
+
+## AI content templates and styles
+
+Generating a post with AI now starts with picking a format: a single image card, a carousel, or a tweet-style card (there's even one with a verified badge, and one that sits on a photo background). You choose the visual style on the same screen. These templates also show up inside automations, so your scheduled content can use them too.
+
+## Smoother onboarding and a cleaner workspace
+
+Signing up is quicker — Google and GitHub are front and center, and your first workspace gets created for you. Onboarding also asks you to connect a social network before checkout, so you can post the moment you're in. On the brand settings page, you can pull your brand details straight from your website instead of typing them out. The sidebar got a small tidy-up too, with a new "Others" section for quick links.
+
+## New features
+
+- Invite clients or stakeholders as Viewers — they can review posts and leave comments, but can't edit.
+- New AI formats: image cards, carousels, and tweet-style cards (verified badge or photo background).
+- Pick a visual style for AI images right after the format.
+- Use the same content templates inside automations.
+- Fill your brand details from your website on the brand settings page.
+
+## Fixes
+
+- Telegram connection problems now show a clear message instead of quietly failing.
+- Opening a post as a Viewer shows a clean read-only view instead of an error.
+- Post status labels (like "Pending") show correctly everywhere now.
+
+Cheers,
+Paulo from TryPost.it


### PR DESCRIPTION
Local mirrors of the v1.0.4 release artifacts produced by the Friday release ritual.

- `releases/v1.0.4/changelog.md` — GitHub-native changelog (PR list) used as the [release](https://github.com/trypostit/trypost/releases/tag/v1.0.4) body
- `releases/v1.0.4/email.md` — customer-facing changelog email (Cal.com style)

The tag `v1.0.4` and the GitHub release are already published; this PR just preserves the artifacts in-repo.