### PR TITLE
feat(onboarding): expand persona options and make the labels consistent

### DIFF
--- a/app/Enums/User/Persona.php
+++ b/app/Enums/User/Persona.php
@@ -8,6 +8,7 @@ enum Persona: string
 {
     case Creator = 'creator';
     case Freelancer = 'freelancer';
+    case Developer = 'developer';
     case Startup = 'startup';
     case Agency = 'agency';
     case SmallBusiness = 'small_business';

--- a/app/Enums/User/Persona.php
+++ b/app/Enums/User/Persona.php
@@ -12,5 +12,7 @@ enum Persona: string
     case Startup = 'startup';
     case Agency = 'agency';
     case SmallBusiness = 'small_business';
+    case Marketer = 'marketer';
+    case OnlineStore = 'online_store';
     case Other = 'other';
 }

--- a/lang/en/onboarding.php
+++ b/lang/en/onboarding.php
@@ -9,6 +9,7 @@ return [
     'personas' => [
         'creator' => 'Creator',
         'freelancer' => 'Freelancer',
+        'developer' => 'Developer',
         'startup' => 'Startup',
         'agency' => 'Agency',
         'small_business' => 'Small business',

--- a/lang/en/onboarding.php
+++ b/lang/en/onboarding.php
@@ -13,6 +13,8 @@ return [
         'startup' => 'Startup',
         'agency' => 'Agency',
         'small_business' => 'Small business',
+        'marketer' => 'Marketer',
+        'online_store' => 'Online store',
         'other' => 'Other',
     ],
     'connect' => [

--- a/lang/en/onboarding.php
+++ b/lang/en/onboarding.php
@@ -4,10 +4,10 @@ declare(strict_types=1);
 
 return [
     'title' => 'Welcome to TryPost',
-    'description' => 'Tell us what best describes you so we can tailor your experience.',
+    'description' => 'Tell us what best describes you or your business so we can tailor your experience.',
     'continue' => 'Continue',
     'personas' => [
-        'creator' => 'Creator',
+        'creator' => 'Content creator',
         'freelancer' => 'Freelancer',
         'developer' => 'Developer',
         'startup' => 'Startup',

--- a/lang/es/onboarding.php
+++ b/lang/es/onboarding.php
@@ -9,6 +9,7 @@ return [
     'personas' => [
         'creator' => 'Creador',
         'freelancer' => 'Freelancer',
+        'developer' => 'Desarrollador',
         'startup' => 'Startup',
         'agency' => 'Agencia',
         'small_business' => 'Pequeña empresa',

--- a/lang/es/onboarding.php
+++ b/lang/es/onboarding.php
@@ -13,6 +13,8 @@ return [
         'startup' => 'Startup',
         'agency' => 'Agencia',
         'small_business' => 'Pequeña empresa',
+        'marketer' => 'Marketing',
+        'online_store' => 'Tienda online',
         'other' => 'Otro',
     ],
     'connect' => [

--- a/lang/es/onboarding.php
+++ b/lang/es/onboarding.php
@@ -4,16 +4,16 @@ declare(strict_types=1);
 
 return [
     'title' => 'Bienvenido a TryPost',
-    'description' => 'Cuéntanos qué te describe mejor para personalizar tu experiencia.',
+    'description' => 'Cuéntanos qué te describe mejor a ti o a tu negocio para personalizar tu experiencia.',
     'continue' => 'Continuar',
     'personas' => [
-        'creator' => 'Creador',
+        'creator' => 'Creador de contenido',
         'freelancer' => 'Freelancer',
         'developer' => 'Desarrollador',
         'startup' => 'Startup',
         'agency' => 'Agencia',
         'small_business' => 'Pequeña empresa',
-        'marketer' => 'Marketing',
+        'marketer' => 'Profesional de marketing',
         'online_store' => 'Tienda online',
         'other' => 'Otro',
     ],

--- a/lang/pt-BR/onboarding.php
+++ b/lang/pt-BR/onboarding.php
@@ -9,6 +9,7 @@ return [
     'personas' => [
         'creator' => 'Criador',
         'freelancer' => 'Freelancer',
+        'developer' => 'Desenvolvedor',
         'startup' => 'Startup',
         'agency' => 'Agência',
         'small_business' => 'Pequena empresa',

--- a/lang/pt-BR/onboarding.php
+++ b/lang/pt-BR/onboarding.php
@@ -13,6 +13,8 @@ return [
         'startup' => 'Startup',
         'agency' => 'Agência',
         'small_business' => 'Pequena empresa',
+        'marketer' => 'Marketing',
+        'online_store' => 'Loja online',
         'other' => 'Outro',
     ],
     'connect' => [

--- a/lang/pt-BR/onboarding.php
+++ b/lang/pt-BR/onboarding.php
@@ -4,16 +4,16 @@ declare(strict_types=1);
 
 return [
     'title' => 'Bem-vindo ao TryPost',
-    'description' => 'Conte o que melhor te descreve para personalizarmos sua experiência.',
+    'description' => 'Conte o que melhor descreve você ou seu negócio para personalizarmos sua experiência.',
     'continue' => 'Continuar',
     'personas' => [
-        'creator' => 'Criador',
+        'creator' => 'Criador de conteúdo',
         'freelancer' => 'Freelancer',
         'developer' => 'Desenvolvedor',
         'startup' => 'Startup',
         'agency' => 'Agência',
         'small_business' => 'Pequena empresa',
-        'marketer' => 'Marketing',
+        'marketer' => 'Profissional de marketing',
         'online_store' => 'Loja online',
         'other' => 'Outro',
     ],

--- a/resources/js/pages/onboarding/Index.vue
+++ b/resources/js/pages/onboarding/Index.vue
@@ -6,6 +6,7 @@ import {
     IconBuildingSkyscraper,
     IconBuildingStore,
     IconCheck,
+    IconCode,
     IconDots,
     IconRocket,
     IconUser,
@@ -26,6 +27,7 @@ const form = useForm({ persona: props.selected ?? '' });
 const personaMeta: Record<string, { icon: FunctionalComponent; color: string }> = {
     creator: { icon: IconUser, color: 'text-rose-600' },
     freelancer: { icon: IconBriefcase, color: 'text-amber-600' },
+    developer: { icon: IconCode, color: 'text-cyan-600' },
     startup: { icon: IconRocket, color: 'text-violet-700' },
     agency: { icon: IconBuildingSkyscraper, color: 'text-blue-700' },
     small_business: { icon: IconBuildingStore, color: 'text-emerald-600' },

--- a/resources/js/pages/onboarding/Index.vue
+++ b/resources/js/pages/onboarding/Index.vue
@@ -9,6 +9,8 @@ import {
     IconCode,
     IconDots,
     IconRocket,
+    IconShoppingBag,
+    IconSpeakerphone,
     IconUser,
 } from '@tabler/icons-vue';
 import { trans } from 'laravel-vue-i18n';
@@ -31,6 +33,8 @@ const personaMeta: Record<string, { icon: FunctionalComponent; color: string }> 
     startup: { icon: IconRocket, color: 'text-violet-700' },
     agency: { icon: IconBuildingSkyscraper, color: 'text-blue-700' },
     small_business: { icon: IconBuildingStore, color: 'text-emerald-600' },
+    marketer: { icon: IconSpeakerphone, color: 'text-fuchsia-600' },
+    online_store: { icon: IconShoppingBag, color: 'text-teal-600' },
     other: { icon: IconDots, color: 'text-sky-600' },
 };
 

--- a/tests/Unit/Enums/PersonaTest.php
+++ b/tests/Unit/Enums/PersonaTest.php
@@ -6,7 +6,7 @@ use App\Enums\User\Persona;
 
 test('persona values are stable', function () {
     expect(array_map(fn (Persona $persona): string => $persona->value, Persona::cases()))
-        ->toBe(['creator', 'freelancer', 'startup', 'agency', 'small_business', 'other']);
+        ->toBe(['creator', 'freelancer', 'developer', 'startup', 'agency', 'small_business', 'other']);
 });
 
 test('every persona has an onboarding label in every locale', function (string $locale) {

--- a/tests/Unit/Enums/PersonaTest.php
+++ b/tests/Unit/Enums/PersonaTest.php
@@ -6,7 +6,7 @@ use App\Enums\User\Persona;
 
 test('persona values are stable', function () {
     expect(array_map(fn (Persona $persona): string => $persona->value, Persona::cases()))
-        ->toBe(['creator', 'freelancer', 'developer', 'startup', 'agency', 'small_business', 'other']);
+        ->toBe(['creator', 'freelancer', 'developer', 'startup', 'agency', 'small_business', 'marketer', 'online_store', 'other']);
 });
 
 test('every persona has an onboarding label in every locale', function (string $locale) {


### PR DESCRIPTION
## What
Expands and tidies the onboarding persona step.

## Why
The step lets people pick what describes them, but the set was thin and inconsistent:
- Common audiences (developers, marketers, e-commerce) fell into "Other".
- The options mix individual **roles** (creator, developer) with **organization types** (startup, agency), yet the prompt only asked what describes "you".

## Changes
**New personas** (completing a 3×3 grid):
- **Developer** — a distinct individual role.
- **Marketer** — in-house marketing / social media, a scheduling tool's core user (distinct from Agency, which serves clients).
- **Online store** — e-commerce, a high-intent commercial segment distinct from generic Small business.

**Consistent copy:**
- Broaden the prompt to **"you or your business"** so the role + organization mix reads intentionally.
- **Creator → Content creator**, and **Marketer** gets a proper role label in every locale (es/pt: *Profesional/Profissional de marketing*) so the role group is consistent.

All labels are in en/es/pt-BR. Options flow to the frontend via `Persona::cases()` and are accepted by `Rule::enum(Persona::class)`. "Other" stays last.

Final grid:
```
Content creator   Freelancer     Developer
Startup           Agency         Small business
Marketer          Online store   Other
```

## Tests
`PersonaTest` (stable values + label-in-every-locale across en/es/pt-BR) and `OnboardingControllerTest` pass; Pint and eslint clean.