### PR TITLE
fix(social): stop chunked video uploads from exhausting memory

### DIFF
--- a/app/Services/Social/AbstractLinkedInPublisher.php
+++ b/app/Services/Social/AbstractLinkedInPublisher.php
@@ -370,6 +370,9 @@ abstract class AbstractLinkedInPublisher
                 if ($etag) {
                     $uploadedPartIds[] = $etag;
                 }
+
+                unset($chunkData, $chunkResponse);
+                $this->freeChunkMemory();
             }
         } finally {
             fclose($handle);

--- a/app/Services/Social/Concerns/HasSocialHttpClient.php
+++ b/app/Services/Social/Concerns/HasSocialHttpClient.php
@@ -41,4 +41,16 @@ trait HasSocialHttpClient
     {
         return TokenRedactor::redact($body);
     }
+
+    /**
+     * Reclaim memory between chunks of a streaming upload. Each request's body
+     * and the HTTP client's request/response objects are held alive by reference
+     * cycles the PHP runtime only frees when the cycle collector runs, so a
+     * long chunked upload accumulates the whole file in memory without this.
+     * Callers must `unset()` the chunk and response first.
+     */
+    protected function freeChunkMemory(): void
+    {
+        gc_collect_cycles();
+    }
 }

--- a/app/Services/Social/Concerns/HasSocialHttpClient.php
+++ b/app/Services/Social/Concerns/HasSocialHttpClient.php
@@ -32,7 +32,7 @@ trait HasSocialHttpClient
         return Http::retry(
             times: 3,
             sleepMilliseconds: 5000,
-            when: fn ($exception, $request) => $exception->response?->status() === 429,
+            when: fn ($exception, $request) => ($exception->response ?? null)?->status() === 429,
             throw: false,
         )->timeout(120);
     }

--- a/app/Services/Social/XPublisher.php
+++ b/app/Services/Social/XPublisher.php
@@ -237,11 +237,8 @@ class XPublisher
 
                 $index++;
 
-                // The HTTP client/retry wrapper keeps each segment's body alive
-                // through reference cycles, so without forcing collection a large
-                // video accumulates its full size in memory and exhausts the limit.
                 unset($chunk, $appendResponse);
-                gc_collect_cycles();
+                $this->freeChunkMemory();
             }
         } finally {
             fclose($handle);

--- a/app/Services/Social/XPublisher.php
+++ b/app/Services/Social/XPublisher.php
@@ -236,6 +236,12 @@ class XPublisher
                 }
 
                 $index++;
+
+                // The HTTP client/retry wrapper keeps each segment's body alive
+                // through reference cycles, so without forcing collection a large
+                // video accumulates its full size in memory and exhausts the limit.
+                unset($chunk, $appendResponse);
+                gc_collect_cycles();
             }
         } finally {
             fclose($handle);

--- a/app/Services/Social/YouTubePublisher.php
+++ b/app/Services/Social/YouTubePublisher.php
@@ -167,9 +167,6 @@ class YouTubePublisher
             while (! $uploadStatus && ! feof($handle)) {
                 $chunk = fread($handle, self::CHUNK_SIZE);
                 $uploadStatus = $mediaUpload->nextChunk($chunk);
-
-                unset($chunk);
-                $this->freeChunkMemory();
             }
 
             fclose($handle);

--- a/app/Services/Social/YouTubePublisher.php
+++ b/app/Services/Social/YouTubePublisher.php
@@ -167,6 +167,9 @@ class YouTubePublisher
             while (! $uploadStatus && ! feof($handle)) {
                 $chunk = fread($handle, self::CHUNK_SIZE);
                 $uploadStatus = $mediaUpload->nextChunk($chunk);
+
+                unset($chunk);
+                $this->freeChunkMemory();
             }
 
             fclose($handle);

--- a/tests/Feature/Services/Social/LinkedInPublisherTest.php
+++ b/tests/Feature/Services/Social/LinkedInPublisherTest.php
@@ -431,6 +431,75 @@ test('linkedin publisher can publish post with video', function () {
     Http::assertSent(fn ($request) => str_contains($request->url(), '/rest/posts'));
 });
 
+test('linkedin publisher uploads a video across multiple chunks', function () {
+    $this->post->update([
+        'media' => [
+            [
+                'id' => 'test-media-video',
+                'path' => 'media/2026-01/test-video.mp4',
+                'url' => 'https://example.com/media/2026-01/test-video.mp4',
+                'mime_type' => 'video/mp4',
+                'original_filename' => 'test-video.mp4',
+            ],
+        ],
+    ]);
+
+    $chunkBase = 'https://www.linkedin.com/dms/upload/v2/chunk/video/';
+    $chunkPuts = 0;
+
+    Http::fake(function ($request) use ($chunkBase, &$chunkPuts) {
+        $url = $request->url();
+
+        if (str_contains($url, 'initializeUpload') && str_contains($url, '/rest/videos')) {
+            return Http::response([
+                'value' => [
+                    'video' => 'urn:li:video:FakeVideoUrn',
+                    'uploadToken' => 'upload-token-abc',
+                    'uploadInstructions' => [
+                        ['uploadUrl' => $chunkBase.'0', 'firstByte' => 0, 'lastByte' => 1023],
+                        ['uploadUrl' => $chunkBase.'1', 'firstByte' => 1024, 'lastByte' => 2047],
+                        ['uploadUrl' => $chunkBase.'2', 'firstByte' => 2048, 'lastByte' => 3071],
+                    ],
+                ],
+            ], 200);
+        }
+
+        if (str_starts_with($url, $chunkBase)) {
+            $chunkPuts++;
+
+            return Http::response(null, 200, ['etag' => '"etag-'.$chunkPuts.'"']);
+        }
+
+        if (str_contains($url, 'finalizeUpload') && str_contains($url, '/rest/videos')) {
+            return Http::response(null, 200);
+        }
+
+        if (str_contains($url, '/rest/videos/')) {
+            return Http::response(['status' => 'AVAILABLE'], 200);
+        }
+
+        if (str_contains($url, '/rest/posts')) {
+            return Http::response(null, 201, ['x-restli-id' => 'urn:li:share:multichunk']);
+        }
+
+        return Http::response(str_repeat('x', 4096), 200);
+    });
+
+    $result = $this->publisher->publish($this->postPlatform);
+
+    expect($result['id'])->toBe('urn:li:share:multichunk');
+    expect($chunkPuts)->toBe(3);
+
+    // All three chunk etags are collected and sent to finalize.
+    Http::assertSent(function ($request) {
+        if (! str_contains($request->url(), 'finalizeUpload')) {
+            return false;
+        }
+
+        return count(data_get($request->data(), 'finalizeUploadRequest.uploadedPartIds', [])) === 3;
+    });
+});
+
 test('linkedin publisher can publish a document (pdf carousel) with a title', function () {
     $this->postPlatform->update([
         'content_type' => ContentType::LinkedInPost,

--- a/tests/Feature/Services/Social/XPublisherTest.php
+++ b/tests/Feature/Services/Social/XPublisherTest.php
@@ -304,3 +304,52 @@ test('x publisher uploads video via chunked upload', function () {
     Http::assertSent(fn ($request) => str_contains($request->url(), '/finalize'));
     Http::assertSent(fn ($request) => str_contains($request->url(), '/2/tweets'));
 });
+
+test('x publisher uploads a large video in sequential 1MB segments', function () {
+    $this->post->update([
+        'media' => [
+            [
+                'id' => 'test-media-video',
+                'path' => 'media/2026-01/big-video.mp4',
+                'url' => 'https://example.com/media/2026-01/big-video.mp4',
+                'mime_type' => 'video/mp4',
+                'original_filename' => 'big-video.mp4',
+            ],
+        ],
+    ]);
+
+    $appendCount = 0;
+
+    Http::fake(function ($request) use (&$appendCount) {
+        $url = $request->url();
+
+        if (str_contains($url, '/2/media/upload/initialize')) {
+            return Http::response(['data' => ['id' => 'media_id_999']], 200);
+        }
+
+        if (str_contains($url, '/append')) {
+            $appendCount++;
+
+            return Http::response(null, 204);
+        }
+
+        if (str_contains($url, '/finalize')) {
+            return Http::response(['data' => ['id' => 'media_id_999']], 200);
+        }
+
+        if (str_contains($url, '/2/media/')) {
+            return Http::response(['processing_info' => ['state' => 'succeeded']], 200);
+        }
+
+        if (str_contains($url, '/2/tweets')) {
+            return Http::response(['data' => ['id' => '9876543210987654321', 'text' => 'Hello from X!']], 200);
+        }
+
+        // ~2.5MB download -> at least three 1MB segments.
+        return Http::response(str_repeat('x', (int) (2.5 * 1024 * 1024)), 200);
+    });
+
+    $this->publisher->publish($this->postPlatform);
+
+    expect($appendCount)->toBeGreaterThan(1);
+});


### PR DESCRIPTION
## The bug

A user hit `Allowed memory size of 536870912 bytes exhausted` uploading a **49MB** video to X. The size wasn't the problem — a memory leak in the chunked-upload loop was.

## Root cause (reproduced with the real 49MB file)

The leak is in **Laravel's HTTP client layer** (`PendingRequest`/`Response`/`Http::retry`), not Guzzle: in a per-chunk request loop those objects are held alive by reference cycles PHP's GC doesn't reclaim mid-loop, so memory grows linearly with the video. Measured over the real file against a local HTTP server (no `Http::fake`, which records requests and would skew the numbers):

| Path | Before | After |
|---|---|---|
| X (`Http::retry`) | ~242MB for 49MB | **flat ~50MB** |
| LinkedIn (`Http::withToken`) | ~146MB for 49MB | **flat ~48MB** |
| Raw Guzzle (baseline) | flat ~42MB | — |
| `Google\Client::execute` (YouTube) | flat ~42MB | — |

In production the higher baseline pushed the leaking paths past 512MB.

## Fix

Centralized as `freeChunkMemory()` on the shared `HasSocialHttpClient` trait (`gc_collect_cycles()`); each loop `unset()`s the chunk/response and calls it. Applied to **X** and **LinkedIn** (the company-page publisher shares the same base loop).

Also hardens `socialHttp()`'s retry predicate, which read `$exception->response` directly and fatals on exceptions without a response (e.g. a `ConnectionException` during a long upload), masking the real error.

## Full audit — every network

| Network | Upload mechanism | Leak? | Status |
|---|---|---|---|
| X | per-chunk loop via Laravel HTTP | yes (reproduced) | **fixed + tested** |
| LinkedIn (profile + page) | per-chunk loop via Laravel HTTP | yes (reproduced) | **fixed + tested** |
| YouTube | per-chunk loop via Google SDK (raw Guzzle) | **no — measured flat (42MB)** | safe, no change |
| TikTok | `PULL_FROM_URL` | no | safe |
| Instagram / Instagram-Facebook | `video_url` container | no | safe |
| Threads | `video_url` container | no | safe |
| Facebook | reels stream / stories URL | no | safe |
| Bluesky | single streamed POST from disk | no | safe |
| Mastodon | single streamed POST from disk | no | safe |
| Pinterest | video streamed (single request) | no | safe |
| Telegram / Discord | no chunked video upload | no | safe |

### Why YouTube needs no fix (verified, not assumed)

YouTube uploads through `Google\Http\MediaFileUpload::nextChunk()`, which builds a fresh request per chunk and sends it via the Google API client's own Guzzle — it doesn't retain the chunk. Measured both raw Guzzle and `Google\Client::execute` looping 1MB PUTs over the real 49MB file: memory stays flat (~42MB). The leak is specific to Laravel's HTTP wrapper, which YouTube bypasses.

## Tests

- X: a video is split into multiple sequential APPEND segments.
- LinkedIn: a video is uploaded across multiple chunks (etags collected into finalize).

These exercise the loops across several iterations. They assert the loops behave correctly; they don't assert memory flatness, because `Http::fake` records every request (its own growth) and would mask the fix — the memory result is verified by the reproductions above. All 307 social-publisher tests pass.