### PR TITLE
chore(release): add v1.0.5 changelog + customer email artifacts

### DIFF
--- a/releases/v1.0.5/changelog.md
+++ b/releases/v1.0.5/changelog.md
@@ -1,0 +1,10 @@
+## What's Changed
+* chore(release): add v1.0.4 changelog artifacts by @paulocastellano in https://github.com/trypostit/trypost/pull/109
+* feat(bluesky): support video upload and embedding by @Schrall in https://github.com/trypostit/trypost/pull/110
+* feat(onboarding): expand persona options and make the labels consistent by @paulocastellano in https://github.com/trypostit/trypost/pull/111
+* feat(linkedin): PDF documents, media-inferred post format, and unified connection by @paulocastellano in https://github.com/trypostit/trypost/pull/112
+* feat(onboarding): add goal step after persona by @paulocastellano in https://github.com/trypostit/trypost/pull/115
+* fix(social): stop chunked video uploads from exhausting memory by @paulocastellano in https://github.com/trypostit/trypost/pull/116
+
+
+**Full Changelog**: https://github.com/trypostit/trypost/compare/v1.0.4...v1.0.5

--- a/releases/v1.0.5/email.md
+++ b/releases/v1.0.5/email.md
@@ -28,10 +28,6 @@ Discord is a channel now. Connect a server, pick the exact channel, add mentions
 
 Generating a post with AI starts with picking a format now: a single image card, a carousel, or a tweet-style card (one even comes with a verified badge, and one sits on a photo background). You pick the visual style on the same screen, and these templates work inside automations too, so your scheduled content can use them.
 
-## A smoother start
-
-Signing up is quicker, with Google and GitHub up front and your first workspace created for you. When you join, we ask two quick things: what best describes you, and what you want to get done with TryPost. There are more ways to describe yourself too, with Developer, Marketer, and Online store added to the list. On the brand settings page, you can pull your brand details straight from your website instead of typing them out.
-
 ## New features
 
 - Post swipeable PDF carousels to LinkedIn, and preview PDFs without leaving the editor
@@ -40,8 +36,6 @@ Signing up is quicker, with Google and GitHub up front and your first workspace 
 - Publish straight to Discord channels and groups
 - AI post formats: image cards, carousels, and tweet-style cards
 - RSS and Atom automations that pull variables from the feed
-- Tell us your goals at signup, plus new personas (Developer, Marketer, Online store)
-- Fill your brand details from your website
 
 ## Fixes
 
@@ -52,7 +46,7 @@ Signing up is quicker, with Google and GitHub up front and your first workspace 
 - Per-platform settings (aspect ratio, TikTok privacy, Pinterest boards, Discord channel) carry through the API and MCP now, not just the app
 - Telegram connection problems show a clear message instead of failing quietly
 
-Questions or ideas? Come hang out in our [Discord](https://trypost.it/discord).
+Questions or ideas? Join the conversation in [GitHub Discussions](https://github.com/orgs/trypostit/discussions).
 
 Cheers,
 Paulo from TryPost.it

--- a/releases/v1.0.5/email.md
+++ b/releases/v1.0.5/email.md
@@ -1,12 +1,12 @@
 ---
-subject: "Changelog v1.0.5 — LinkedIn PDF carousels, better video, smoother onboarding"
+subject: "Changelog v1.0.5 — LinkedIn PDFs, video, team roles, Discord posting & more"
 ---
 
-# Changelog v1.0.5 — LinkedIn PDF carousels, better video, smoother onboarding
+# Changelog v1.0.5 — LinkedIn PDFs, video, team roles, Discord posting & more
 
 By TryPost Product Team • [Release v1.0.5](https://github.com/trypostit/trypost/releases/tag/v1.0.5)
 
-Hello! Welcome to this week's update. Here's what's new in TryPost.
+Hey! It's been a few weeks since the last roundup, so this one covers a bigger stretch. Here's everything that's shipped in TryPost.
 
 ## LinkedIn PDF carousels
 
@@ -16,24 +16,41 @@ You can now post swipeable PDF documents to LinkedIn, the same format people act
 
 Bluesky now handles video: upload a clip and it embeds natively in your post. We also made video uploads steadier everywhere. Large videos to X and LinkedIn were failing with memory errors, and that's sorted now. Pinterest video pins get a cover image on their own, and YouTube Shorts can't be scheduled without the text that becomes their title, so they stop failing at publish time.
 
+## Team roles and client review
+
+You can invite people into a workspace with a role that fits: Admin, Member, or Viewer. Viewers are read-only, but they can open any post and leave comments. This is the one I'm most excited about: hand a client or a manager a Viewer seat, let them review what's scheduled, and collect their feedback right on the post, with no risk of them changing something. Members handle the day-to-day, while connecting accounts and managing the team stays with Admins and the owner.
+
+## Post straight to Discord, smarter automations
+
+Discord is a channel now. Connect a server, pick the exact channel, add mentions, and check a live preview before it goes out, with Discord engagement flowing into your metrics like everything else. Automations got smarter too: they read both RSS and Atom feeds, and you can pull dynamic variables straight from a feed so each item templates itself instead of being copied by hand.
+
+## AI content templates
+
+Generating a post with AI now starts with picking a format: a single image card, a carousel, or a tweet-style card (there's even one with a verified badge, and one on a photo background). You choose the visual style on the same screen, and these templates show up inside automations too, so your scheduled content can use them.
+
 ## A smoother start
 
-When you sign up, we now ask two quick things: what best describes you, and what you're hoping to get done with TryPost. There are more ways to describe yourself too, with Developer, Marketer, and Online store added to the list. It takes a few seconds and helps us shape the product around what you actually came for.
+Signing up is quicker, with Google and GitHub front and center and your first workspace created for you. We now ask two quick things when you join: what best describes you, and what you're hoping to get done with TryPost. There are more ways to describe yourself too, with Developer, Marketer, and Online store added to the list. On the brand settings page, you can also pull your brand details straight from your website instead of typing them out.
 
 ## New features
 
-- Post swipeable PDF carousels (documents) to LinkedIn
+- Post swipeable PDF carousels to LinkedIn, and preview PDFs without leaving the editor
 - Upload and embed videos on Bluesky
-- Preview PDFs without leaving the editor
-- Tell us your goals at signup so we can tailor things to you
-- New personas to pick from: Developer, Marketer, and Online store
+- Invite clients or stakeholders as Viewers, who can review and comment but not edit
+- Publish straight to Discord channels and groups
+- AI post formats: image cards, carousels, and tweet-style cards
+- RSS and Atom automations with dynamic variables pulled from the feed
+- Tell us your goals at signup, plus new personas (Developer, Marketer, Online store)
+- Fill your brand details from your website
 
 ## Fixes
 
 - Large video uploads to X and LinkedIn no longer run out of memory
-- Pinterest video pins now publish with a cover image automatically
+- Pinterest video pins publish with a cover image automatically
 - YouTube Shorts can no longer be scheduled without their title text
 - An image and a video can no longer be combined in the same post
+- Per-platform settings (aspect ratio, TikTok privacy, Pinterest boards, Discord channel) now carry through the API and MCP, not just the app
+- Telegram connection problems show a clear message instead of failing quietly
 
 Questions or ideas? Come hang out in our [Discord](https://trypost.it/discord).
 

--- a/releases/v1.0.5/email.md
+++ b/releases/v1.0.5/email.md
@@ -1,0 +1,41 @@
+---
+subject: "Changelog v1.0.5 — LinkedIn PDF carousels, better video, smoother onboarding"
+---
+
+# Changelog v1.0.5 — LinkedIn PDF carousels, better video, smoother onboarding
+
+By TryPost Product Team • [Release v1.0.5](https://github.com/trypostit/trypost/releases/tag/v1.0.5)
+
+Hello! Welcome to this week's update. Here's what's new in TryPost.
+
+## LinkedIn PDF carousels
+
+You can now post swipeable PDF documents to LinkedIn, the same format people actually stop to read. Attach a PDF and TryPost picks the right post type for you, with no extra settings to fiddle with. You can also preview PDFs straight from the media gallery, so you don't have to open them in a new tab just to check you grabbed the right file.
+
+## Better video publishing
+
+Bluesky now handles video: upload a clip and it embeds natively in your post. We also made video uploads steadier everywhere. Large videos to X and LinkedIn were failing with memory errors, and that's sorted now. Pinterest video pins get a cover image on their own, and YouTube Shorts can't be scheduled without the text that becomes their title, so they stop failing at publish time.
+
+## A smoother start
+
+When you sign up, we now ask two quick things: what best describes you, and what you're hoping to get done with TryPost. There are more ways to describe yourself too, with Developer, Marketer, and Online store added to the list. It takes a few seconds and helps us shape the product around what you actually came for.
+
+## New features
+
+- Post swipeable PDF carousels (documents) to LinkedIn
+- Upload and embed videos on Bluesky
+- Preview PDFs without leaving the editor
+- Tell us your goals at signup so we can tailor things to you
+- New personas to pick from: Developer, Marketer, and Online store
+
+## Fixes
+
+- Large video uploads to X and LinkedIn no longer run out of memory
+- Pinterest video pins now publish with a cover image automatically
+- YouTube Shorts can no longer be scheduled without their title text
+- An image and a video can no longer be combined in the same post
+
+Questions or ideas? Come hang out in our [Discord](https://trypost.it/discord).
+
+Cheers,
+Paulo from TryPost.it

--- a/releases/v1.0.5/email.md
+++ b/releases/v1.0.5/email.md
@@ -6,31 +6,31 @@ subject: "Changelog v1.0.5 — LinkedIn PDFs, video, team roles, Discord posting
 
 By TryPost Product Team • [Release v1.0.5](https://github.com/trypostit/trypost/releases/tag/v1.0.5)
 
-Hey! It's been a few weeks since the last roundup, so this one covers a bigger stretch. Here's everything that's shipped in TryPost.
+Hey, it's been a few weeks, so this is a bigger catch-up than usual. Here's everything that's shipped in TryPost.
 
 ## LinkedIn PDF carousels
 
-You can now post swipeable PDF documents to LinkedIn, the same format people actually stop to read. Attach a PDF and TryPost picks the right post type for you, with no extra settings to fiddle with. You can also preview PDFs straight from the media gallery, so you don't have to open them in a new tab just to check you grabbed the right file.
+You can post swipeable PDF carousels to LinkedIn now, the format people actually stop to read. Attach a PDF and TryPost sets the post up as a document for you, with nothing extra to configure. You can also preview PDFs right in the media gallery, so you don't have to open them in a new tab to check you grabbed the right file.
 
 ## Better video publishing
 
-Bluesky now handles video: upload a clip and it embeds natively in your post. We also made video uploads steadier everywhere. Large videos to X and LinkedIn were failing with memory errors, and that's sorted now. Pinterest video pins get a cover image on their own, and YouTube Shorts can't be scheduled without the text that becomes their title, so they stop failing at publish time.
+Bluesky handles video now: upload a clip and it embeds natively in your post. We also made video uploads steadier everywhere. Big videos to X and LinkedIn were failing with memory errors, and that's fixed. Pinterest video pins get a cover image on their own, and YouTube Shorts can't be scheduled without the text that becomes their title, so they stop failing at publish time.
 
 ## Team roles and client review
 
-You can invite people into a workspace with a role that fits: Admin, Member, or Viewer. Viewers are read-only, but they can open any post and leave comments. This is the one I'm most excited about: hand a client or a manager a Viewer seat, let them review what's scheduled, and collect their feedback right on the post, with no risk of them changing something. Members handle the day-to-day, while connecting accounts and managing the team stays with Admins and the owner.
+You can invite people into a workspace with the right role: Admin, Member, or Viewer. Viewers are read-only, but they can open any post and leave comments. This is the one I'm most excited about: give a client or a manager a Viewer seat, let them review what's scheduled, and collect their feedback right on the post, with no chance of them changing something by accident. Members run the day-to-day, while connecting accounts and managing the team stays with Admins and the owner.
 
 ## Post straight to Discord, smarter automations
 
-Discord is a channel now. Connect a server, pick the exact channel, add mentions, and check a live preview before it goes out, with Discord engagement flowing into your metrics like everything else. Automations got smarter too: they read both RSS and Atom feeds, and you can pull dynamic variables straight from a feed so each item templates itself instead of being copied by hand.
+Discord is a channel now. Connect a server, pick the exact channel, add mentions, and check a live preview before it goes out, and Discord engagement shows up in your metrics like everything else. Automations got smarter too: they read both RSS and Atom feeds now, and you can pull variables straight from a feed, so each item fills in its own post instead of you copying them by hand.
 
 ## AI content templates
 
-Generating a post with AI now starts with picking a format: a single image card, a carousel, or a tweet-style card (there's even one with a verified badge, and one on a photo background). You choose the visual style on the same screen, and these templates show up inside automations too, so your scheduled content can use them.
+Generating a post with AI starts with picking a format now: a single image card, a carousel, or a tweet-style card (one even comes with a verified badge, and one sits on a photo background). You pick the visual style on the same screen, and these templates work inside automations too, so your scheduled content can use them.
 
 ## A smoother start
 
-Signing up is quicker, with Google and GitHub front and center and your first workspace created for you. We now ask two quick things when you join: what best describes you, and what you're hoping to get done with TryPost. There are more ways to describe yourself too, with Developer, Marketer, and Online store added to the list. On the brand settings page, you can also pull your brand details straight from your website instead of typing them out.
+Signing up is quicker, with Google and GitHub up front and your first workspace created for you. When you join, we ask two quick things: what best describes you, and what you want to get done with TryPost. There are more ways to describe yourself too, with Developer, Marketer, and Online store added to the list. On the brand settings page, you can pull your brand details straight from your website instead of typing them out.
 
 ## New features
 
@@ -39,17 +39,17 @@ Signing up is quicker, with Google and GitHub front and center and your first wo
 - Invite clients or stakeholders as Viewers, who can review and comment but not edit
 - Publish straight to Discord channels and groups
 - AI post formats: image cards, carousels, and tweet-style cards
-- RSS and Atom automations with dynamic variables pulled from the feed
+- RSS and Atom automations that pull variables from the feed
 - Tell us your goals at signup, plus new personas (Developer, Marketer, Online store)
 - Fill your brand details from your website
 
 ## Fixes
 
-- Large video uploads to X and LinkedIn no longer run out of memory
+- Big video uploads to X and LinkedIn no longer run out of memory
 - Pinterest video pins publish with a cover image automatically
-- YouTube Shorts can no longer be scheduled without their title text
-- An image and a video can no longer be combined in the same post
-- Per-platform settings (aspect ratio, TikTok privacy, Pinterest boards, Discord channel) now carry through the API and MCP, not just the app
+- YouTube Shorts can't be scheduled without their title text anymore
+- An image and a video can't be combined in the same post anymore
+- Per-platform settings (aspect ratio, TikTok privacy, Pinterest boards, Discord channel) carry through the API and MCP now, not just the app
 - Telegram connection problems show a clear message instead of failing quietly
 
 Questions or ideas? Come hang out in our [Discord](https://trypost.it/discord).


### PR DESCRIPTION
Local mirrors for the v1.0.5 release: the GitHub-native changelog and the customer-facing email draft.

- `releases/v1.0.5/changelog.md` — PR-level changelog (mirrors the GitHub release).
- `releases/v1.0.5/email.md` — Cal.com-style customer email draft.

Tag `v1.0.5` and the [GitHub release](https://github.com/trypostit/trypost/releases/tag/v1.0.5) are already published; this just preserves the artifacts in the repo.