### PR TITLE
fix(media): don't 500 when the Unsplash/Giphy key is set to null

### DIFF
--- a/app/Services/GiphyService.php
+++ b/app/Services/GiphyService.php
@@ -15,7 +15,7 @@ class GiphyService
 
     public function __construct()
     {
-        $this->apiKey = config('services.giphy.api_key', '');
+        $this->apiKey = (string) config('services.giphy.api_key', '');
     }
 
     /**

--- a/app/Services/UnsplashService.php
+++ b/app/Services/UnsplashService.php
@@ -15,7 +15,7 @@ class UnsplashService
 
     public function __construct()
     {
-        $this->accessKey = config('services.unsplash.access_key', '');
+        $this->accessKey = (string) config('services.unsplash.access_key', '');
     }
 
     /**

--- a/tests/Unit/Services/MediaSearchKeyFallbackTest.php
+++ b/tests/Unit/Services/MediaSearchKeyFallbackTest.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Services\GiphyService;
+use App\Services\UnsplashService;
+
+test('unsplash service tolerates a null access key without throwing', function () {
+    config(['services.unsplash.access_key' => null]);
+
+    $result = (new UnsplashService)->search('cats');
+
+    expect($result)->toBe(['results' => [], 'total' => 0, 'total_pages' => 0]);
+});
+
+test('giphy service tolerates a null api key without throwing', function () {
+    config(['services.giphy.api_key' => null]);
+
+    $result = (new GiphyService)->search('cats');
+
+    expect($result)->toBe(['results' => [], 'total' => 0, 'total_pages' => 0]);
+});


### PR DESCRIPTION
## Problem

`config('services.unsplash.access_key', '')` only falls back to `''` when the
key is **absent**. If the env var is present but empty, `config()` returns
`null`, and assigning `null` to the `string` property throws a `TypeError` in the
constructor — taking the whole request down with a 500 during media search.
`GiphyService` has the same issue with `services.giphy.api_key`.

## Fix

Cast to `(string)` so a null/empty key degrades gracefully to `''`. Both services
already return an empty result set when the key is empty (`if (empty(...))`), so
this restores that intended behavior instead of throwing.

## Tests

`MediaSearchKeyFallbackTest` — constructing each service with a `null` key and
calling `search()` returns an empty result set without throwing.