### PR TITLE
feat(prompts): make 'no em/en dashes' an explicit rule in the content prompts

### DIFF
--- a/resources/views/prompts/post_content/generator.blade.php
+++ b/resources/views/prompts/post_content/generator.blade.php
@@ -22,6 +22,7 @@ Rules:
 - Avoid AI-clichés (testament, pivotal moment, emojis on every line, "Let's dive in").
 - Keep paragraphs short. Vary sentence rhythm.
 - If the user mentions a specific platform, follow that platform's typical conventions.
+- NEVER use em dashes or en dashes (— or –). They read as AI-written. Rewrite with a comma, parentheses, a colon, or two separate sentences. Regular hyphens in compound words (e.g. "e-mail") are fine.
 @if(!empty($target_chars))
 
 CRITICAL — length for {{ $platform_label ?? 'the target platform' }}:

--- a/resources/views/prompts/post_content/humanizer.blade.php
+++ b/resources/views/prompts/post_content/humanizer.blade.php
@@ -48,8 +48,8 @@ LLMs force ideas into groups of three. If three items don't add value, use one o
 **False ranges:**
 "from X to Y" where X and Y aren't on a meaningful scale — just list them.
 
-**Em dashes (—):**
-LLMs overuse them. Most can be commas, periods, or parentheses.
+**Em dashes and en dashes (top priority):**
+The single most recognizable AI-tell. Remove EVERY one. Rewrite with a comma, parentheses, a colon, or split into two sentences. Regular hyphens in compound words (e.g. "e-mail") are fine. The final output must contain zero — and – characters.
 
 **Curly quotes:**
 Replace " " ' ' with straight " "  ' '.
@@ -85,6 +85,7 @@ Replace " " ' ' with straight " "  ' '.
 6. **Match the brand voice.** If brand voice traits were provided, mirror their rhythm and word choices.
 7. **Preserve meaning.** The core message and any specific facts/numbers/claims stay intact.
 8. **Match the original length roughly.** Don't dramatically expand or shrink the input — humanize, don't rewrite into a different post.
+9. **Never leave em dashes or en dashes (— or –).** They are the most recognizable AI-tell. Remove them; rewrite with a comma, parentheses, a colon, or two separate sentences. Regular hyphens in compound words (e.g. "e-mail") are fine.
 
 ## Input you'll receive
 

--- a/resources/views/prompts/post_content/humanizer.blade.php
+++ b/resources/views/prompts/post_content/humanizer.blade.php
@@ -85,7 +85,6 @@ Replace " " ' ' with straight " "  ' '.
 6. **Match the brand voice.** If brand voice traits were provided, mirror their rhythm and word choices.
 7. **Preserve meaning.** The core message and any specific facts/numbers/claims stay intact.
 8. **Match the original length roughly.** Don't dramatically expand or shrink the input — humanize, don't rewrite into a different post.
-9. **Never leave em dashes or en dashes (— or –).** They are the most recognizable AI-tell. Remove them; rewrite with a comma, parentheses, a colon, or two separate sentences. Regular hyphens in compound words (e.g. "e-mail") are fine.
 
 ## Input you'll receive
 

--- a/resources/views/prompts/post_content/humanizer.blade.php
+++ b/resources/views/prompts/post_content/humanizer.blade.php
@@ -96,4 +96,6 @@ For carousel input: humanize the `caption`, and each slide's `title` and `body`.
 For single-post input: humanize the `content` field.
 @endif
 
+FINAL CHECK before replying: scan every text field of your JSON output for em dash (—) and en dash (–) characters. If even one remains, rewrite that sentence using a comma, parentheses, a colon, or two separate sentences, until none are left. A response that still contains a — or – is a failed response. Return your answer only after zero remain.
+
 Reply with the JSON object only, no preamble.

--- a/resources/views/prompts/post_content/reviewer.blade.php
+++ b/resources/views/prompts/post_content/reviewer.blade.php
@@ -16,4 +16,5 @@ Rules:
 - Each `reason` is a 1-line explanation in the output language.
 - If the text is fine, return an empty `suggestions` array.
 - Do NOT propose stylistic changes. ONLY grammar, spelling, and clarity.
+- EXCEPTION: ALWAYS flag every em dash and en dash (— –) with a suggestion that replaces it (comma, parentheses, colon, or a period + new sentence). Removing em/en dashes is a hard rule, not optional style.
 - Maximum 8 suggestions per request. Prioritize the most important ones.


### PR DESCRIPTION
## Problem

Em and en dashes (— –) are the most recognizable AI-tell in generated text. The
generator prompt had no rule against them, and the humanizer only mentioned them
weakly ("LLMs overuse them. Most can be commas, periods, or parentheses.").

## Change

- **generator** — explicit rule to never use em/en dashes: rewrite with a comma,
  parentheses, a colon, or two separate sentences. Regular hyphens in compound
  words (e.g. "e-mail") stay fine.
- **humanizer** — strengthen the existing em-dash note into a top-priority
  removal rule (also covering en dashes) and add it to the numbered rewrite
  checklist.
- **reviewer** — always flag every em/en dash with a concrete replacement
  suggestion, as a hard rule rather than optional style.