### PR TITLE
fix(workspace): default content_language to the app locale, not 'en'

### DIFF
--- a/app/Actions/Workspace/CreateWorkspace.php
+++ b/app/Actions/Workspace/CreateWorkspace.php
@@ -24,7 +24,7 @@ class CreateWorkspace
             'brand_color' => data_get($data, 'brand_color'),
             'background_color' => data_get($data, 'background_color'),
             'text_color' => data_get($data, 'text_color'),
-            'content_language' => data_get($data, 'content_language'),
+            'content_language' => data_get($data, 'content_language', app()->getLocale()),
         ], static fn ($value): bool => $value !== null);
 
         $workspace = DB::transaction(function () use ($user, $attributes): Workspace {

--- a/tests/Feature/Actions/Workspace/CreateWorkspaceTest.php
+++ b/tests/Feature/Actions/Workspace/CreateWorkspaceTest.php
@@ -42,6 +42,28 @@ test('CreateWorkspace switches user current workspace and attaches as admin', fu
     expect($member?->pivot->role)->toBe(Role::Admin->value);
 });
 
+test('CreateWorkspace inherits the app locale as content_language when none is given', function () {
+    app()->setLocale('pt-BR');
+
+    $account = Account::factory()->create();
+    $user = User::factory()->create(['account_id' => $account->id]);
+
+    $workspace = CreateWorkspace::execute($user, ['name' => 'Acme']);
+
+    expect($workspace->content_language)->toBe('pt-BR');
+});
+
+test('CreateWorkspace keeps an explicit content_language over the app locale', function () {
+    app()->setLocale('pt-BR');
+
+    $account = Account::factory()->create();
+    $user = User::factory()->create(['account_id' => $account->id]);
+
+    $workspace = CreateWorkspace::execute($user, ['name' => 'Acme', 'content_language' => 'es']);
+
+    expect($workspace->content_language)->toBe('es');
+});
+
 test('CreateWorkspace ignores unknown extra keys like logo_url', function () {
     $account = Account::factory()->create();
     $user = User::factory()->create(['account_id' => $account->id]);


### PR DESCRIPTION
## Problem

When a workspace is created without an explicit `content_language`,
`data_get($data, 'content_language')` returns `null`, `array_filter` drops the
key, and the column falls back to its DB default of `'en'`. So AI content and
notifications came out in English even when the app was running in another
locale.

## Fix

Default to `app()->getLocale()`:

```php
'content_language' => data_get($data, 'content_language', app()->getLocale()),
```

Since `getLocale()` is never null, `array_filter` keeps the key and a new
workspace inherits the user's current language. An explicit `content_language`
still wins.

## Tests

`CreateWorkspaceTest` — a workspace with no `content_language` inherits the app
locale (`pt-BR`), and an explicit value (`es`) is kept over the locale.