### PR TITLE
fix(tracking): fire begin_checkout when onboarding checkout starts

### DIFF
--- a/app/Http/Controllers/App/OnboardingController.php
+++ b/app/Http/Controllers/App/OnboardingController.php
@@ -150,9 +150,15 @@ class OnboardingController extends Controller
                 'network' => $platform->network(),
             ])->values();
 
+        $plan = Plan::where('slug', Slug::Workspace)->firstOrFail();
+
         return Inertia::render('onboarding/Connect', [
             'platforms' => $platforms,
             'accounts' => SocialAccountResource::collection($accounts)->resolve(),
+            'plan' => [
+                'name' => $plan->name,
+                'interval' => 'monthly',
+            ],
         ]);
     }
 

--- a/resources/js/pages/onboarding/Connect.vue
+++ b/resources/js/pages/onboarding/Connect.vue
@@ -9,13 +9,17 @@ import NetworkConnectGrid, {
     type ConnectedAccount,
 } from '@/components/accounts/NetworkConnectGrid.vue';
 import { Button } from '@/components/ui/button';
+import { useTracking } from '@/composables/useTracking';
 
 const props = defineProps<{
     platforms: AvailablePlatform[];
     accounts: ConnectedAccount[];
+    plan: { name: string; interval: string };
 }>();
 
 const form = useForm({});
+
+const { trackBeginCheckout } = useTracking();
 
 const hasConnected = computed((): boolean => props.accounts.length > 0);
 
@@ -23,6 +27,8 @@ const submit = (): void => {
     if (!hasConnected.value || form.processing) {
         return;
     }
+
+    trackBeginCheckout({ name: props.plan.name, interval: props.plan.interval });
 
     form.post(checkout.url());
 };

--- a/tests/Feature/Onboarding/OnboardingControllerTest.php
+++ b/tests/Feature/Onboarding/OnboardingControllerTest.php
@@ -263,6 +263,22 @@ test('connect renders the network grid for an unsubscribed account that picked a
     );
 });
 
+test('connect passes the workspace plan so the client can fire begin_checkout', function () {
+    $this->user->update(['persona' => Persona::Agency->value, 'goals' => [Goal::SaveTime->value]]);
+    onboardingWorkspace($this->user);
+
+    $plan = Plan::where('slug', Slug::Workspace)->firstOrFail();
+
+    $response = $this->actingAs($this->user->fresh())->get(route('app.onboarding.connect'));
+
+    $response->assertOk();
+    $response->assertInertia(fn ($page) => $page
+        ->component('onboarding/Connect')
+        ->where('plan.name', $plan->name)
+        ->where('plan.interval', 'monthly')
+    );
+});
+
 test('connect offers a single linkedin card and no standalone linkedin page card', function () {
     $this->user->update(['persona' => Persona::Agency->value, 'goals' => [Goal::SaveTime->value]]);
     onboardingWorkspace($this->user);


### PR DESCRIPTION
## Problema

`trackBeginCheckout()` (em `resources/js/composables/useTracking.ts`) estava definido mas **nunca era chamado** — código morto. Por isso os eventos `begin_checkout` (GTM/dataLayer) e `checkout.started` (PostHog) nunca disparavam, deixando um buraco no funil entre `sign_up` e `purchase`.

A única tela que inicia checkout, `onboarding/Connect.vue`, fazia `form.post(checkout.url())` direto pro Stripe sem disparar tracking.

## Correção

- **`OnboardingController::connect`** — passa o plano (`name` + `interval: 'monthly'`) pra tela. O interval é sempre `monthly` porque esse checkout usa `stripe_monthly_price_id`.
- **`Connect.vue`** — importa `useTracking` e chama `trackBeginCheckout({ name, interval })` no `submit()`, **antes** do `form.post()`.

O redirect pro Stripe é um `Inertia::location`, que só acontece depois do round-trip que cria a sessão no Stripe. Esse gap serve de buffer natural pro beacon do PostHog/GTM sair antes da navegação — sem precisar de timer artificial como o `Processing.vue`.

## Teste

Novo caso em `OnboardingControllerTest` garantindo que a tela `connect` recebe `plan.name` e `plan.interval`. O projeto não tem runner de teste JS, então essa é a cobertura programática cabível para a mudança.

- `php artisan test` (onboarding): 34 passed
- Pint: passed · ESLint (`Connect.vue`): limpo