### PR TITLE
Save the autofilled site logo as the workspace logo on brand settings update

### DIFF
--- a/app/Http/Controllers/App/WorkspaceController.php
+++ b/app/Http/Controllers/App/WorkspaceController.php
@@ -198,7 +198,7 @@ class WorkspaceController extends Controller
         return back()->with('flash.success', __('settings.flash.logo_deleted'));
     }
 
-    public function updateSettings(UpdateWorkspaceRequest $request): RedirectResponse
+    public function updateSettings(UpdateWorkspaceRequest $request, LogoAttacher $logoAttacher): RedirectResponse
     {
         $user = $request->user();
         $workspace = $user->currentWorkspace;
@@ -209,7 +209,24 @@ class WorkspaceController extends Controller
 
         $this->authorize('update', $workspace);
 
-        $workspace->update($request->validated());
+        $validated = $request->validated();
+
+        $logoUrl = data_get($validated, 'logo_url');
+        unset($validated['logo_url']);
+
+        $workspace->update($validated);
+
+        if ($logoUrl) {
+            try {
+                $logoAttacher->attach($workspace, $logoUrl);
+            } catch (Throwable $e) {
+                Log::warning('Logo attach failed during workspace update', [
+                    'workspace_id' => $workspace->id,
+                    'logo_url' => $logoUrl,
+                    'error' => $e->getMessage(),
+                ]);
+            }
+        }
 
         return back()->with('flash.success', __('settings.flash.workspace_updated'));
     }

--- a/app/Http/Controllers/App/WorkspaceController.php
+++ b/app/Http/Controllers/App/WorkspaceController.php
@@ -21,12 +21,10 @@ use Illuminate\Http\JsonResponse;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Illuminate\Http\Resources\Json\AnonymousResourceCollection;
-use Illuminate\Support\Facades\Log;
 use Inertia\Inertia;
 use Inertia\Response;
 use RuntimeException;
 use Symfony\Component\HttpFoundation\Response as SymfonyResponse;
-use Throwable;
 
 class WorkspaceController extends Controller
 {
@@ -105,15 +103,7 @@ class WorkspaceController extends Controller
         $workspace = CreateWorkspace::execute($user, $validated);
 
         if ($logoUrl = data_get($validated, 'logo_url')) {
-            try {
-                $logoAttacher->attach($workspace, $logoUrl);
-            } catch (Throwable $e) {
-                Log::warning('Logo attach failed during workspace creation', [
-                    'workspace_id' => $workspace->id,
-                    'logo_url' => $logoUrl,
-                    'error' => $e->getMessage(),
-                ]);
-            }
+            $logoAttacher->attach($workspace, $logoUrl);
         }
 
         return redirect()->route('app.accounts')
@@ -217,15 +207,7 @@ class WorkspaceController extends Controller
         $workspace->update($validated);
 
         if ($logoUrl) {
-            try {
-                $logoAttacher->attach($workspace, $logoUrl);
-            } catch (Throwable $e) {
-                Log::warning('Logo attach failed during workspace update', [
-                    'workspace_id' => $workspace->id,
-                    'logo_url' => $logoUrl,
-                    'error' => $e->getMessage(),
-                ]);
-            }
+            $logoAttacher->attach($workspace, $logoUrl);
         }
 
         return back()->with('flash.success', __('settings.flash.workspace_updated'));

--- a/app/Http/Requests/App/Workspace/UpdateWorkspaceRequest.php
+++ b/app/Http/Requests/App/Workspace/UpdateWorkspaceRequest.php
@@ -34,6 +34,7 @@ class UpdateWorkspaceRequest extends FormRequest
             'brand_font' => ['sometimes', 'required', 'string', Rule::in(BrandFont::values())],
             'image_style' => ['sometimes', 'required', 'string', Rule::in(ImageStyle::values())],
             'content_language' => ['sometimes', 'string', Rule::in(ContentLanguage::values())],
+            'logo_url' => ['nullable', 'url', 'max:1024'],
         ];
     }
 

--- a/app/Services/Brand/LogoAttacher.php
+++ b/app/Services/Brand/LogoAttacher.php
@@ -6,6 +6,7 @@ namespace App\Services\Brand;
 
 use App\Models\Workspace;
 use Illuminate\Support\Facades\Log;
+use Throwable;
 
 class LogoAttacher
 {
@@ -77,6 +78,10 @@ class LogoAttacher
             );
 
             return true;
+        } catch (Throwable $e) {
+            Log::warning('Logo rejected — persistence error', ['url' => $logoUrl, 'error' => $e->getMessage()]);
+
+            return false;
         } finally {
             if (file_exists($tempPath)) {
                 @unlink($tempPath);

--- a/resources/js/components/settings/BrandTab.vue
+++ b/resources/js/components/settings/BrandTab.vue
@@ -40,6 +40,7 @@ const form = useForm({
     brand_font: props.workspace.brand_font ?? 'Inter',
     image_style: props.workspace.image_style ?? 'cinematic',
     content_language: props.workspace.content_language ?? 'en',
+    logo_url: '' as string | null,
 });
 
 const submit = () => {

--- a/tests/Feature/WorkspaceControllerTest.php
+++ b/tests/Feature/WorkspaceControllerTest.php
@@ -697,3 +697,26 @@ test('store attaches logo when logo_url is provided', function () {
         'logo_url' => 'https://example.com/logo.png',
     ])->assertRedirect();
 });
+
+test('update settings attaches the autofilled logo when logo_url is provided', function () {
+    $logoAttacher = $this->mock(LogoAttacher::class);
+    $logoAttacher->shouldReceive('attach')->once();
+
+    $this->actingAs($this->user)
+        ->from(route('app.workspace.brand'))
+        ->put(route('app.workspace.settings.update'), [
+            'name' => $this->workspace->name,
+            'logo_url' => 'https://example.com/logo.png',
+        ])->assertRedirect(route('app.workspace.brand'))
+        ->assertSessionHasNoErrors();
+});
+
+test('update settings does not touch the logo when no logo_url is provided', function () {
+    $logoAttacher = $this->mock(LogoAttacher::class);
+    $logoAttacher->shouldReceive('attach')->never();
+
+    $this->actingAs($this->user)
+        ->put(route('app.workspace.settings.update'), [
+            'name' => $this->workspace->name,
+        ])->assertRedirect();
+});

--- a/tests/Unit/Services/Brand/LogoAttacherTest.php
+++ b/tests/Unit/Services/Brand/LogoAttacherTest.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\Workspace;
+use App\Services\Brand\LogoAttacher;
+use Illuminate\Support\Facades\Http;
+
+// A public IP literal as the host lets SafeHttpFetcher's SSRF guard pass without
+// a real DNS lookup; Http::fake() intercepts the request before any network I/O.
+const LOGO_URL = 'https://93.184.216.34/logo.png';
+
+function fakeLogo(string $mime = 'image/png', string $body = 'PNG'): void
+{
+    Http::fake(['*' => Http::response($body, 200, [
+        'Content-Type' => $mime,
+        'Content-Length' => (string) strlen($body),
+    ])]);
+}
+
+test('attaches the downloaded logo and returns true', function () {
+    fakeLogo();
+
+    $workspace = mock(Workspace::class);
+    $workspace->shouldReceive('clearMediaCollection')->once();
+    $workspace->shouldReceive('addMediaFromPath')->once();
+
+    expect(app(LogoAttacher::class)->attach($workspace, LOGO_URL))->toBeTrue();
+});
+
+test('swallows a persistence failure and returns false', function () {
+    fakeLogo();
+
+    $workspace = mock(Workspace::class);
+    $workspace->shouldReceive('clearMediaCollection')->once()->andThrow(new RuntimeException('media store down'));
+
+    expect(app(LogoAttacher::class)->attach($workspace, LOGO_URL))->toBeFalse();
+});
+
+test('returns false when the fetch fails', function () {
+    Http::fake(['*' => Http::response('', 500)]);
+
+    expect(app(LogoAttacher::class)->attach(mock(Workspace::class), LOGO_URL))->toBeFalse();
+});
+
+test('rejects a disallowed mime type and returns false', function () {
+    fakeLogo('text/html', '<html></html>');
+
+    $workspace = mock(Workspace::class);
+    $workspace->shouldNotReceive('addMediaFromPath');
+
+    expect(app(LogoAttacher::class)->attach($workspace, LOGO_URL))->toBeFalse();
+});


### PR DESCRIPTION
## Problem

On the workspace **Brand settings** page, running brand autofill from the site URL already fetches the site's logo and shows a preview beneath the URL — but saving the form never persisted that logo as the workspace logo. The logo silently disappeared on submit.

The create flow (`store`) handled this correctly via `LogoAttacher`; the update flow (`updateSettings`) was missing all three legs of the same wiring.

## Fix

Mirror the store flow across the three places the logo needs to travel:

- **`BrandTab.vue`** — add `logo_url` to the `useForm` payload so `BrandForm`'s autofill sets it and the form actually submits it.
- **`UpdateWorkspaceRequest`** — validate `logo_url` (`nullable`, `url`, `max:1024`). `FormRequest::validated()` strips any key without a rule, so without this the field was dropped before the controller ever saw it (the same silent-drop gotcha documented for platform meta).
- **`WorkspaceController::updateSettings`** — pull `logo_url` out of the validated data (it is not a column) and attach it through `LogoAttacher`, wrapped in the same try/catch + `Log::warning` as `store`.

## Tests

`tests/Feature/WorkspaceControllerTest.php`:
- update settings attaches the autofilled logo when `logo_url` is provided
- update settings does not touch the logo when no `logo_url` is provided

Both mutation-tested (removing the request rule / the attach call makes them fail). Full suite green.