### PR TITLE
chore(release): v1.0.6 changelog + customer email artifacts

### DIFF
--- a/.claude/commands/release.md
+++ b/.claude/commands/release.md
@@ -31,7 +31,7 @@ Stop and tell the user if any of these fail:
 - Current branch must be `main`. Else: ask user to `git checkout main`.
 - Working tree must be clean. Else: ask user to commit/stash.
 - Local in sync with `origin/main` (rev-list count `0	0`). Else: ask user to pull/push.
-- Commits-since-tag list must be non-empty. Else: "Nada novo desde a última tag."
+- Commits-since-tag list must be non-empty. Else: "Nothing new since the last tag."
 
 ### Step 2 — Determine next version
 
@@ -202,7 +202,7 @@ Show:
    - `releases/<version>/email.md`
    - Branch `chore/release-<version>-artifacts` + a PR versioning the two files above
 
-Then ask in Portuguese: **"Crio a tag, publico o release e abro o PR com os arquivos?"**
+Then ask: **"Create the tag, publish the release, and open the PR with the artifacts?"**
 
 Do **not** proceed without explicit yes.
 

--- a/.claude/commands/release.md
+++ b/.claude/commands/release.md
@@ -200,31 +200,46 @@ Show:
    - GitHub release `<version>`
    - `releases/<version>/changelog.md`
    - `releases/<version>/email.md`
+   - Branch `chore/release-<version>-artifacts` + a PR versioning the two files above
 
-Then ask in Portuguese: **"Crio a tag, publico o release e salvo os arquivos?"**
+Then ask in Portuguese: **"Crio a tag, publico o release e abro o PR com os arquivos?"**
 
 Do **not** proceed without explicit yes.
 
 ### Step 7 — Execute
 
-After confirmation, in this exact order:
+After confirmation, in this exact order. Steps 4–6 (tag + release) run from `main` so the tag stays on the released `main` commit; steps 7–8 version the artifacts on a separate branch and open a PR.
 
 1. Create local directory: `mkdir -p releases/<version>`
 2. Write `releases/<version>/changelog.md` with the Step 3 content (raw GitHub markdown).
 3. Write `releases/<version>/email.md` with frontmatter + humanized body.
-4. Create annotated tag: `git tag -a <version> -m "Release <version>"`
+4. From `main`, create the annotated tag: `git tag -a <version> -m "Release <version>"`
 5. Push tag: `git push origin <version>`
 6. Create the GitHub release using the changelog file as body:
    ```bash
    gh release create <version> --title "<version>" --notes-file releases/<version>/changelog.md
    ```
-7. Report to the user:
-   - GitHub release URL (from `gh` output)
+7. Version the artifacts on a branch (the two files carry over from the working tree) and push:
+   ```bash
+   git checkout -b chore/release-<version>-artifacts
+   git add releases/<version>/changelog.md releases/<version>/email.md
+   git commit -m "chore(release): add <version> changelog + customer email artifacts"
+   git push -u origin chore/release-<version>-artifacts
+   ```
+8. Open the PR against `main` (body: what the two files are + a link to the GitHub release):
+   ```bash
+   gh pr create --base main --head chore/release-<version>-artifacts \
+     --title "chore(release): <version> changelog + customer email artifacts" \
+     --body "<short body — the two artifact files + link to the release>"
+   ```
+9. Report to the user:
+   - GitHub release URL (from `gh release` output)
+   - PR URL (from `gh pr create` output)
    - Local paths: `releases/<version>/changelog.md`, `releases/<version>/email.md`
-   - Reminder: *"Os arquivos em `releases/<version>/` não foram commitados. Commit depois se quiser preservar o histórico no repo."*
 
 ### On failure
 
 - `git push origin <version>` fails: report the exact error, leave the local tag in place, do not retry destructively.
 - `gh release create` fails: the tag is already pushed; tell the user they can recreate manually with `gh release create <version> --title "<version>" --notes-file releases/<version>/changelog.md`.
+- `git push` / `gh pr create` for the artifacts branch fails: the tag and GitHub release are already live; report the error and tell the user they can open the PR manually from `chore/release-<version>-artifacts`.
 - `Skill` or `Write` failure during artifact prep: report and stop. Do not push the tag without the artifacts being prepared.

--- a/releases/v1.0.6/changelog.md
+++ b/releases/v1.0.6/changelog.md
@@ -1,0 +1,29 @@
+## What's Changed
+* chore(release): add v1.0.5 changelog + customer email artifacts by @paulocastellano in https://github.com/trypostit/trypost/pull/117
+* docs(readme): add Telegram & Discord, fix doc links and org slug by @paulocastellano in https://github.com/trypostit/trypost/pull/118
+* chore(release): add unsubscribe footer to the customer email template by @paulocastellano in https://github.com/trypostit/trypost/pull/119
+* fix(tiktok): resize oversized photos before PULL_FROM_URL by @paulocastellano in https://github.com/trypostit/trypost/pull/120
+* fix: make external-URL media safe end-to-end (API hosting, X MIME, error sanitization) by @paulocastellano in https://github.com/trypostit/trypost/pull/122
+* fix(tracking): fire begin_checkout when onboarding checkout starts by @paulocastellano in https://github.com/trypostit/trypost/pull/170
+* fix(media): don't 500 when the Unsplash/Giphy key is set to null by @dantaspaulo in https://github.com/trypostit/trypost/pull/144
+* fix(workspace): default content_language to the app locale, not 'en' by @dantaspaulo in https://github.com/trypostit/trypost/pull/146
+* Fix social account disconnects: refresh tokens per platform's refresh model by @paulocastellano in https://github.com/trypostit/trypost/pull/171
+* feat(prompts): make 'no em/en dashes' an explicit rule in the content prompts by @dantaspaulo in https://github.com/trypostit/trypost/pull/145
+* Add more content languages by @rallisf1 in https://github.com/trypostit/trypost/pull/125
+* Save the autofilled site logo as the workspace logo on brand settings update by @paulocastellano in https://github.com/trypostit/trypost/pull/173
+* Crop the avatar/logo before upload with a native selection cropper by @paulocastellano in https://github.com/trypostit/trypost/pull/174
+* Charge $1 for the first month instead of a free trial by @paulocastellano in https://github.com/trypostit/trypost/pull/176
+* Add per-image alt text for accessibility across 9 platforms by @paulocastellano in https://github.com/trypostit/trypost/pull/179
+* feat(instagram): auto-fit story images to 9:16 with blurred background by @paulocastellano in https://github.com/trypostit/trypost/pull/123
+* feat(ai-create): show character counter under the AI prompt field by @dantaspaulo in https://github.com/trypostit/trypost/pull/127
+* Link preview cards for Bluesky, X and Threads by @paulocastellano in https://github.com/trypostit/trypost/pull/185
+* Improve the mobile experience (post editor + app-wide polish) by @paulocastellano in https://github.com/trypostit/trypost/pull/187
+* refactor(sidebar): move Settings from the sidebar footer into the user menu by @dantaspaulo in https://github.com/trypostit/trypost/pull/147
+* feat(ai-create): let users choose brand colors or free AI colors for images by @dantaspaulo in https://github.com/trypostit/trypost/pull/128
+* feat(onboarding): add "where you found us" referral-source step by @paulocastellano in https://github.com/trypostit/trypost/pull/188
+
+## New Contributors
+* @dantaspaulo made their first contribution in https://github.com/trypostit/trypost/pull/144
+* @rallisf1 made their first contribution in https://github.com/trypostit/trypost/pull/125
+
+**Full Changelog**: https://github.com/trypostit/trypost/compare/v1.0.5...v1.0.6

--- a/releases/v1.0.6/email.md
+++ b/releases/v1.0.6/email.md
@@ -1,0 +1,45 @@
+---
+subject: "Changelog v1.0.6 — Your language, mobile, and per-image alt text"
+---
+
+# Changelog v1.0.6 — Your language, mobile, and per-image alt text
+
+By TryPost Product Team • [Release v1.0.6](https://github.com/trypostit/trypost/releases/tag/v1.0.6)
+
+Hello! Welcome to this week's update. Here's what's new in TryPost.
+
+## TryPost now speaks your language
+
+The whole interface is now translated into 12 new languages, with full right-to-left support for languages like Arabic and Hebrew. You can also write content in more languages than before, and when you create a workspace your content language now follows the language you're already using the app in, instead of defaulting to English. Pick your language once and the rest just follows.
+
+## A real mobile experience
+
+The post editor works properly on your phone now. Composing, switching between platform previews, editing per-platform text, the calendar, the asset gallery, automations — we went through the whole app and made it usable on a small screen instead of squeezing the desktop layout onto it. If you've ever tried to fix a typo on your phone before a post goes out, this one's for you.
+
+## Alt text, story fitting, and link previews
+
+You can now add alt text to each image, and we publish it everywhere it belongs — Bluesky, X, Mastodon, LinkedIn, Facebook, Instagram, Threads, Pinterest and Discord — so people using screen readers can actually read your posts. Instagram stories automatically fit to 9:16 with a soft blurred background, so a landscape photo no longer gets awkwardly cropped. Links in Bluesky, X and Threads posts now show a preview card. And when you upload an avatar or logo, you can crop it right there before it's saved.
+
+## New features
+
+- Add alt text to each image and have it published across every supported platform
+- Choose whether AI image generation uses your brand colors or picks freely
+- A character counter under the AI prompt field so you know how much room you have
+- Link preview cards for Bluesky, X and Threads posts
+- Crop your avatar or logo before uploading it
+
+## Fixes
+
+- Fixed TikTok photo posts failing when the image was larger than TikTok allows
+- External image and video links you add to a post are now downloaded and hosted reliably
+- The media picker no longer errors when Unsplash or Giphy isn't configured
+- Social accounts stay connected — we fixed a token-refresh issue that could disconnect them
+- New workspaces now default to your app language instead of always English
+
+Cheers,
+Paulo from TryPost.it
+
+---
+
+You're receiving this because you subscribed.
+[Unsubscribe]({{unsubscribe_url}})


### PR DESCRIPTION
Local mirrors for the **v1.0.6** release.

- `releases/v1.0.6/changelog.md` — GitHub-native changelog (PR list + authors)
- `releases/v1.0.6/email.md` — customer-facing changelog email (Cal.com style, humanized)

Release: https://github.com/trypostit/trypost/releases/tag/v1.0.6

No app/runtime changes — documentation artifacts only.