### PR TITLE
feat(ai-create): review the generated copy before spending image credits

### DIFF
--- a/app/Broadcasting/UserAiDraftChannel.php
+++ b/app/Broadcasting/UserAiDraftChannel.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Broadcasting;
+
+use App\Models\User;
+
+class UserAiDraftChannel
+{
+    public function join(User $user, User $owner, string $draftId): bool
+    {
+        return $user->is($owner);
+    }
+}

--- a/app/Enums/Ai/DraftStatus.php
+++ b/app/Enums/Ai/DraftStatus.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Enums\Ai;
+
+/**
+ * Lifecycle of an AI post draft: the two-phase "review before final generation"
+ * flow. Preparing → Ready (text pre-generated, awaiting user review) →
+ * Generating (images being rendered from the reviewed text) → Completed.
+ */
+enum DraftStatus: string
+{
+    case Preparing = 'preparing';
+    case Ready = 'ready';
+    case Generating = 'generating';
+    case Completed = 'completed';
+    case Failed = 'failed';
+}

--- a/app/Events/Ai/PostContentPrepared.php
+++ b/app/Events/Ai/PostContentPrepared.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Events\Ai;
+
+use Illuminate\Broadcasting\InteractsWithSockets;
+use Illuminate\Broadcasting\PrivateChannel;
+use Illuminate\Contracts\Broadcasting\ShouldBroadcast;
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+
+/**
+ * Phase A of the review flow: the AI has pre-generated the structured text of a
+ * post draft and it's ready for the user to review/edit. Failure carries `error`.
+ */
+class PostContentPrepared implements ShouldBroadcast
+{
+    use Dispatchable, InteractsWithSockets, SerializesModels;
+
+    public function __construct(
+        public string $userId,
+        public string $draftId,
+        public ?string $error = null,
+    ) {}
+
+    public function broadcastAs(): string
+    {
+        return 'ai.content.prepared';
+    }
+
+    public function broadcastOn(): PrivateChannel
+    {
+        return new PrivateChannel("user.{$this->userId}.ai-draft.{$this->draftId}");
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function broadcastWith(): array
+    {
+        return [
+            'draft_id' => $this->draftId,
+            'error' => $this->error,
+        ];
+    }
+
+    public function broadcastQueue(): string
+    {
+        return 'broadcasts';
+    }
+}

--- a/app/Http/Controllers/App/PostAiCreateController.php
+++ b/app/Http/Controllers/App/PostAiCreateController.php
@@ -4,8 +4,13 @@ declare(strict_types=1);
 
 namespace App\Http\Controllers\App;
 
+use App\Enums\Ai\DraftStatus;
+use App\Enums\PostPlatform\ContentType;
+use App\Http\Requests\App\Ai\GenerateFromDraftRequest;
 use App\Http\Requests\App\Ai\StartPostCreationRequest;
+use App\Jobs\Ai\PreparePostContent;
 use App\Jobs\Ai\StreamPostCreation;
+use App\Models\AiPostDraft;
 use App\Models\SocialAccount;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
@@ -70,5 +75,180 @@ class PostAiCreateController extends Controller
             'format' => (string) $request->query('format', ''),
             'prompt' => (string) $request->query('prompt', ''),
         ]);
+    }
+
+    /**
+     * Phase A of the review flow: create a draft and pre-generate only its text
+     * (no images) for the user to review. Returns the draft id and its channel.
+     */
+    public function prepare(StartPostCreationRequest $request): JsonResponse
+    {
+        $workspace = $request->user()->currentWorkspace;
+
+        $this->authorize('createPost', $workspace);
+
+        $gate = Gate::inspect('useAi', $workspace->account);
+        if ($gate->denied()) {
+            return response()->json(['message' => $gate->message()], Response::HTTP_PAYMENT_REQUIRED);
+        }
+
+        $socialAccountId = $request->input('social_account_id');
+
+        if ($socialAccountId) {
+            $owned = SocialAccount::where('id', $socialAccountId)
+                ->where('workspace_id', $workspace->id)
+                ->exists();
+
+            if (! $owned) {
+                abort(Response::HTTP_FORBIDDEN);
+            }
+        }
+
+        $draft = AiPostDraft::create([
+            'workspace_id' => $workspace->id,
+            'user_id' => $request->user()->id,
+            'social_account_id' => $socialAccountId,
+            'format' => $request->string('format')->toString(),
+            'template' => $request->input('template', 'image_card'),
+            'image_count' => (int) $request->input('image_count', 0),
+            'apply_brand_visuals' => $request->boolean('apply_brand_visuals', true),
+            'scheduled_date' => $request->input('date'),
+            'prompt' => $request->string('prompt')->toString(),
+            'status' => DraftStatus::Preparing,
+        ]);
+
+        PreparePostContent::dispatch($draft->id);
+
+        return response()->json([
+            'draft_id' => $draft->id,
+            'channel' => "user.{$request->user()->id}.ai-draft.{$draft->id}",
+        ], Response::HTTP_ACCEPTED);
+    }
+
+    /**
+     * The review screen: editable blocks of the pre-generated structure. While
+     * the draft is still `preparing`, the page shows a skeleton and fills in on
+     * the `.ai.content.prepared` broadcast.
+     */
+    public function review(Request $request, AiPostDraft $draft): InertiaResponse
+    {
+        $this->authorizeDraft($request, $draft);
+
+        return Inertia::render('posts/ai/Review', [
+            'draft' => [
+                'id' => $draft->id,
+                'status' => $draft->status->value,
+                'format' => $draft->format,
+                'template' => $draft->template,
+                'is_carousel' => $draft->format === ContentType::CAROUSEL_FORMAT,
+                'image_count' => $draft->image_count,
+                // Formats that publish no caption (stories and the like) hide the
+                // field instead of letting the user edit text that never ships.
+                'supports_caption' => $draft->format === ContentType::CAROUSEL_FORMAT
+                    || (ContentType::tryFrom((string) $draft->format)?->supportsCaption() ?? true),
+                'structured' => $draft->structured,
+                'error' => $draft->error,
+                'channel' => "user.{$draft->user_id}.ai-draft.{$draft->id}",
+            ],
+        ]);
+    }
+
+    /**
+     * Phase B: render the images from the REVIEWED structure and create the post.
+     * Reuses StreamPostCreation (with `preparedStructured`), so the loading
+     * screen and the completion event work unchanged.
+     */
+    public function generate(GenerateFromDraftRequest $request, AiPostDraft $draft): JsonResponse
+    {
+        $this->authorizeDraft($request, $draft);
+
+        // Only a `ready` draft may generate: this stops a replay (double click or
+        // a re-POST) from creating a duplicate post and billing images twice.
+        abort_unless($draft->status === DraftStatus::Ready, Response::HTTP_CONFLICT);
+
+        $workspace = $request->user()->currentWorkspace;
+
+        $gate = Gate::inspect('useAi', $workspace->account);
+        if ($gate->denied()) {
+            return response()->json(['message' => $gate->message()], Response::HTTP_PAYMENT_REQUIRED);
+        }
+
+        $structured = $request->input('structured');
+
+        $draft->update([
+            'structured' => $structured,
+            'status' => DraftStatus::Generating,
+        ]);
+
+        StreamPostCreation::dispatch(
+            userId: $draft->user_id,
+            creationId: $draft->id,
+            workspaceId: $draft->workspace_id,
+            format: $draft->format,
+            socialAccountId: $draft->social_account_id,
+            imageCount: $draft->image_count,
+            prompt: $draft->prompt,
+            date: $draft->scheduled_date?->format('Y-m-d'),
+            template: $draft->template,
+            applyBrandVisuals: $draft->apply_brand_visuals,
+            preparedStructured: $structured,
+            draftId: $draft->id,
+        );
+
+        return response()->json([
+            'creation_id' => $draft->id,
+            'channel' => "user.{$draft->user_id}.ai-creation.{$draft->id}",
+        ], Response::HTTP_ACCEPTED);
+    }
+
+    /**
+     * Autosaves the review edits, and only while the draft is `ready`. It never
+     * triggers generation nor spends AI credit: it just persists the text.
+     */
+    public function autosave(GenerateFromDraftRequest $request, AiPostDraft $draft): JsonResponse
+    {
+        $this->authorizeDraft($request, $draft);
+
+        if ($draft->status === DraftStatus::Ready) {
+            $draft->update(['structured' => $request->input('structured')]);
+        }
+
+        return response()->json(status: Response::HTTP_NO_CONTENT);
+    }
+
+    /**
+     * Polling fallback for the loading screen: when the completion broadcast is
+     * missed (dropped or reconnecting websocket), the front end asks here and
+     * unblocks. In the review flow the creationId IS the draft id; in the
+     * one-shot flow there is no record to consult, so the status is 'unknown'
+     * and the channel stays the source of truth.
+     */
+    public function creationStatus(Request $request, string $creationId): JsonResponse
+    {
+        $workspace = $request->user()->currentWorkspace;
+
+        $draft = AiPostDraft::query()
+            ->where('workspace_id', $workspace?->id)
+            ->find($creationId);
+
+        if (! $draft) {
+            return response()->json(['status' => 'unknown']);
+        }
+
+        return response()->json(match ($draft->status) {
+            DraftStatus::Completed => ['status' => 'done', 'post_id' => $draft->post_id],
+            DraftStatus::Failed => ['status' => 'error', 'error' => $draft->error],
+            default => ['status' => 'pending'],
+        });
+    }
+
+    /** A draft belongs to the user who created it, inside their current workspace. */
+    private function authorizeDraft(Request $request, AiPostDraft $draft): void
+    {
+        abort_unless(
+            $draft->user_id === $request->user()->id
+                && $draft->workspace_id === $request->user()->currentWorkspace?->id,
+            Response::HTTP_FORBIDDEN,
+        );
     }
 }

--- a/app/Http/Requests/App/Ai/GenerateFromDraftRequest.php
+++ b/app/Http/Requests/App/Ai/GenerateFromDraftRequest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Requests\App\Ai;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class GenerateFromDraftRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function rules(): array
+    {
+        return [
+            // The reviewed structure the user approved. Shape mirrors the
+            // generator output (caption + slides, or content + image_* fields);
+            // downstream assemble() reads keys defensively via data_get().
+            'structured' => ['required', 'array'],
+        ];
+    }
+}

--- a/app/Jobs/Ai/PreparePostContent.php
+++ b/app/Jobs/Ai/PreparePostContent.php
@@ -1,0 +1,92 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Jobs\Ai;
+
+use App\Ai\Templates\AiTemplateRegistry;
+use App\Ai\Templates\TemplateContext;
+use App\Enums\Ai\DraftStatus;
+use App\Enums\PostPlatform\ContentType;
+use App\Events\Ai\PostContentPrepared;
+use App\Models\AiPostDraft;
+use App\Models\SocialAccount;
+use App\Services\Ai\PostContentComposer;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Facades\Log;
+
+/**
+ * Phase A of the review flow: pre-generates ONLY the structured text (generator
+ * + humanizer, no images) and stores it on the draft for the user to review.
+ * Phase B (StreamPostCreation with `preparedStructured`) renders the images from
+ * the reviewed structure.
+ */
+class PreparePostContent implements ShouldQueue
+{
+    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+
+    public function __construct(public string $draftId)
+    {
+        $this->onQueue('ai');
+    }
+
+    public function handle(): void
+    {
+        $draft = AiPostDraft::find($this->draftId);
+
+        if (! $draft) {
+            return;
+        }
+
+        $workspace = $draft->workspace;
+        $socialAccount = $draft->social_account_id ? SocialAccount::find($draft->social_account_id) : null;
+        $style = app(AiTemplateRegistry::class)->find($draft->template);
+        $isCarousel = $draft->format === ContentType::CAROUSEL_FORMAT;
+
+        $context = new TemplateContext(
+            workspace: $workspace,
+            socialAccount: $socialAccount,
+            format: $draft->format,
+            imageCount: $draft->image_count,
+            isCarousel: $isCarousel,
+            applyBrandVisuals: $draft->apply_brand_visuals,
+        );
+
+        try {
+            $structured = app(PostContentComposer::class)->compose(
+                workspace: $workspace,
+                format: $draft->format,
+                imageCount: $draft->image_count,
+                prompt: $draft->prompt,
+                style: $style,
+                context: $context,
+                userId: $draft->user_id,
+            );
+
+            $draft->update([
+                'structured' => $structured,
+                'status' => DraftStatus::Ready,
+            ]);
+
+            PostContentPrepared::dispatch($draft->user_id, $draft->id);
+        } catch (\Throwable $e) {
+            Log::error('PreparePostContent failed', [
+                'draft_id' => $draft->id,
+                'error' => $e->getMessage(),
+            ]);
+
+            $draft->update([
+                'status' => DraftStatus::Failed,
+                'error' => $e->getMessage(),
+            ]);
+
+            PostContentPrepared::dispatch($draft->user_id, $draft->id, $e->getMessage());
+
+            throw $e;
+        }
+    }
+}

--- a/app/Jobs/Ai/StreamPostCreation.php
+++ b/app/Jobs/Ai/StreamPostCreation.php
@@ -5,23 +5,21 @@ declare(strict_types=1);
 namespace App\Jobs\Ai;
 
 use App\Actions\Post\CreatePost;
-use App\Ai\Agents\PostContentGenerator;
-use App\Ai\Agents\PostContentHumanizer;
 use App\Ai\Templates\AiTemplateRegistry;
 use App\Ai\Templates\GeneratedPost;
 use App\Ai\Templates\TemplateContext;
-use App\Enums\Ai\ContentStyle;
-use App\Enums\Ai\GeneratorFormat;
+use App\Enums\Ai\DraftStatus;
 use App\Enums\Notification\Channel as NotificationChannel;
 use App\Enums\Notification\Type as NotificationType;
 use App\Enums\PostPlatform\ContentType;
 use App\Events\Ai\PostCreationReady;
 use App\Jobs\SendNotification;
+use App\Models\AiPostDraft;
 use App\Models\Post;
 use App\Models\SocialAccount;
 use App\Models\User;
 use App\Models\Workspace;
-use App\Services\Ai\RecordAiUsage;
+use App\Services\Ai\PostContentComposer;
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Bus\Dispatchable;
@@ -44,6 +42,10 @@ class StreamPostCreation implements ShouldQueue
         public ?string $date = null,
         public string $template = 'image_card',
         public bool $applyBrandVisuals = true,
+        /** Review flow (phase B): when set, skip text generation and render this reviewed structure. */
+        public ?array $preparedStructured = null,
+        /** Links this run to an AiPostDraft to mark completed/failed. */
+        public ?string $draftId = null,
     ) {
         $this->onQueue('ai');
     }
@@ -56,8 +58,6 @@ class StreamPostCreation implements ShouldQueue
         $style = app(AiTemplateRegistry::class)->find($this->template);
 
         $isCarousel = $this->format === ContentType::CAROUSEL_FORMAT;
-        $agentFormat = $isCarousel ? GeneratorFormat::Carousel : GeneratorFormat::Single;
-        $slideCount = $isCarousel && $this->imageCount > 0 ? $this->imageCount : 1;
 
         $context = new TemplateContext(
             workspace: $workspace,
@@ -68,34 +68,30 @@ class StreamPostCreation implements ShouldQueue
             applyBrandVisuals: $this->applyBrandVisuals,
         );
 
-        $agent = new PostContentGenerator(
-            workspace: $workspace,
-            format: $agentFormat,
-            slideCount: $slideCount,
-            platformContext: $this->format,
-            template: $style,
-            templateContext: $context,
-        );
-
         try {
-            $response = $agent->prompt($this->prompt);
-
-            RecordAiUsage::recordText(
-                workspace: $workspace,
-                promptTokens: $response->usage->promptTokens,
-                completionTokens: $response->usage->completionTokens,
-                provider: (string) config('ai.default'),
-                model: (string) config('ai.default_text_model'),
-                userId: $this->userId,
-                metadata: ['agent' => 'post_generator', 'format' => $this->format],
-            );
-
-            $structured = $response->structured ?? [];
-
-            $structured = $this->humanize($workspace, $structured, $agentFormat, $style->style());
+            // The review flow (phase B) passes the reviewed structure: skip text
+            // generation and render images from exactly what the user approved.
+            $structured = $this->preparedStructured
+                ?? app(PostContentComposer::class)->compose(
+                    workspace: $workspace,
+                    format: $this->format,
+                    imageCount: $this->imageCount,
+                    prompt: $this->prompt,
+                    style: $style,
+                    context: $context,
+                    userId: $this->userId,
+                );
 
             $generated = $style->assemble($structured, $context);
             $post = $this->createPostFromGenerated($workspace, $generated, $socialAccount);
+
+            if ($this->draftId !== null) {
+                AiPostDraft::whereKey($this->draftId)->update([
+                    'post_id' => $post->id,
+                    'status' => DraftStatus::Completed,
+                ]);
+            }
+
             $this->notifyReady($workspace, $post);
         } catch (\Throwable $e) {
             Log::error('StreamPostCreation failed', [
@@ -103,88 +99,17 @@ class StreamPostCreation implements ShouldQueue
                 'error' => $e->getMessage(),
             ]);
 
+            if ($this->draftId !== null) {
+                AiPostDraft::whereKey($this->draftId)->update([
+                    'status' => DraftStatus::Failed,
+                    'error' => $e->getMessage(),
+                ]);
+            }
+
             PostCreationReady::dispatch($this->userId, $this->creationId, null, $e->getMessage());
 
             throw $e;
         }
-    }
-
-    /**
-     * Run the structured generator output through the humanizer pass and merge
-     * the humanized text fields back over the original structure (preserving
-     * image_keywords and slide order/count). Failures are logged and the
-     * original structure is returned so generation never breaks because of the
-     * polish step.
-     *
-     * @param  array<string, mixed>  $structured
-     * @return array<string, mixed>
-     */
-    private function humanize(Workspace $workspace, array $structured, GeneratorFormat $format, ContentStyle $style): array
-    {
-        if (! $style->humanizes()) {
-            return $structured;
-        }
-
-        try {
-            $input = $format->isCarousel()
-                ? [
-                    'caption' => data_get($structured, 'caption', ''),
-                    'slides' => array_map(
-                        fn ($s) => [
-                            'title' => data_get($s, 'title', ''),
-                            'body' => data_get($s, 'body', ''),
-                        ],
-                        data_get($structured, 'slides', []),
-                    ),
-                ]
-                : [
-                    'content' => data_get($structured, 'content', ''),
-                    'image_title' => data_get($structured, 'image_title', ''),
-                    'image_body' => data_get($structured, 'image_body', ''),
-                ];
-
-            $humanizer = new PostContentHumanizer($workspace, $format, platformContext: $this->format);
-            $response = $humanizer->prompt(json_encode($input, JSON_UNESCAPED_UNICODE));
-            $humanized = $response->structured ?? [];
-
-            RecordAiUsage::recordText(
-                workspace: $workspace,
-                promptTokens: $response->usage->promptTokens,
-                completionTokens: $response->usage->completionTokens,
-                provider: (string) config('ai.default'),
-                model: (string) config('ai.default_text_model'),
-                userId: $this->userId,
-                metadata: ['agent' => 'post_humanizer', 'format' => $format->value],
-            );
-        } catch (\Throwable $e) {
-            Log::warning('PostContentHumanizer failed, using generator output as-is', [
-                'creation_id' => $this->creationId,
-                'error' => $e->getMessage(),
-            ]);
-
-            return $structured;
-        }
-
-        if ($format->isCarousel()) {
-            $structured['caption'] = data_get($humanized, 'caption', $structured['caption'] ?? '');
-            $originalSlides = $structured['slides'] ?? [];
-            $humanizedSlides = data_get($humanized, 'slides', []);
-
-            foreach ($originalSlides as $i => $slide) {
-                if (isset($humanizedSlides[$i])) {
-                    $originalSlides[$i]['title'] = data_get($humanizedSlides[$i], 'title', $slide['title'] ?? '');
-                    $originalSlides[$i]['body'] = data_get($humanizedSlides[$i], 'body', $slide['body'] ?? '');
-                }
-            }
-
-            $structured['slides'] = $originalSlides;
-        } else {
-            $structured['content'] = data_get($humanized, 'content', $structured['content'] ?? '');
-            $structured['image_title'] = data_get($humanized, 'image_title', $structured['image_title'] ?? '');
-            $structured['image_body'] = data_get($humanized, 'image_body', $structured['image_body'] ?? '');
-        }
-
-        return $structured;
     }
 
     private function createPostFromGenerated(Workspace $workspace, GeneratedPost $generated, ?SocialAccount $socialAccount): Post

--- a/app/Models/AiPostDraft.php
+++ b/app/Models/AiPostDraft.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+use App\Enums\Ai\DraftStatus;
+use Database\Factories\AiPostDraftFactory;
+use Illuminate\Database\Eloquent\Concerns\HasUuids;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+/**
+ * Intermediate, editable structure of an AI post between the "pre-generate text"
+ * phase and the "generate final images" phase. The user reviews/edits the
+ * `structured` payload before the images are rendered from it.
+ */
+class AiPostDraft extends Model
+{
+    /** @use HasFactory<AiPostDraftFactory> */
+    use HasFactory, HasUuids;
+
+    protected $fillable = [
+        'workspace_id',
+        'user_id',
+        'social_account_id',
+        'format',
+        'template',
+        'image_count',
+        'apply_brand_visuals',
+        'scheduled_date',
+        'prompt',
+        'structured',
+        'status',
+        'post_id',
+        'error',
+    ];
+
+    /**
+     * @return array<string, string>
+     */
+    protected function casts(): array
+    {
+        return [
+            'structured' => 'array',
+            'status' => DraftStatus::class,
+            'scheduled_date' => 'date',
+            'image_count' => 'integer',
+            'apply_brand_visuals' => 'boolean',
+        ];
+    }
+
+    public function workspace(): BelongsTo
+    {
+        return $this->belongsTo(Workspace::class);
+    }
+
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+
+    public function socialAccount(): BelongsTo
+    {
+        return $this->belongsTo(SocialAccount::class);
+    }
+
+    public function post(): BelongsTo
+    {
+        return $this->belongsTo(Post::class);
+    }
+}

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -7,6 +7,7 @@ namespace App\Providers;
 use App\Listeners\StripeEventListener;
 use App\Models\AccessToken;
 use App\Models\Account;
+use App\Models\AiPostDraft;
 use App\Models\AiUsageLog;
 use App\Models\Automation;
 use App\Models\AutomationNodeRun;
@@ -114,6 +115,7 @@ class AppServiceProvider extends ServiceProvider
         Relation::enforceMorphMap([
             'accessToken' => AccessToken::class,
             'account' => Account::class,
+            'aiPostDraft' => AiPostDraft::class,
             'aiUsageLog' => AiUsageLog::class,
             'automation' => Automation::class,
             'automationNodeRun' => AutomationNodeRun::class,

--- a/app/Services/Ai/PostContentComposer.php
+++ b/app/Services/Ai/PostContentComposer.php
@@ -1,0 +1,149 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Ai;
+
+use App\Ai\Agents\PostContentGenerator;
+use App\Ai\Agents\PostContentHumanizer;
+use App\Ai\Templates\AiContentTemplate;
+use App\Ai\Templates\TemplateContext;
+use App\Enums\Ai\ContentStyle;
+use App\Enums\Ai\GeneratorFormat;
+use App\Enums\PostPlatform\ContentType;
+use App\Models\Workspace;
+use Illuminate\Support\Facades\Log;
+
+/**
+ * Produces the structured TEXT of an AI post (no images): runs the content
+ * generator, then the humanizer pass. Extracted from StreamPostCreation so the
+ * one-shot flow and the two-phase review flow (PreparePostContent) share one
+ * implementation instead of drifting apart.
+ *
+ * Behaviour is identical to the inline version it replaces.
+ */
+class PostContentComposer
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function compose(
+        Workspace $workspace,
+        string $format,
+        int $imageCount,
+        string $prompt,
+        AiContentTemplate $style,
+        TemplateContext $context,
+        string $userId,
+    ): array {
+        $isCarousel = $format === ContentType::CAROUSEL_FORMAT;
+        $agentFormat = $isCarousel ? GeneratorFormat::Carousel : GeneratorFormat::Single;
+        $slideCount = $isCarousel && $imageCount > 0 ? $imageCount : 1;
+
+        $agent = new PostContentGenerator(
+            workspace: $workspace,
+            format: $agentFormat,
+            slideCount: $slideCount,
+            platformContext: $format,
+            template: $style,
+            templateContext: $context,
+        );
+
+        $response = $agent->prompt($prompt);
+
+        RecordAiUsage::recordText(
+            workspace: $workspace,
+            promptTokens: $response->usage->promptTokens,
+            completionTokens: $response->usage->completionTokens,
+            provider: (string) config('ai.default'),
+            model: (string) config('ai.default_text_model'),
+            userId: $userId,
+            metadata: ['agent' => 'post_generator', 'format' => $format],
+        );
+
+        return $this->humanize($workspace, $response->structured ?? [], $agentFormat, $style->style(), $userId, $format);
+    }
+
+    /**
+     * Run the structured generator output through the humanizer pass and merge
+     * the humanized text fields back over the original structure (preserving
+     * image_keywords and slide order/count). Failures are logged and the
+     * original structure is returned so generation never breaks because of the
+     * polish step.
+     *
+     * @param  array<string, mixed>  $structured
+     * @return array<string, mixed>
+     */
+    private function humanize(
+        Workspace $workspace,
+        array $structured,
+        GeneratorFormat $format,
+        ContentStyle $style,
+        string $userId,
+        string $platformFormat,
+    ): array {
+        if (! $style->humanizes()) {
+            return $structured;
+        }
+
+        try {
+            $input = $format->isCarousel()
+                ? [
+                    'caption' => data_get($structured, 'caption', ''),
+                    'slides' => array_map(
+                        fn ($s) => [
+                            'title' => data_get($s, 'title', ''),
+                            'body' => data_get($s, 'body', ''),
+                        ],
+                        data_get($structured, 'slides', []),
+                    ),
+                ]
+                : [
+                    'content' => data_get($structured, 'content', ''),
+                    'image_title' => data_get($structured, 'image_title', ''),
+                    'image_body' => data_get($structured, 'image_body', ''),
+                ];
+
+            $humanizer = new PostContentHumanizer($workspace, $format, platformContext: $platformFormat);
+            $response = $humanizer->prompt(json_encode($input, JSON_UNESCAPED_UNICODE));
+            $humanized = $response->structured ?? [];
+
+            RecordAiUsage::recordText(
+                workspace: $workspace,
+                promptTokens: $response->usage->promptTokens,
+                completionTokens: $response->usage->completionTokens,
+                provider: (string) config('ai.default'),
+                model: (string) config('ai.default_text_model'),
+                userId: $userId,
+                metadata: ['agent' => 'post_humanizer', 'format' => $format->value],
+            );
+        } catch (\Throwable $e) {
+            Log::warning('PostContentHumanizer failed, using generator output as-is', [
+                'error' => $e->getMessage(),
+            ]);
+
+            return $structured;
+        }
+
+        if ($format->isCarousel()) {
+            $structured['caption'] = data_get($humanized, 'caption', $structured['caption'] ?? '');
+            $originalSlides = $structured['slides'] ?? [];
+            $humanizedSlides = data_get($humanized, 'slides', []);
+
+            foreach ($originalSlides as $i => $slide) {
+                if (isset($humanizedSlides[$i])) {
+                    $originalSlides[$i]['title'] = data_get($humanizedSlides[$i], 'title', $slide['title'] ?? '');
+                    $originalSlides[$i]['body'] = data_get($humanizedSlides[$i], 'body', $slide['body'] ?? '');
+                }
+            }
+
+            $structured['slides'] = $originalSlides;
+        } else {
+            $structured['content'] = data_get($humanized, 'content', $structured['content'] ?? '');
+            $structured['image_title'] = data_get($humanized, 'image_title', $structured['image_title'] ?? '');
+            $structured['image_body'] = data_get($humanized, 'image_body', $structured['image_body'] ?? '');
+        }
+
+        return $structured;
+    }
+}

--- a/database/factories/AiPostDraftFactory.php
+++ b/database/factories/AiPostDraftFactory.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Database\Factories;
+
+use App\Enums\Ai\DraftStatus;
+use App\Models\AiPostDraft;
+use App\Models\User;
+use App\Models\Workspace;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<AiPostDraft>
+ */
+class AiPostDraftFactory extends Factory
+{
+    protected $model = AiPostDraft::class;
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'workspace_id' => Workspace::factory(),
+            'user_id' => User::factory(),
+            'social_account_id' => null,
+            'format' => 'instagram_carousel',
+            'template' => 'image_card',
+            'image_count' => 3,
+            'apply_brand_visuals' => true,
+            'scheduled_date' => null,
+            'prompt' => $this->faker->sentence(),
+            'structured' => null,
+            'status' => DraftStatus::Preparing,
+            'post_id' => null,
+            'error' => null,
+        ];
+    }
+
+    public function ready(array $structured): static
+    {
+        return $this->state(fn () => [
+            'status' => DraftStatus::Ready,
+            'structured' => $structured,
+        ]);
+    }
+}

--- a/database/migrations/2026_07_20_000000_create_ai_post_drafts_table.php
+++ b/database/migrations/2026_07_20_000000_create_ai_post_drafts_table.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('ai_post_drafts', function (Blueprint $table) {
+            $table->uuid('id')->primary();
+            $table->foreignUuid('workspace_id')->constrained()->cascadeOnDelete();
+            $table->foreignUuid('user_id')->constrained()->cascadeOnDelete();
+            $table->uuid('social_account_id')->nullable();
+            $table->string('format');
+            $table->string('template')->default('image_card');
+            $table->unsignedInteger('image_count')->default(0);
+            $table->boolean('apply_brand_visuals')->default(true);
+            $table->date('scheduled_date')->nullable();
+            $table->text('prompt');
+            $table->json('structured')->nullable();
+            $table->string('status')->default('preparing');
+            $table->uuid('post_id')->nullable();
+            $table->text('error')->nullable();
+            $table->timestamps();
+
+            $table->index(['workspace_id', 'user_id']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('ai_post_drafts');
+    }
+};

--- a/lang/ar/posts.php
+++ b/lang/ar/posts.php
@@ -1,6 +1,30 @@
 <?php
 
 return [
+
+    'ai_review' => [
+        'page_title' => 'Review your post',
+        'title' => 'Review before generating',
+        'description' => 'Edit the copy the AI wrote. Images are only generated after you approve it.',
+        'preparing' => 'Writing your post…',
+        'failed' => 'We could not write this post. Try again.',
+        'back' => 'Back',
+        'generate' => 'Generate images',
+        'saving' => 'Saving…',
+        'saved' => 'Saved',
+        'caption' => 'Caption',
+        'caption_placeholder' => 'The caption published with the post',
+        'no_caption_for_format' => 'This format publishes no caption, so there is nothing to edit here.',
+        'field_tweet_text' => 'Tweet text',
+        'field_title' => 'Title',
+        'field_body' => 'Body',
+        'field_image_title' => 'Image headline',
+        'field_image_body' => 'Image body',
+        'field_image_keywords' => 'Photo keywords',
+        'field_image_keywords_hint' => 'Comma-separated terms used to search the photo for this card.',
+        'field_image_keywords_placeholder' => 'office, team, meeting',
+        'reorder_slide' => 'Reorder slide :number',
+    ],
     'title' => 'المنشورات',
     'search' => 'البحث في المنشورات...',
     'all_posts' => 'جميع المنشورات',

--- a/lang/de/posts.php
+++ b/lang/de/posts.php
@@ -3,6 +3,30 @@
 declare(strict_types=1);
 
 return [
+
+    'ai_review' => [
+        'page_title' => 'Review your post',
+        'title' => 'Review before generating',
+        'description' => 'Edit the copy the AI wrote. Images are only generated after you approve it.',
+        'preparing' => 'Writing your post…',
+        'failed' => 'We could not write this post. Try again.',
+        'back' => 'Back',
+        'generate' => 'Generate images',
+        'saving' => 'Saving…',
+        'saved' => 'Saved',
+        'caption' => 'Caption',
+        'caption_placeholder' => 'The caption published with the post',
+        'no_caption_for_format' => 'This format publishes no caption, so there is nothing to edit here.',
+        'field_tweet_text' => 'Tweet text',
+        'field_title' => 'Title',
+        'field_body' => 'Body',
+        'field_image_title' => 'Image headline',
+        'field_image_body' => 'Image body',
+        'field_image_keywords' => 'Photo keywords',
+        'field_image_keywords_hint' => 'Comma-separated terms used to search the photo for this card.',
+        'field_image_keywords_placeholder' => 'office, team, meeting',
+        'reorder_slide' => 'Reorder slide :number',
+    ],
     'title' => 'Beiträge',
     'search' => 'Beiträge suchen...',
     'all_posts' => 'Alle Beiträge',

--- a/lang/el/posts.php
+++ b/lang/el/posts.php
@@ -1,6 +1,30 @@
 <?php
 
 return [
+
+    'ai_review' => [
+        'page_title' => 'Review your post',
+        'title' => 'Review before generating',
+        'description' => 'Edit the copy the AI wrote. Images are only generated after you approve it.',
+        'preparing' => 'Writing your post…',
+        'failed' => 'We could not write this post. Try again.',
+        'back' => 'Back',
+        'generate' => 'Generate images',
+        'saving' => 'Saving…',
+        'saved' => 'Saved',
+        'caption' => 'Caption',
+        'caption_placeholder' => 'The caption published with the post',
+        'no_caption_for_format' => 'This format publishes no caption, so there is nothing to edit here.',
+        'field_tweet_text' => 'Tweet text',
+        'field_title' => 'Title',
+        'field_body' => 'Body',
+        'field_image_title' => 'Image headline',
+        'field_image_body' => 'Image body',
+        'field_image_keywords' => 'Photo keywords',
+        'field_image_keywords_hint' => 'Comma-separated terms used to search the photo for this card.',
+        'field_image_keywords_placeholder' => 'office, team, meeting',
+        'reorder_slide' => 'Reorder slide :number',
+    ],
     'title' => 'Δημοσιεύσεις',
     'search' => 'Αναζήτηση δημοσιεύσεων...',
     'all_posts' => 'Όλες οι δημοσιεύσεις',

--- a/lang/en/posts.php
+++ b/lang/en/posts.php
@@ -1,6 +1,30 @@
 <?php
 
 return [
+
+    'ai_review' => [
+        'page_title' => 'Review your post',
+        'title' => 'Review before generating',
+        'description' => 'Edit the copy the AI wrote. Images are only generated after you approve it.',
+        'preparing' => 'Writing your post…',
+        'failed' => 'We could not write this post. Try again.',
+        'back' => 'Back',
+        'generate' => 'Generate images',
+        'saving' => 'Saving…',
+        'saved' => 'Saved',
+        'caption' => 'Caption',
+        'caption_placeholder' => 'The caption published with the post',
+        'no_caption_for_format' => 'This format publishes no caption, so there is nothing to edit here.',
+        'field_tweet_text' => 'Tweet text',
+        'field_title' => 'Title',
+        'field_body' => 'Body',
+        'field_image_title' => 'Image headline',
+        'field_image_body' => 'Image body',
+        'field_image_keywords' => 'Photo keywords',
+        'field_image_keywords_hint' => 'Comma-separated terms used to search the photo for this card.',
+        'field_image_keywords_placeholder' => 'office, team, meeting',
+        'reorder_slide' => 'Reorder slide :number',
+    ],
     'title' => 'Posts',
     'search' => 'Search posts...',
     'all_posts' => 'All Posts',

--- a/lang/es/posts.php
+++ b/lang/es/posts.php
@@ -1,6 +1,30 @@
 <?php
 
 return [
+
+    'ai_review' => [
+        'page_title' => 'Review your post',
+        'title' => 'Review before generating',
+        'description' => 'Edit the copy the AI wrote. Images are only generated after you approve it.',
+        'preparing' => 'Writing your post…',
+        'failed' => 'We could not write this post. Try again.',
+        'back' => 'Back',
+        'generate' => 'Generate images',
+        'saving' => 'Saving…',
+        'saved' => 'Saved',
+        'caption' => 'Caption',
+        'caption_placeholder' => 'The caption published with the post',
+        'no_caption_for_format' => 'This format publishes no caption, so there is nothing to edit here.',
+        'field_tweet_text' => 'Tweet text',
+        'field_title' => 'Title',
+        'field_body' => 'Body',
+        'field_image_title' => 'Image headline',
+        'field_image_body' => 'Image body',
+        'field_image_keywords' => 'Photo keywords',
+        'field_image_keywords_hint' => 'Comma-separated terms used to search the photo for this card.',
+        'field_image_keywords_placeholder' => 'office, team, meeting',
+        'reorder_slide' => 'Reorder slide :number',
+    ],
     'title' => 'Posts',
     'search' => 'Buscar posts...',
     'all_posts' => 'Todos los posts',

--- a/lang/fr/posts.php
+++ b/lang/fr/posts.php
@@ -1,6 +1,30 @@
 <?php
 
 return [
+
+    'ai_review' => [
+        'page_title' => 'Review your post',
+        'title' => 'Review before generating',
+        'description' => 'Edit the copy the AI wrote. Images are only generated after you approve it.',
+        'preparing' => 'Writing your post…',
+        'failed' => 'We could not write this post. Try again.',
+        'back' => 'Back',
+        'generate' => 'Generate images',
+        'saving' => 'Saving…',
+        'saved' => 'Saved',
+        'caption' => 'Caption',
+        'caption_placeholder' => 'The caption published with the post',
+        'no_caption_for_format' => 'This format publishes no caption, so there is nothing to edit here.',
+        'field_tweet_text' => 'Tweet text',
+        'field_title' => 'Title',
+        'field_body' => 'Body',
+        'field_image_title' => 'Image headline',
+        'field_image_body' => 'Image body',
+        'field_image_keywords' => 'Photo keywords',
+        'field_image_keywords_hint' => 'Comma-separated terms used to search the photo for this card.',
+        'field_image_keywords_placeholder' => 'office, team, meeting',
+        'reorder_slide' => 'Reorder slide :number',
+    ],
     'title' => 'Publications',
     'search' => 'Rechercher des publications...',
     'all_posts' => 'Toutes les publications',

--- a/lang/it/posts.php
+++ b/lang/it/posts.php
@@ -1,6 +1,30 @@
 <?php
 
 return [
+
+    'ai_review' => [
+        'page_title' => 'Review your post',
+        'title' => 'Review before generating',
+        'description' => 'Edit the copy the AI wrote. Images are only generated after you approve it.',
+        'preparing' => 'Writing your post…',
+        'failed' => 'We could not write this post. Try again.',
+        'back' => 'Back',
+        'generate' => 'Generate images',
+        'saving' => 'Saving…',
+        'saved' => 'Saved',
+        'caption' => 'Caption',
+        'caption_placeholder' => 'The caption published with the post',
+        'no_caption_for_format' => 'This format publishes no caption, so there is nothing to edit here.',
+        'field_tweet_text' => 'Tweet text',
+        'field_title' => 'Title',
+        'field_body' => 'Body',
+        'field_image_title' => 'Image headline',
+        'field_image_body' => 'Image body',
+        'field_image_keywords' => 'Photo keywords',
+        'field_image_keywords_hint' => 'Comma-separated terms used to search the photo for this card.',
+        'field_image_keywords_placeholder' => 'office, team, meeting',
+        'reorder_slide' => 'Reorder slide :number',
+    ],
     'title' => 'Post',
     'search' => 'Cerca post...',
     'all_posts' => 'Tutti i post',

--- a/lang/ja/posts.php
+++ b/lang/ja/posts.php
@@ -1,6 +1,30 @@
 <?php
 
 return [
+
+    'ai_review' => [
+        'page_title' => 'Review your post',
+        'title' => 'Review before generating',
+        'description' => 'Edit the copy the AI wrote. Images are only generated after you approve it.',
+        'preparing' => 'Writing your post…',
+        'failed' => 'We could not write this post. Try again.',
+        'back' => 'Back',
+        'generate' => 'Generate images',
+        'saving' => 'Saving…',
+        'saved' => 'Saved',
+        'caption' => 'Caption',
+        'caption_placeholder' => 'The caption published with the post',
+        'no_caption_for_format' => 'This format publishes no caption, so there is nothing to edit here.',
+        'field_tweet_text' => 'Tweet text',
+        'field_title' => 'Title',
+        'field_body' => 'Body',
+        'field_image_title' => 'Image headline',
+        'field_image_body' => 'Image body',
+        'field_image_keywords' => 'Photo keywords',
+        'field_image_keywords_hint' => 'Comma-separated terms used to search the photo for this card.',
+        'field_image_keywords_placeholder' => 'office, team, meeting',
+        'reorder_slide' => 'Reorder slide :number',
+    ],
     'title' => '投稿',
     'search' => '投稿を検索...',
     'all_posts' => 'すべての投稿',

--- a/lang/ko/posts.php
+++ b/lang/ko/posts.php
@@ -1,6 +1,30 @@
 <?php
 
 return [
+
+    'ai_review' => [
+        'page_title' => 'Review your post',
+        'title' => 'Review before generating',
+        'description' => 'Edit the copy the AI wrote. Images are only generated after you approve it.',
+        'preparing' => 'Writing your post…',
+        'failed' => 'We could not write this post. Try again.',
+        'back' => 'Back',
+        'generate' => 'Generate images',
+        'saving' => 'Saving…',
+        'saved' => 'Saved',
+        'caption' => 'Caption',
+        'caption_placeholder' => 'The caption published with the post',
+        'no_caption_for_format' => 'This format publishes no caption, so there is nothing to edit here.',
+        'field_tweet_text' => 'Tweet text',
+        'field_title' => 'Title',
+        'field_body' => 'Body',
+        'field_image_title' => 'Image headline',
+        'field_image_body' => 'Image body',
+        'field_image_keywords' => 'Photo keywords',
+        'field_image_keywords_hint' => 'Comma-separated terms used to search the photo for this card.',
+        'field_image_keywords_placeholder' => 'office, team, meeting',
+        'reorder_slide' => 'Reorder slide :number',
+    ],
     'title' => '게시물',
     'search' => '게시물 검색...',
     'all_posts' => '모든 게시물',

--- a/lang/nl/posts.php
+++ b/lang/nl/posts.php
@@ -1,6 +1,30 @@
 <?php
 
 return [
+
+    'ai_review' => [
+        'page_title' => 'Review your post',
+        'title' => 'Review before generating',
+        'description' => 'Edit the copy the AI wrote. Images are only generated after you approve it.',
+        'preparing' => 'Writing your post…',
+        'failed' => 'We could not write this post. Try again.',
+        'back' => 'Back',
+        'generate' => 'Generate images',
+        'saving' => 'Saving…',
+        'saved' => 'Saved',
+        'caption' => 'Caption',
+        'caption_placeholder' => 'The caption published with the post',
+        'no_caption_for_format' => 'This format publishes no caption, so there is nothing to edit here.',
+        'field_tweet_text' => 'Tweet text',
+        'field_title' => 'Title',
+        'field_body' => 'Body',
+        'field_image_title' => 'Image headline',
+        'field_image_body' => 'Image body',
+        'field_image_keywords' => 'Photo keywords',
+        'field_image_keywords_hint' => 'Comma-separated terms used to search the photo for this card.',
+        'field_image_keywords_placeholder' => 'office, team, meeting',
+        'reorder_slide' => 'Reorder slide :number',
+    ],
     'title' => 'Posts',
     'search' => 'Posts zoeken...',
     'all_posts' => 'Alle posts',

--- a/lang/pl/posts.php
+++ b/lang/pl/posts.php
@@ -1,6 +1,30 @@
 <?php
 
 return [
+
+    'ai_review' => [
+        'page_title' => 'Review your post',
+        'title' => 'Review before generating',
+        'description' => 'Edit the copy the AI wrote. Images are only generated after you approve it.',
+        'preparing' => 'Writing your post…',
+        'failed' => 'We could not write this post. Try again.',
+        'back' => 'Back',
+        'generate' => 'Generate images',
+        'saving' => 'Saving…',
+        'saved' => 'Saved',
+        'caption' => 'Caption',
+        'caption_placeholder' => 'The caption published with the post',
+        'no_caption_for_format' => 'This format publishes no caption, so there is nothing to edit here.',
+        'field_tweet_text' => 'Tweet text',
+        'field_title' => 'Title',
+        'field_body' => 'Body',
+        'field_image_title' => 'Image headline',
+        'field_image_body' => 'Image body',
+        'field_image_keywords' => 'Photo keywords',
+        'field_image_keywords_hint' => 'Comma-separated terms used to search the photo for this card.',
+        'field_image_keywords_placeholder' => 'office, team, meeting',
+        'reorder_slide' => 'Reorder slide :number',
+    ],
     'title' => 'Posty',
     'search' => 'Szukaj postów...',
     'all_posts' => 'Wszystkie posty',

--- a/lang/pt-BR/posts.php
+++ b/lang/pt-BR/posts.php
@@ -1,6 +1,30 @@
 <?php
 
 return [
+
+    'ai_review' => [
+        'page_title' => 'Revise seu post',
+        'title' => 'Revise antes de gerar',
+        'description' => 'Edite o texto que a IA escreveu. As imagens só são geradas depois que você aprovar.',
+        'preparing' => 'Escrevendo seu post…',
+        'failed' => 'Não conseguimos escrever este post. Tente de novo.',
+        'back' => 'Voltar',
+        'generate' => 'Gerar imagens',
+        'saving' => 'Salvando…',
+        'saved' => 'Salvo',
+        'caption' => 'Legenda',
+        'caption_placeholder' => 'A legenda publicada junto com o post',
+        'no_caption_for_format' => 'Este formato não publica legenda, então não há o que editar aqui.',
+        'field_tweet_text' => 'Texto do tweet',
+        'field_title' => 'Título',
+        'field_body' => 'Descrição',
+        'field_image_title' => 'Título da imagem',
+        'field_image_body' => 'Texto da imagem',
+        'field_image_keywords' => 'Palavras-chave da foto',
+        'field_image_keywords_hint' => 'Termos separados por vírgula usados para buscar a foto deste card.',
+        'field_image_keywords_placeholder' => 'cidade, equipe, reunião',
+        'reorder_slide' => 'Reordenar slide :number',
+    ],
     'title' => 'Posts',
     'search' => 'Buscar posts...',
     'all_posts' => 'Todos os Posts',

--- a/lang/ru/posts.php
+++ b/lang/ru/posts.php
@@ -1,6 +1,30 @@
 <?php
 
 return [
+
+    'ai_review' => [
+        'page_title' => 'Review your post',
+        'title' => 'Review before generating',
+        'description' => 'Edit the copy the AI wrote. Images are only generated after you approve it.',
+        'preparing' => 'Writing your post…',
+        'failed' => 'We could not write this post. Try again.',
+        'back' => 'Back',
+        'generate' => 'Generate images',
+        'saving' => 'Saving…',
+        'saved' => 'Saved',
+        'caption' => 'Caption',
+        'caption_placeholder' => 'The caption published with the post',
+        'no_caption_for_format' => 'This format publishes no caption, so there is nothing to edit here.',
+        'field_tweet_text' => 'Tweet text',
+        'field_title' => 'Title',
+        'field_body' => 'Body',
+        'field_image_title' => 'Image headline',
+        'field_image_body' => 'Image body',
+        'field_image_keywords' => 'Photo keywords',
+        'field_image_keywords_hint' => 'Comma-separated terms used to search the photo for this card.',
+        'field_image_keywords_placeholder' => 'office, team, meeting',
+        'reorder_slide' => 'Reorder slide :number',
+    ],
     'title' => 'Посты',
     'search' => 'Поиск постов...',
     'all_posts' => 'Все посты',

--- a/lang/tr/posts.php
+++ b/lang/tr/posts.php
@@ -3,6 +3,30 @@
 declare(strict_types=1);
 
 return [
+
+    'ai_review' => [
+        'page_title' => 'Review your post',
+        'title' => 'Review before generating',
+        'description' => 'Edit the copy the AI wrote. Images are only generated after you approve it.',
+        'preparing' => 'Writing your post…',
+        'failed' => 'We could not write this post. Try again.',
+        'back' => 'Back',
+        'generate' => 'Generate images',
+        'saving' => 'Saving…',
+        'saved' => 'Saved',
+        'caption' => 'Caption',
+        'caption_placeholder' => 'The caption published with the post',
+        'no_caption_for_format' => 'This format publishes no caption, so there is nothing to edit here.',
+        'field_tweet_text' => 'Tweet text',
+        'field_title' => 'Title',
+        'field_body' => 'Body',
+        'field_image_title' => 'Image headline',
+        'field_image_body' => 'Image body',
+        'field_image_keywords' => 'Photo keywords',
+        'field_image_keywords_hint' => 'Comma-separated terms used to search the photo for this card.',
+        'field_image_keywords_placeholder' => 'office, team, meeting',
+        'reorder_slide' => 'Reorder slide :number',
+    ],
     'title' => 'Gönderiler',
     'search' => 'Gönderi ara...',
     'all_posts' => 'Tüm Gönderiler',

--- a/lang/zh/posts.php
+++ b/lang/zh/posts.php
@@ -1,6 +1,30 @@
 <?php
 
 return [
+
+    'ai_review' => [
+        'page_title' => 'Review your post',
+        'title' => 'Review before generating',
+        'description' => 'Edit the copy the AI wrote. Images are only generated after you approve it.',
+        'preparing' => 'Writing your post…',
+        'failed' => 'We could not write this post. Try again.',
+        'back' => 'Back',
+        'generate' => 'Generate images',
+        'saving' => 'Saving…',
+        'saved' => 'Saved',
+        'caption' => 'Caption',
+        'caption_placeholder' => 'The caption published with the post',
+        'no_caption_for_format' => 'This format publishes no caption, so there is nothing to edit here.',
+        'field_tweet_text' => 'Tweet text',
+        'field_title' => 'Title',
+        'field_body' => 'Body',
+        'field_image_title' => 'Image headline',
+        'field_image_body' => 'Image body',
+        'field_image_keywords' => 'Photo keywords',
+        'field_image_keywords_hint' => 'Comma-separated terms used to search the photo for this card.',
+        'field_image_keywords_placeholder' => 'office, team, meeting',
+        'reorder_slide' => 'Reorder slide :number',
+    ],
     'title' => '帖子',
     'search' => '搜索帖子…',
     'all_posts' => '所有帖子',

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-    "name": "trypost",
+    "name": "wt-review",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {

--- a/resources/js/components/posts/ai/ReviewBlockCard.vue
+++ b/resources/js/components/posts/ai/ReviewBlockCard.vue
@@ -1,0 +1,143 @@
+<script setup lang="ts">
+/* eslint-disable vue/no-mutating-props */
+import { IconGripVertical } from '@tabler/icons-vue';
+import { computed } from 'vue';
+
+import { Input } from '@/components/ui/input';
+import { Textarea } from '@/components/ui/textarea';
+
+export interface ReviewSlide {
+    role?: string;
+    title?: string;
+    body?: string;
+    tweet_text?: string;
+    image_keywords?: string[];
+}
+
+const props = defineProps<{
+    slide: ReviewSlide;
+    index: number;
+    isTweet?: boolean;
+}>();
+
+defineEmits<{
+    (e: 'grab'): void;
+    (e: 'release'): void;
+}>();
+
+// image_keywords is an array on the backend; it is edited here as comma-separated text.
+const keywordsText = computed<string>({
+    get: () => (props.slide.image_keywords ?? []).join(', '),
+    set: (value: string) => {
+        props.slide.image_keywords = value
+            .split(',')
+            .map((k) => k.trim())
+            .filter(Boolean);
+    },
+});
+
+// The generator labels each slide with its narrative role; the badge keeps that
+// visible while reordering so the arc stays readable at a glance.
+const roleStyles: Record<string, string> = {
+    hook: 'bg-amber-200 text-amber-950',
+    development: 'bg-sky-200 text-sky-950',
+    proof: 'bg-teal-200 text-teal-950',
+    cta: 'bg-foreground text-background',
+};
+
+const roleClass = computed(
+    () =>
+        roleStyles[props.slide.role ?? ''] ?? 'bg-muted text-muted-foreground',
+);
+</script>
+
+<template>
+    <div
+        class="flex h-full flex-col gap-2 rounded-xl border-2 border-foreground bg-card p-2.5 shadow-2xs"
+    >
+        <div class="flex items-center justify-between gap-1">
+            <div class="flex items-center gap-1">
+                <button
+                    type="button"
+                    class="cursor-grab touch-none text-foreground/40 hover:text-foreground active:cursor-grabbing"
+                    :aria-label="
+                        $t('posts.ai_review.reorder_slide', {
+                            number: String(index + 1),
+                        })
+                    "
+                    @mousedown="$emit('grab')"
+                    @mouseup="$emit('release')"
+                    @touchstart="$emit('grab')"
+                    @touchend="$emit('release')"
+                >
+                    <IconGripVertical class="size-4" />
+                </button>
+                <span
+                    class="inline-flex size-6 items-center justify-center rounded-lg border-2 border-foreground bg-background text-xs font-black"
+                >
+                    {{ index + 1 }}
+                </span>
+            </div>
+            <span
+                v-if="slide.role"
+                class="rounded-full px-2 py-0.5 text-[10px] font-black tracking-wide uppercase"
+                :class="roleClass"
+            >
+                {{ slide.role }}
+            </span>
+        </div>
+
+        <!-- Tweet card: just the tweet text. -->
+        <template v-if="isTweet">
+            <Textarea
+                v-model="slide.tweet_text"
+                class="min-h-64 flex-1 text-sm"
+                style="resize: vertical; field-sizing: fixed"
+                :placeholder="$t('posts.ai_review.field_tweet_text')"
+            />
+        </template>
+
+        <!-- Image card: headline, body and the photo search keywords. -->
+        <template v-else>
+            <div class="space-y-0.5">
+                <p
+                    class="text-[10px] font-black tracking-widest text-foreground/60 uppercase"
+                >
+                    {{ $t('posts.ai_review.field_title') }}
+                </p>
+                <Input v-model="slide.title" class="h-8 text-sm" />
+            </div>
+
+            <div class="space-y-0.5 border-t-2 border-foreground/10 pt-2">
+                <p
+                    class="text-[10px] font-black tracking-widest text-foreground/60 uppercase"
+                >
+                    {{ $t('posts.ai_review.field_body') }}
+                </p>
+                <Textarea
+                    v-model="slide.body"
+                    class="min-h-32 text-sm"
+                    style="resize: vertical; field-sizing: fixed"
+                />
+            </div>
+
+            <div class="space-y-1 border-t-2 border-foreground/10 pt-2">
+                <p
+                    class="text-[10px] font-black tracking-widest text-foreground/60 uppercase"
+                >
+                    {{ $t('posts.ai_review.field_image_keywords') }}
+                </p>
+                <p class="text-[10px] leading-tight text-muted-foreground">
+                    {{ $t('posts.ai_review.field_image_keywords_hint') }}
+                </p>
+                <Input
+                    v-model="keywordsText"
+                    class="h-8 text-sm"
+                    :placeholder="
+                        $t('posts.ai_review.field_image_keywords_placeholder')
+                    "
+                />
+            </div>
+        </template>
+    </div>
+</template>

--- a/resources/js/components/posts/create/AiPostWizard.vue
+++ b/resources/js/components/posts/create/AiPostWizard.vue
@@ -9,15 +9,15 @@ import { computed, ref, watch } from 'vue';
 import { toast } from 'vue-sonner';
 
 
-import { start as startRoute } from '@/actions/App/Http/Controllers/App/PostAiCreateController';
 import ContentStylePicker from '@/components/ai/ContentStylePicker.vue';
 import { Button } from '@/components/ui/button';
 import { Label } from '@/components/ui/label';
 import { Switch } from '@/components/ui/switch';
 import { Textarea } from '@/components/ui/textarea';
 import { getPlatformLogo } from '@/composables/usePlatformLogo';
-import { loading as loadingRoute } from '@/routes/app/posts/ai';
 import { ContentType, type ContentTypeValue } from '@/types/content-type';
+
+import { prepare as prepareRoute, review as reviewRoute } from '@/routes/app/posts/ai/drafts';
 
 interface SocialAccount {
     id: string;
@@ -220,18 +220,12 @@ const startGeneration = async () => {
     httpStart.apply_brand_visuals = useBrandColors.value;
 
     try {
-        const data = await httpStart.post(startRoute.url()) as { creation_id: string; channel: string };
+        // Phase A: pre-generate only the text, then hand over to the review
+        // screen. Images (the expensive part) are rendered from there, after
+        // the user has approved the copy.
+        const data = await httpStart.post(prepareRoute.url()) as { draft_id: string; channel: string };
 
-        router.visit(loadingRoute(
-            { creationId: data.creation_id },
-            {
-                query: {
-                    images: String(submittedImageCount.value),
-                    format: selectedFormat.value ?? '',
-                    prompt: promptText.value.trim(),
-                },
-            },
-        ).url);
+        router.visit(reviewRoute.url({ draft: data.draft_id }));
     } catch (err: any) {
         toast.error(err?.response?.data?.message ?? trans('posts.create.steps.preview_error'));
         submitting.value = false;

--- a/resources/js/pages/posts/ai/Review.vue
+++ b/resources/js/pages/posts/ai/Review.vue
@@ -1,0 +1,562 @@
+<script setup lang="ts">
+import { Head, router, useHttp } from '@inertiajs/vue3';
+import { echo } from '@laravel/echo-vue';
+import {
+    IconAlertTriangle,
+    IconArrowLeft,
+    IconCheck,
+    IconLoader2,
+    IconSparkles,
+} from '@tabler/icons-vue';
+import { trans } from 'laravel-vue-i18n';
+import {
+    computed,
+    nextTick,
+    onBeforeUnmount,
+    onMounted,
+    reactive,
+    ref,
+    watch,
+} from 'vue';
+import { toast } from 'vue-sonner';
+
+import PageHeader from '@/components/PageHeader.vue';
+import ReviewBlockCard, {
+    type ReviewSlide,
+} from '@/components/posts/ai/ReviewBlockCard.vue';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Textarea } from '@/components/ui/textarea';
+import AppLayout from '@/layouts/AppLayout.vue';
+
+import { create as createPostRoute } from '@/routes/app/posts';
+import { loading as loadingRoute } from '@/routes/app/posts/ai';
+import {
+    autosave as autosaveDraftRoute,
+    generate as generateDraftRoute,
+} from '@/routes/app/posts/ai/drafts';
+
+interface ReviewDraft {
+    id: string;
+    status: string;
+    format: string;
+    template: string;
+    is_carousel: boolean;
+    image_count: number;
+    supports_caption?: boolean;
+    structured: Record<string, any> | null;
+    error: string | null;
+    channel: string;
+}
+
+const props = defineProps<{ draft: ReviewDraft }>();
+
+const status = ref(props.draft.status);
+const submitting = ref(false);
+
+interface ReviewForm {
+    caption?: string;
+    content?: string;
+    image_title?: string;
+    image_body?: string;
+    image_keywords?: string[];
+    tweet_text?: string;
+    slides: ReviewSlide[];
+}
+
+const form = reactive<ReviewForm>({ slides: [] });
+
+const isCarousel = computed(() => props.draft.is_carousel);
+// Formats that publish no caption (stories and the like) hide the field and
+// explain why, instead of letting the user edit text that never ships.
+const supportsCaption = computed(() => props.draft.supports_caption ?? true);
+// Tweet-card templates carry `tweet_text` instead of the image-card fields.
+const isTweet = computed(() => (props.draft.template ?? '').includes('tweet'));
+const isPreparing = computed(() => status.value === 'preparing');
+const isFailed = computed(() => status.value === 'failed');
+const isReady = computed(
+    () =>
+        !isPreparing.value &&
+        !isFailed.value &&
+        (props.draft.structured !== null || form.slides.length > 0),
+);
+
+const skeletonCount = computed(() =>
+    isCarousel.value ? Math.max(1, props.draft.image_count) : 1,
+);
+
+const singleKeywordsText = computed<string>({
+    get: () => (form.image_keywords ?? []).join(', '),
+    set: (value: string) => {
+        form.image_keywords = value
+            .split(',')
+            .map((k) => k.trim())
+            .filter(Boolean);
+    },
+});
+
+// While true the autosave watcher ignores changes: this is hydration, not a user edit.
+let hydrating = false;
+
+const hydrateForm = (structured: Record<string, any> | null) => {
+    if (!structured) {
+        return;
+    }
+
+    hydrating = true;
+    nextTick(() => {
+        hydrating = false;
+    });
+
+    if (isCarousel.value) {
+        form.caption = (structured.caption as string) ?? '';
+        form.slides = ((structured.slides as ReviewSlide[]) ?? []).map((s) => ({
+            ...s,
+            image_keywords: [...((s.image_keywords as string[]) ?? [])],
+        }));
+    } else if (isTweet.value) {
+        form.tweet_text = (structured.tweet_text as string) ?? '';
+    } else {
+        form.content = (structured.content as string) ?? '';
+        form.image_title = (structured.image_title as string) ?? '';
+        form.image_body = (structured.image_body as string) ?? '';
+        form.image_keywords = [
+            ...((structured.image_keywords as string[]) ?? []),
+        ];
+    }
+};
+
+let channel: unknown = null;
+// Safety poll: if the broadcast is missed (the job finished between render and
+// subscribe), the periodic reload reconciles instead of hanging on the skeleton.
+let pollTimer: ReturnType<typeof setInterval> | null = null;
+
+const subscribe = () => {
+    channel = echo()
+        .private(props.draft.channel)
+        .listen('.ai.content.prepared', (e: { error?: string }) => {
+            if (e.error) {
+                status.value = 'failed';
+                return;
+            }
+            // Reload the draft (now carrying the structure) without leaving the page.
+            router.reload({ only: ['draft'] });
+        });
+};
+
+const startWaiting = () => {
+    subscribe();
+    pollTimer = setInterval(() => router.reload({ only: ['draft'] }), 4000);
+};
+
+const stopWaiting = () => {
+    if (channel) {
+        echo().leave(`private-${props.draft.channel}`);
+        channel = null;
+    }
+    if (pollTimer) {
+        clearInterval(pollTimer);
+        pollTimer = null;
+    }
+};
+
+onMounted(() => {
+    status.value = props.draft.status;
+    if (props.draft.structured) {
+        hydrateForm(props.draft.structured);
+    }
+    if (props.draft.status === 'preparing') {
+        startWaiting();
+    }
+});
+
+onBeforeUnmount(stopWaiting);
+
+// After the Inertia reload (prepared event), rehydrate with the finished text.
+watch(
+    () => props.draft,
+    (draft) => {
+        status.value = draft.status;
+        if (draft.status !== 'preparing') {
+            if (draft.structured) {
+                hydrateForm(draft.structured);
+            }
+            stopWaiting();
+        }
+    },
+    { deep: true },
+);
+
+// Shallow (non-recursive) payload type — avoids FormDataType's "excessively deep" error.
+type StructuredField = string | string[] | undefined;
+type StructuredSlide = Record<string, StructuredField>;
+type StructuredPayload = Record<string, StructuredField | StructuredSlide[]>;
+
+const buildStructured = (): StructuredPayload => {
+    if (isCarousel.value) {
+        return {
+            caption: form.caption,
+            slides: form.slides as StructuredSlide[],
+        };
+    }
+    if (isTweet.value) {
+        return { tweet_text: form.tweet_text };
+    }
+
+    return {
+        content: form.content,
+        image_title: form.image_title,
+        image_body: form.image_body,
+        image_keywords: form.image_keywords,
+    };
+};
+
+const httpGenerate = useHttp<{ structured: StructuredPayload }>({
+    structured: {},
+});
+
+const generate = async () => {
+    if (submitting.value) {
+        return;
+    }
+    submitting.value = true;
+    httpGenerate.structured = buildStructured();
+
+    try {
+        const data = (await httpGenerate.post(
+            generateDraftRoute.url({ draft: props.draft.id }),
+        )) as { creation_id: string };
+
+        router.visit(
+            loadingRoute(
+                { creationId: data.creation_id },
+                {
+                    query: {
+                        images: String(props.draft.image_count),
+                        format: props.draft.format,
+                    },
+                },
+            ).url,
+        );
+    } catch (err: any) {
+        submitting.value = false;
+        toast.error(
+            err?.response?.data?.message ??
+                trans('posts.create.steps.preview_error'),
+        );
+    }
+};
+
+const goBack = () => {
+    router.visit(createPostRoute().url);
+};
+
+// Slide reordering. `dragEnabled` only turns on while the grip is held, so it
+// never interferes with selecting text inside the inputs.
+const dragEnabled = ref(false);
+const draggingIndex = ref<number | null>(null);
+const dragOverIndex = ref<number | null>(null);
+
+const onDragStart = (i: number) => {
+    draggingIndex.value = i;
+};
+
+const onDragOver = (i: number) => {
+    dragOverIndex.value = i;
+};
+
+const onDrop = (i: number) => {
+    const from = draggingIndex.value;
+    if (from === null || from === i) {
+        return;
+    }
+    const slides = [...form.slides];
+    const [moved] = slides.splice(from, 1);
+    slides.splice(i, 0, moved);
+    form.slides = slides;
+};
+
+const onDragEnd = () => {
+    draggingIndex.value = null;
+    dragOverIndex.value = null;
+    dragEnabled.value = false;
+};
+
+// Autosave: every edit persists the draft (debounced) with a status indicator.
+const saveState = ref<'idle' | 'saving' | 'saved'>('idle');
+const httpAutosave = useHttp<{ structured: StructuredPayload }>({
+    structured: {},
+});
+let saveTimer: ReturnType<typeof setTimeout> | null = null;
+
+const scheduleAutosave = () => {
+    if (saveTimer) {
+        clearTimeout(saveTimer);
+    }
+    saveState.value = 'saving';
+    saveTimer = setTimeout(async () => {
+        httpAutosave.structured = buildStructured();
+        try {
+            await httpAutosave.post(
+                autosaveDraftRoute.url({ draft: props.draft.id }),
+            );
+            saveState.value = 'saved';
+        } catch {
+            saveState.value = 'idle';
+        }
+    }, 1200);
+};
+
+watch(
+    form,
+    () => {
+        if (hydrating || !isReady.value || submitting.value) {
+            return;
+        }
+        scheduleAutosave();
+    },
+    { deep: true },
+);
+
+onBeforeUnmount(() => {
+    if (saveTimer) {
+        clearTimeout(saveTimer);
+    }
+});
+</script>
+
+<template>
+    <Head :title="$t('posts.ai_review.page_title')" />
+
+    <AppLayout>
+        <div
+            class="mx-auto flex w-full flex-col gap-6 p-4"
+            :class="isCarousel ? 'max-w-5xl' : 'max-w-2xl'"
+        >
+            <PageHeader
+                :title="$t('posts.ai_review.title')"
+                :description="$t('posts.ai_review.description')"
+            />
+
+            <!-- Preparing: skeleton on the same grid while the text is generated. -->
+            <div v-if="isPreparing" class="space-y-4">
+                <div
+                    class="inline-flex items-center gap-2 rounded-full border-2 border-foreground bg-card px-3 py-1.5 text-xs font-bold text-foreground shadow-2xs"
+                >
+                    <IconLoader2 class="size-4 animate-spin" />
+                    {{ $t('posts.ai_review.preparing') }}
+                </div>
+
+                <div class="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+                    <div
+                        v-for="n in skeletonCount"
+                        :key="n"
+                        class="animate-pulse space-y-2 rounded-xl border-2 border-foreground/30 bg-card p-2.5"
+                    >
+                        <div class="flex items-center justify-between">
+                            <div class="flex items-center gap-1.5">
+                                <div class="h-4 w-2 rounded bg-muted"></div>
+                                <div class="size-6 rounded-lg bg-muted"></div>
+                            </div>
+                            <div class="h-4 w-16 rounded-full bg-muted"></div>
+                        </div>
+
+                        <div class="h-64 w-full rounded-md bg-muted"></div>
+
+                        <div
+                            class="space-y-1 border-t-2 border-foreground/10 pt-2"
+                        >
+                            <div class="h-2.5 w-24 rounded bg-muted"></div>
+                            <div class="h-8 w-full rounded-md bg-muted"></div>
+                        </div>
+                    </div>
+                </div>
+
+                <div v-if="isCarousel" class="animate-pulse space-y-1.5">
+                    <div class="h-4 w-24 rounded bg-muted"></div>
+                    <div
+                        class="h-40 w-full rounded-md border-2 border-foreground/30 bg-muted"
+                    ></div>
+                </div>
+            </div>
+
+            <!-- The text generation failed. -->
+            <div
+                v-else-if="isFailed"
+                class="flex flex-col items-center gap-4 rounded-2xl border-2 border-foreground bg-destructive/10 p-6 text-center shadow-2xs"
+            >
+                <span
+                    class="flex size-12 items-center justify-center rounded-2xl border-2 border-foreground bg-destructive/20"
+                >
+                    <IconAlertTriangle class="size-6 text-destructive" />
+                </span>
+                <p class="text-sm font-semibold text-destructive">
+                    {{ $t('posts.ai_review.failed') }}
+                </p>
+                <Button variant="outline" @click="goBack">{{
+                    $t('posts.ai_review.back')
+                }}</Button>
+            </div>
+
+            <!-- Review: editable blocks. -->
+            <template v-else-if="isReady">
+                <!-- Carousel: grid of cards, draggable to reorder. -->
+                <template v-if="isCarousel">
+                    <div class="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+                        <div
+                            v-for="(slide, i) in form.slides"
+                            :key="i"
+                            :draggable="dragEnabled"
+                            class="rounded-xl transition"
+                            :class="[
+                                dragOverIndex === i && draggingIndex !== i
+                                    ? 'ring-2 ring-primary ring-offset-2'
+                                    : '',
+                                draggingIndex === i ? 'opacity-40' : '',
+                            ]"
+                            @dragstart="onDragStart(i)"
+                            @dragover.prevent="onDragOver(i)"
+                            @drop="onDrop(i)"
+                            @dragend="onDragEnd"
+                        >
+                            <ReviewBlockCard
+                                :slide="slide"
+                                :index="i"
+                                :is-tweet="isTweet"
+                                @grab="dragEnabled = true"
+                                @release="dragEnabled = false"
+                            />
+                        </div>
+                    </div>
+
+                    <div class="space-y-1">
+                        <Label class="text-sm font-bold">{{
+                            $t('posts.ai_review.caption')
+                        }}</Label>
+                        <Textarea
+                            v-model="form.caption"
+                            class="min-h-40"
+                            style="resize: vertical; field-sizing: fixed"
+                            :placeholder="
+                                $t('posts.ai_review.caption_placeholder')
+                            "
+                        />
+                    </div>
+                </template>
+
+                <!-- Single post: tweet card. -->
+                <div
+                    v-else-if="isTweet"
+                    class="space-y-3 rounded-2xl border-2 border-foreground bg-card p-4 shadow-2xs"
+                >
+                    <div class="space-y-1">
+                        <Label class="text-xs font-bold text-foreground/70">{{
+                            $t('posts.ai_review.field_tweet_text')
+                        }}</Label>
+                        <Textarea
+                            v-model="form.tweet_text"
+                            class="min-h-64"
+                            style="resize: vertical; field-sizing: fixed"
+                        />
+                    </div>
+                </div>
+
+                <!-- Single post: image card. -->
+                <div
+                    v-else
+                    class="space-y-3 rounded-2xl border-2 border-foreground bg-card p-4 shadow-2xs"
+                >
+                    <div v-if="supportsCaption" class="space-y-1">
+                        <Label class="text-xs font-bold text-foreground/70">{{
+                            $t('posts.ai_review.caption')
+                        }}</Label>
+                        <Textarea
+                            v-model="form.content"
+                            class="min-h-40"
+                            style="resize: vertical; field-sizing: fixed"
+                        />
+                    </div>
+                    <p
+                        v-else
+                        class="rounded-lg border-2 border-foreground/15 bg-muted/50 px-3 py-2 text-xs text-muted-foreground"
+                    >
+                        {{ $t('posts.ai_review.no_caption_for_format') }}
+                    </p>
+                    <div class="space-y-1">
+                        <Label class="text-xs font-bold text-foreground/70">{{
+                            $t('posts.ai_review.field_image_title')
+                        }}</Label>
+                        <Input v-model="form.image_title" />
+                    </div>
+                    <div class="space-y-1">
+                        <Label class="text-xs font-bold text-foreground/70">{{
+                            $t('posts.ai_review.field_image_body')
+                        }}</Label>
+                        <Textarea
+                            v-model="form.image_body"
+                            class="min-h-40"
+                            style="resize: vertical; field-sizing: fixed"
+                        />
+                    </div>
+                    <div class="space-y-1">
+                        <Label class="text-xs font-bold text-foreground/70">{{
+                            $t('posts.ai_review.field_image_keywords')
+                        }}</Label>
+                        <p
+                            class="text-[11px] leading-tight text-muted-foreground"
+                        >
+                            {{
+                                $t('posts.ai_review.field_image_keywords_hint')
+                            }}
+                        </p>
+                        <Input
+                            v-model="singleKeywordsText"
+                            :placeholder="
+                                $t(
+                                    'posts.ai_review.field_image_keywords_placeholder',
+                                )
+                            "
+                        />
+                    </div>
+                </div>
+
+                <!-- Action bar: sticky inside the column, so it respects the sidebar. -->
+                <div
+                    class="sticky bottom-0 z-20 -mx-4 flex items-center gap-3 border-t-2 border-foreground bg-background/95 px-4 py-4 backdrop-blur"
+                >
+                    <Button
+                        variant="outline"
+                        :disabled="submitting"
+                        @click="goBack"
+                    >
+                        <IconArrowLeft class="size-4" />
+                        {{ $t('posts.ai_review.back') }}
+                    </Button>
+
+                    <span
+                        class="flex flex-1 items-center justify-center gap-1.5 text-xs text-muted-foreground"
+                    >
+                        <template v-if="saveState === 'saving'">
+                            <IconLoader2 class="size-3.5 animate-spin" />
+                            {{ $t('posts.ai_review.saving') }}
+                        </template>
+                        <template v-else-if="saveState === 'saved'">
+                            <IconCheck class="size-3.5" />
+                            {{ $t('posts.ai_review.saved') }}
+                        </template>
+                    </span>
+
+                    <Button :disabled="submitting" @click="generate">
+                        <IconLoader2
+                            v-if="submitting"
+                            class="size-4 animate-spin"
+                        />
+                        <IconSparkles v-else class="size-4" />
+                        {{ $t('posts.ai_review.generate') }}
+                    </Button>
+                </div>
+            </template>
+        </div>
+    </AppLayout>
+</template>

--- a/routes/app.php
+++ b/routes/app.php
@@ -204,6 +204,11 @@ Route::middleware(['auth', EnsureAccountReady::class, EnsureHasWorkspace::class]
     Route::post('posts/{post}/ai/review', [PostAiReviewController::class, 'review'])->name('app.posts.ai.review');
     Route::post('posts/ai/create', [PostAiCreateController::class, 'start'])->name('app.posts.ai.create');
     Route::get('posts/ai/{creationId}/loading', [PostAiCreateController::class, 'loading'])->name('app.posts.ai.loading')->whereUuid('creationId');
+    Route::get('posts/ai/{creationId}/status', [PostAiCreateController::class, 'creationStatus'])->name('app.posts.ai.creation-status')->whereUuid('creationId');
+    Route::post('posts/ai/drafts/prepare', [PostAiCreateController::class, 'prepare'])->name('app.posts.ai.drafts.prepare');
+    Route::get('posts/ai/drafts/{draft}/review', [PostAiCreateController::class, 'review'])->name('app.posts.ai.drafts.review')->whereUuid('draft');
+    Route::post('posts/ai/drafts/{draft}/generate', [PostAiCreateController::class, 'generate'])->name('app.posts.ai.drafts.generate')->whereUuid('draft');
+    Route::post('posts/ai/drafts/{draft}/autosave', [PostAiCreateController::class, 'autosave'])->name('app.posts.ai.drafts.autosave')->whereUuid('draft');
 
     // Post Comments
     Route::get('posts/{post}/comments', [PostCommentController::class, 'index'])->name('app.posts.comments.index');

--- a/routes/channels.php
+++ b/routes/channels.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 use App\Broadcasting\AutomationChannel;
 use App\Broadcasting\PostChannel;
 use App\Broadcasting\UserAiCreationChannel;
+use App\Broadcasting\UserAiDraftChannel;
 use App\Broadcasting\UserAiGenerationChannel;
 use App\Broadcasting\UserAiMediaRegenerationChannel;
 use App\Broadcasting\WorkspaceChannel;
@@ -22,5 +23,6 @@ Broadcast::channel('workspace.{workspace}.user.{owner}', WorkspaceUserChannel::c
 Broadcast::channel('user.{owner}.ai-gen.{generationId}', UserAiGenerationChannel::class);
 
 Broadcast::channel('user.{owner}.ai-creation.{creationId}', UserAiCreationChannel::class);
+Broadcast::channel('user.{owner}.ai-draft.{draftId}', UserAiDraftChannel::class);
 
 Broadcast::channel('user.{owner}.ai-media.{regenerationId}', UserAiMediaRegenerationChannel::class);

--- a/tests/Feature/Ai/CreationStatusTest.php
+++ b/tests/Feature/Ai/CreationStatusTest.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Enums\Ai\DraftStatus;
+use App\Enums\UserWorkspace\Role;
+use App\Models\AiPostDraft;
+use App\Models\Post;
+use App\Models\User;
+use App\Models\Workspace;
+use Illuminate\Support\Str;
+
+beforeEach(function () {
+    $this->user = User::factory()->create();
+    $this->workspace = Workspace::factory()->create(['user_id' => $this->user->id]);
+    $this->workspace->members()->attach($this->user->id, ['role' => Role::Member->value]);
+    $this->user->update(['current_workspace_id' => $this->workspace->id]);
+});
+
+function makeDraft(Workspace $workspace, User $user, DraftStatus $status, ?string $postId = null): AiPostDraft
+{
+    return AiPostDraft::create([
+        'workspace_id' => $workspace->id,
+        'user_id' => $user->id,
+        'format' => 'instagram_carousel',
+        'template' => 'tweet_mock_light',
+        'image_count' => 5,
+        'prompt' => 'teste',
+        'status' => $status,
+        'post_id' => $postId,
+        'error' => $status === DraftStatus::Failed ? 'Algo deu errado.' : null,
+    ]);
+}
+
+test('status returns done with post id for a completed draft', function () {
+    $post = Post::factory()->create(['workspace_id' => $this->workspace->id, 'user_id' => $this->user->id]);
+    $draft = makeDraft($this->workspace, $this->user, DraftStatus::Completed, $post->id);
+
+    $this->actingAs($this->user)
+        ->getJson(route('app.posts.ai.creation-status', $draft->id))
+        ->assertOk()
+        ->assertJson(['status' => 'done', 'post_id' => $post->id]);
+});
+
+test('status returns pending while generating and error when failed', function () {
+    $generating = makeDraft($this->workspace, $this->user, DraftStatus::Generating);
+    $failed = makeDraft($this->workspace, $this->user, DraftStatus::Failed);
+
+    $this->actingAs($this->user)
+        ->getJson(route('app.posts.ai.creation-status', $generating->id))
+        ->assertJson(['status' => 'pending']);
+
+    $this->actingAs($this->user)
+        ->getJson(route('app.posts.ai.creation-status', $failed->id))
+        ->assertJson(['status' => 'error', 'error' => 'Algo deu errado.']);
+});
+
+test('status is unknown for missing ids and drafts of other workspaces', function () {
+    $foreign = makeDraft(Workspace::factory()->create(), User::factory()->create(), DraftStatus::Completed);
+
+    $this->actingAs($this->user)
+        ->getJson(route('app.posts.ai.creation-status', (string) Str::uuid()))
+        ->assertJson(['status' => 'unknown']);
+
+    $this->actingAs($this->user)
+        ->getJson(route('app.posts.ai.creation-status', $foreign->id))
+        ->assertJson(['status' => 'unknown']);
+});

--- a/tests/Feature/Ai/PostAiReviewFlowTest.php
+++ b/tests/Feature/Ai/PostAiReviewFlowTest.php
@@ -1,0 +1,259 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Ai\Agents\PostContentGenerator;
+use App\Ai\Agents\PostContentHumanizer;
+use App\Enums\Ai\DraftStatus;
+use App\Enums\SocialAccount\Platform;
+use App\Enums\UserWorkspace\Role;
+use App\Jobs\Ai\PreparePostContent;
+use App\Jobs\Ai\StreamPostCreation;
+use App\Models\AiPostDraft;
+use App\Models\SocialAccount;
+use App\Models\User;
+use App\Models\Workspace;
+use Illuminate\Support\Facades\Bus;
+use Symfony\Component\HttpFoundation\Response;
+
+beforeEach(function () {
+    $this->user = User::factory()->create();
+    $this->workspace = Workspace::factory()->create(['user_id' => $this->user->id]);
+    $this->workspace->members()->attach($this->user->id, ['role' => Role::Member->value]);
+    $this->user->update(['current_workspace_id' => $this->workspace->id]);
+});
+
+test('prepare requires authentication', function () {
+    $this->postJson(route('app.posts.ai.drafts.prepare'), ['prompt' => 'x', 'format' => 'x_post'])
+        ->assertStatus(Response::HTTP_UNAUTHORIZED);
+});
+
+test('prepare creates a draft and dispatches PreparePostContent', function () {
+    Bus::fake();
+
+    $account = SocialAccount::factory()->create([
+        'workspace_id' => $this->workspace->id,
+        'platform' => Platform::Instagram,
+    ]);
+
+    $response = $this->actingAs($this->user)
+        ->postJson(route('app.posts.ai.drafts.prepare'), [
+            'prompt' => 'Five tips about productivity',
+            'format' => 'instagram_carousel',
+            'social_account_id' => $account->id,
+            'image_count' => 3,
+        ])
+        ->assertStatus(Response::HTTP_ACCEPTED)
+        ->assertJsonStructure(['draft_id', 'channel']);
+
+    $draftId = $response->json('draft_id');
+    $draft = AiPostDraft::find($draftId);
+
+    expect($draft)->not->toBeNull();
+    expect($draft->status)->toBe(DraftStatus::Preparing);
+    expect($draft->workspace_id)->toBe($this->workspace->id);
+    expect($draft->image_count)->toBe(3);
+
+    Bus::assertDispatched(PreparePostContent::class, fn ($job) => $job->draftId === $draftId);
+});
+
+test('prepare rejects social_account_id from another workspace', function () {
+    Bus::fake();
+
+    $other = Workspace::factory()->create();
+    $foreign = SocialAccount::factory()->create([
+        'workspace_id' => $other->id,
+        'platform' => Platform::X,
+    ]);
+
+    $this->actingAs($this->user)
+        ->postJson(route('app.posts.ai.drafts.prepare'), [
+            'prompt' => 'hello',
+            'format' => 'x_post',
+            'social_account_id' => $foreign->id,
+        ])
+        ->assertStatus(Response::HTTP_FORBIDDEN);
+});
+
+test('review renders the review page for the own draft', function () {
+    $draft = AiPostDraft::factory()->ready(['caption' => 'c', 'slides' => []])->create([
+        'workspace_id' => $this->workspace->id,
+        'user_id' => $this->user->id,
+    ]);
+
+    $this->actingAs($this->user)
+        ->get(route('app.posts.ai.drafts.review', $draft->id))
+        ->assertOk()
+        ->assertInertia(fn ($page) => $page->component('posts/ai/Review')->where('draft.id', $draft->id));
+});
+
+test('review forbids another users draft', function () {
+    $other = Workspace::factory()->create();
+    $draft = AiPostDraft::factory()->create(['workspace_id' => $other->id]);
+
+    $this->actingAs($this->user)
+        ->get(route('app.posts.ai.drafts.review', $draft->id))
+        ->assertForbidden();
+});
+
+test('generate saves the reviewed structure and dispatches StreamPostCreation with the prepared structure', function () {
+    Bus::fake();
+
+    $account = SocialAccount::factory()->create([
+        'workspace_id' => $this->workspace->id,
+        'platform' => Platform::Instagram,
+    ]);
+
+    $draft = AiPostDraft::factory()->create([
+        'workspace_id' => $this->workspace->id,
+        'user_id' => $this->user->id,
+        'social_account_id' => $account->id,
+        'format' => 'instagram_carousel',
+        'image_count' => 2,
+        'status' => DraftStatus::Ready,
+    ]);
+
+    $structured = [
+        'caption' => 'edited caption',
+        'slides' => [
+            ['role' => 'hook', 'title' => 'A', 'body' => 'B', 'image_keywords' => ['x']],
+        ],
+    ];
+
+    $this->actingAs($this->user)
+        ->postJson(route('app.posts.ai.drafts.generate', $draft->id), ['structured' => $structured])
+        ->assertStatus(Response::HTTP_ACCEPTED)
+        ->assertJson(['creation_id' => $draft->id]);
+
+    $draft->refresh();
+    expect($draft->status)->toBe(DraftStatus::Generating);
+    expect($draft->structured)->toBe($structured);
+
+    Bus::assertDispatched(
+        StreamPostCreation::class,
+        fn ($job) => $job->draftId === $draft->id
+            && $job->creationId === $draft->id
+            && $job->preparedStructured === $structured,
+    );
+});
+
+test('generate rejects a draft that is not ready (replay guard)', function () {
+    Bus::fake();
+
+    $draft = AiPostDraft::factory()->create([
+        'workspace_id' => $this->workspace->id,
+        'user_id' => $this->user->id,
+        'status' => DraftStatus::Generating,
+    ]);
+
+    $this->actingAs($this->user)
+        ->postJson(route('app.posts.ai.drafts.generate', $draft->id), ['structured' => ['caption' => 'x']])
+        ->assertStatus(Response::HTTP_CONFLICT);
+
+    Bus::assertNotDispatched(StreamPostCreation::class);
+});
+
+test('generate forbids another workspace draft', function () {
+    Bus::fake();
+
+    $other = Workspace::factory()->create();
+    $draft = AiPostDraft::factory()->create(['workspace_id' => $other->id]);
+
+    $this->actingAs($this->user)
+        ->postJson(route('app.posts.ai.drafts.generate', $draft->id), ['structured' => ['caption' => 'x']])
+        ->assertForbidden();
+});
+
+test('autosave persists the structure while the draft is ready', function () {
+    $draft = AiPostDraft::factory()->create([
+        'workspace_id' => $this->workspace->id,
+        'user_id' => $this->user->id,
+        'status' => DraftStatus::Ready,
+    ]);
+
+    $structured = ['caption' => 'auto-saved', 'slides' => [['title' => 'x']]];
+
+    $this->actingAs($this->user)
+        ->postJson(route('app.posts.ai.drafts.autosave', $draft->id), ['structured' => $structured])
+        ->assertNoContent();
+
+    expect($draft->fresh()->structured)->toBe($structured);
+});
+
+test('autosave is a no-op once the draft left the ready state', function () {
+    $draft = AiPostDraft::factory()->create([
+        'workspace_id' => $this->workspace->id,
+        'user_id' => $this->user->id,
+        'status' => DraftStatus::Generating,
+        'structured' => ['caption' => 'original'],
+    ]);
+
+    $this->actingAs($this->user)
+        ->postJson(route('app.posts.ai.drafts.autosave', $draft->id), ['structured' => ['caption' => 'changed']])
+        ->assertNoContent();
+
+    expect($draft->fresh()->structured)->toBe(['caption' => 'original']);
+});
+
+test('autosave forbids another workspace draft', function () {
+    $other = Workspace::factory()->create();
+    $draft = AiPostDraft::factory()->create(['workspace_id' => $other->id, 'status' => DraftStatus::Ready]);
+
+    $this->actingAs($this->user)
+        ->postJson(route('app.posts.ai.drafts.autosave', $draft->id), ['structured' => ['caption' => 'x']])
+        ->assertForbidden();
+});
+
+test('generate validates structured is required', function () {
+    Bus::fake();
+
+    $draft = AiPostDraft::factory()->create([
+        'workspace_id' => $this->workspace->id,
+        'user_id' => $this->user->id,
+    ]);
+
+    $this->actingAs($this->user)
+        ->postJson(route('app.posts.ai.drafts.generate', $draft->id), [])
+        ->assertStatus(Response::HTTP_UNPROCESSABLE_ENTITY)
+        ->assertJsonValidationErrors(['structured']);
+});
+
+test('PreparePostContent composes the text and marks the draft ready, preserving untouched fields', function () {
+    PostContentGenerator::fake([[
+        'caption' => 'Swipe to see',
+        'slides' => [
+            ['role' => 'hook', 'title' => 'T', 'body' => 'B', 'image_keywords' => ['sunrise', 'desk']],
+        ],
+    ]]);
+    PostContentHumanizer::fake([[
+        'caption' => 'Swipe to see',
+        'slides' => [
+            ['title' => 'T polished', 'body' => 'B polished'],
+        ],
+    ]]);
+
+    $account = SocialAccount::factory()->create([
+        'workspace_id' => $this->workspace->id,
+        'platform' => Platform::Instagram,
+    ]);
+
+    $draft = AiPostDraft::factory()->create([
+        'workspace_id' => $this->workspace->id,
+        'user_id' => $this->user->id,
+        'social_account_id' => $account->id,
+        'format' => 'instagram_carousel',
+        'image_count' => 1,
+        'status' => DraftStatus::Preparing,
+    ]);
+
+    (new PreparePostContent($draft->id))->handle();
+
+    $draft->refresh();
+
+    expect($draft->status)->toBe(DraftStatus::Ready);
+    expect($draft->structured['caption'])->toBe('Swipe to see');
+    // The humanizer only returns title/body; role and image_keywords survive the merge.
+    expect($draft->structured['slides'][0]['title'])->toBe('T polished');
+    expect($draft->structured['slides'][0]['role'])->toBe('hook');
+    expect($draft->structured['slides'][0]['image_keywords'])->toBe(['sunrise', 'desk']);
+});


### PR DESCRIPTION
## Problem

AI creation is one shot: the wizard sends the prompt and `StreamPostCreation` writes the copy AND renders the images in a single pass. The user only sees the result once everything has been generated and the post already exists.

That is expensive and frustrating. Images are the costly part of a generation, so a weak headline, an off-tone caption, or a carousel whose slides arrived in the wrong order all cost a full image render before the user can react — and fixing it means starting over and paying again.

## Change

Generation is split into two phases, with a review step in between.

**Phase A** (`PreparePostContent`) writes only the structured text — the same generator and humanizer as today, no images — and stores it on a new `AiPostDraft`.

**The review screen** shows that text as editable blocks: headline, body, caption, photo keywords, and for carousels one card per slide, reorderable by dragging. Edits autosave (debounced) so nothing is lost.

**Phase B** reuses `StreamPostCreation` with the approved structure, so it skips text generation and renders images from exactly what the user signed off on.

The one-shot path is untouched: `StreamPostCreation` without `preparedStructured` behaves exactly as before.

## How

- **`PostContentComposer`** — the "generate, then humanize" step lifted out of `StreamPostCreation` verbatim so both phases share one implementation. This is a pure extraction: no behaviour change.
- **`AiPostDraft` + `DraftStatus`** (`preparing/ready/generating/completed/failed`) hold the draft between phases. `generate` refuses a draft that is not `ready`, so a double click or a re-POST cannot create a duplicate post or bill images twice.
- **`PostContentPrepared`** broadcasts on `user.{id}.ai-draft.{draftId}` when the text lands. The review screen also polls every 4s, so a dropped websocket cannot strand the user on the skeleton.
- **`creationStatus`** gives the loading screen the same polling fallback for phase B.

## Tests

15 tests covering the flow end to end: draft creation and job dispatch, the cross-workspace social account guard, rendering and authorization of the review screen, `generate` persisting the reviewed structure and dispatching phase B, the replay guard, autosave (persists while `ready`, no-op otherwise), validation, and `PreparePostContent` marking the draft ready while preserving the fields the humanizer does not return.

The full suite passes locally (2638 tests), Pint is clean, and ESLint passes on the touched frontend files.

## Notes for review

- **Translations**: `en` and `pt-BR` are written properly; the other 13 locales carry the English strings as an untranslated fallback so `LocalizationParityTest` passes. Happy to drop them to placeholders or take translations from you if you prefer.
- I did **not** run Prettier over `AiPostWizard.vue` — it does not match `printWidth: 80` on `main` today, and reformatting it would have buried the two-line change in noise. The two new components are formatted.
- Whether the review step should be optional (a wizard toggle or a workspace setting) rather than always-on is a product call — happy to put it behind a flag if you would rather not change the default flow.