### PR TITLE
fix: raise YouTube Shorts max duration to 3 minutes

### DIFF
--- a/lang/ar/posts.php
+++ b/lang/ar/posts.php
@@ -500,7 +500,7 @@ return [
         ],
         'youtube_short' => [
             'label' => 'مقطع قصير',
-            'description' => 'فيديو عمودي حتى 60 ثانية',
+            'description' => 'فيديو عمودي حتى 3 دقائق',
         ],
         'x_post' => [
             'label' => 'منشور',

--- a/lang/de/posts.php
+++ b/lang/de/posts.php
@@ -502,7 +502,7 @@ return [
         ],
         'youtube_short' => [
             'label' => 'Short',
-            'description' => 'Vertikales Video bis zu 60 Sekunden',
+            'description' => 'Vertikales Video bis zu 3 Minuten',
         ],
         'x_post' => [
             'label' => 'Beitrag',

--- a/lang/el/posts.php
+++ b/lang/el/posts.php
@@ -500,7 +500,7 @@ return [
         ],
         'youtube_short' => [
             'label' => 'Short',
-            'description' => 'Κατακόρυφο βίντεο έως 60 δευτερόλεπτα',
+            'description' => 'Κατακόρυφο βίντεο έως 3 λεπτά',
         ],
         'x_post' => [
             'label' => 'Δημοσίευση',

--- a/lang/en/posts.php
+++ b/lang/en/posts.php
@@ -500,7 +500,7 @@ return [
         ],
         'youtube_short' => [
             'label' => 'Short',
-            'description' => 'Vertical video up to 60 seconds',
+            'description' => 'Vertical video up to 3 minutes',
         ],
         'x_post' => [
             'label' => 'Post',

--- a/lang/es/posts.php
+++ b/lang/es/posts.php
@@ -500,7 +500,7 @@ return [
         ],
         'youtube_short' => [
             'label' => 'Short',
-            'description' => 'Video vertical de hasta 60 segundos',
+            'description' => 'Video vertical de hasta 3 minutos',
         ],
         'x_post' => [
             'label' => 'Post',

--- a/lang/fr/posts.php
+++ b/lang/fr/posts.php
@@ -500,7 +500,7 @@ return [
         ],
         'youtube_short' => [
             'label' => 'Short',
-            'description' => 'Vidéo verticale jusqu\'à 60 secondes',
+            'description' => 'Vidéo verticale jusqu\'à 3 minutes',
         ],
         'x_post' => [
             'label' => 'Publication',

--- a/lang/it/posts.php
+++ b/lang/it/posts.php
@@ -500,7 +500,7 @@ return [
         ],
         'youtube_short' => [
             'label' => 'Short',
-            'description' => 'Video verticale fino a 60 secondi',
+            'description' => 'Video verticale fino a 3 minuti',
         ],
         'x_post' => [
             'label' => 'Post',

--- a/lang/ja/posts.php
+++ b/lang/ja/posts.php
@@ -500,7 +500,7 @@ return [
         ],
         'youtube_short' => [
             'label' => 'ショート',
-            'description' => '最大 60 秒の縦型動画',
+            'description' => '最大 3 分の縦型動画',
         ],
         'x_post' => [
             'label' => '投稿',

--- a/lang/ko/posts.php
+++ b/lang/ko/posts.php
@@ -500,7 +500,7 @@ return [
         ],
         'youtube_short' => [
             'label' => 'Short',
-            'description' => '최대 60초 세로 동영상',
+            'description' => '최대 3분 세로 동영상',
         ],
         'x_post' => [
             'label' => '게시물',

--- a/lang/nl/posts.php
+++ b/lang/nl/posts.php
@@ -500,7 +500,7 @@ return [
         ],
         'youtube_short' => [
             'label' => 'Short',
-            'description' => 'Verticale video tot 60 seconden',
+            'description' => 'Verticale video tot 3 minuten',
         ],
         'x_post' => [
             'label' => 'Post',

--- a/lang/pl/posts.php
+++ b/lang/pl/posts.php
@@ -500,7 +500,7 @@ return [
         ],
         'youtube_short' => [
             'label' => 'Short',
-            'description' => 'Pionowy film do 60 sekund',
+            'description' => 'Pionowy film do 3 minut',
         ],
         'x_post' => [
             'label' => 'Post',

--- a/lang/pt-BR/posts.php
+++ b/lang/pt-BR/posts.php
@@ -500,7 +500,7 @@ return [
         ],
         'youtube_short' => [
             'label' => 'Short',
-            'description' => 'Vídeo vertical de até 60 segundos',
+            'description' => 'Vídeo vertical de até 3 minutos',
         ],
         'x_post' => [
             'label' => 'Post',

--- a/lang/ru/posts.php
+++ b/lang/ru/posts.php
@@ -500,7 +500,7 @@ return [
         ],
         'youtube_short' => [
             'label' => 'Short',
-            'description' => 'Вертикальное видео до 60 секунд',
+            'description' => 'Вертикальное видео до 3 минут',
         ],
         'x_post' => [
             'label' => 'Пост',

--- a/lang/tr/posts.php
+++ b/lang/tr/posts.php
@@ -502,7 +502,7 @@ return [
         ],
         'youtube_short' => [
             'label' => 'Short',
-            'description' => '60 saniyeye kadar dikey video',
+            'description' => '3 dakikaya kadar dikey video',
         ],
         'x_post' => [
             'label' => 'Gönderi',

--- a/lang/zh/posts.php
+++ b/lang/zh/posts.php
@@ -500,7 +500,7 @@ return [
         ],
         'youtube_short' => [
             'label' => 'Short',
-            'description' => '最长 60 秒的竖版视频',
+            'description' => '最长 3 分钟的竖版视频',
         ],
         'x_post' => [
             'label' => '帖子',

--- a/resources/js/composables/useMediaRules.ts
+++ b/resources/js/composables/useMediaRules.ts
@@ -92,7 +92,7 @@ const CONTENT_TYPE_RULES: Record<string, MediaRules> = {
     youtube_short: {
         maxFiles: 1, acceptImages: false, acceptVideos: true, requiresMedia: true,
         acceptsGif: false,
-        maxVideoBytes: 256 * GB, maxVideoDurationSec: 60,
+        maxVideoBytes: 256 * GB, maxVideoDurationSec: 3 * 60,
         aspectRatioMin: 0.5, aspectRatioMax: 0.6,
     },
 

--- a/tests/Unit/Enums/ContentTypeTest.php
+++ b/tests/Unit/Enums/ContentTypeTest.php
@@ -23,7 +23,7 @@ test('content type has correct descriptions', function () {
     expect(ContentType::InstagramFeed->description())->toContain('feed');
     expect(ContentType::InstagramReel->description())->toContain('90 seconds');
     expect(ContentType::InstagramStory->description())->toContain('24 hours');
-    expect(ContentType::YouTubeShort->description())->toContain('60 seconds');
+    expect(ContentType::YouTubeShort->description())->toContain('3 minutes');
 });
 
 test('content type maps to correct platform', function () {


### PR DESCRIPTION
## Summary
- Raise `youtube_short` `maxVideoDurationSec` from 60s to 3 minutes in the dashboard media rules
- Update content-type descriptions across all locales
- Align `ContentTypeTest` with the new copy

API and MCP already accept 3-minute Shorts (no server-side duration gate); this unblocks the same uploads in the web editor.

## Test plan
- [ ] In the post editor, attach a ~2–3 min vertical video to a YouTube Short and confirm it is accepted
- [ ] Attach a video longer than 3 minutes and confirm it is still rejected
- [ ] Confirm the Short content-type description shows “up to 3 minutes” (EN / PT-BR)
- [ ] `php artisan test --filter=ContentTypeTest`


Made with [Cursor](https://cursor.com)