### PR TITLE
Track post creation origin with created_via

### DIFF
--- a/app/Actions/Automation/Node/RunGenerateNode.php
+++ b/app/Actions/Automation/Node/RunGenerateNode.php
@@ -12,6 +12,7 @@ use App\Ai\Templates\TemplateContext;
 use App\DataTransferObjects\Automation\NodeRunResult;
 use App\Enums\Ai\ContentStyle;
 use App\Enums\Ai\GeneratorFormat;
+use App\Enums\Post\CreatedVia;
 use App\Enums\PostPlatform\ContentType;
 use App\Models\AutomationRun;
 use App\Models\SocialAccount;
@@ -145,6 +146,7 @@ class RunGenerateNode
             'content' => $generated->content,
             'media' => $generated->media,
             'platforms' => $platforms,
+            'created_via' => CreatedVia::Automation,
         ]);
 
         $run->update(['generated_post_id' => $post->id]);

--- a/app/Actions/Post/CreatePost.php
+++ b/app/Actions/Post/CreatePost.php
@@ -6,7 +6,6 @@ namespace App\Actions\Post;
 
 use App\Enums\Post\CreatedVia;
 use App\Enums\Post\Status as PostStatus;
-use App\Events\PostCreated;
 use App\Models\Post;
 use App\Models\User;
 use App\Models\Workspace;
@@ -90,8 +89,6 @@ class CreatePost
 
             return $post;
         });
-
-        PostCreated::dispatch($post);
 
         return $post;
     }

--- a/app/Actions/Post/CreatePost.php
+++ b/app/Actions/Post/CreatePost.php
@@ -28,8 +28,7 @@ class CreatePost
      * works for REST, MCP, and web callers.
      *
      * `created_via` records which entry point created the post (web, mcp,
-     * api, or automation). Analytical only — null when omitted or invalid,
-     * and never blocks creation.
+     * api, or automation). Analytical only — null when omitted.
      *
      * @param  array{
      *     content?: ?string,
@@ -51,7 +50,7 @@ class CreatePost
                 'content' => data_get($data, 'content', ''),
                 'media' => data_get($data, 'media', []),
                 'status' => PostStatus::Draft,
-                'created_via' => self::resolveCreatedVia($data),
+                'created_via' => data_get($data, 'created_via'),
                 'scheduled_at' => $scheduledAt,
             ]);
 
@@ -95,26 +94,6 @@ class CreatePost
         PostCreated::dispatch($post);
 
         return $post;
-    }
-
-    /**
-     * Analytical only — never fail creation over a missing/invalid value.
-     *
-     * @param  array<string, mixed>  $data
-     */
-    private static function resolveCreatedVia(array $data): ?CreatedVia
-    {
-        $value = data_get($data, 'created_via');
-
-        if ($value instanceof CreatedVia) {
-            return $value;
-        }
-
-        if (is_string($value)) {
-            return CreatedVia::tryFrom($value);
-        }
-
-        return null;
     }
 
     /**

--- a/app/Actions/Post/CreatePost.php
+++ b/app/Actions/Post/CreatePost.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Actions\Post;
 
+use App\Enums\Post\CreatedVia;
 use App\Enums\Post\Status as PostStatus;
 use App\Events\PostCreated;
 use App\Models\Post;
@@ -26,11 +27,15 @@ class CreatePost
      * `label_ids[]` are attached after creation so the same set of UUIDs
      * works for REST, MCP, and web callers.
      *
+     * `created_via` records which entry point created the post (web, mcp,
+     * api, or automation). Callers must set it explicitly.
+     *
      * @param  array{
      *     content?: ?string,
      *     media?: array<int, mixed>,
      *     date?: ?string,
      *     scheduled_at?: ?string,
+     *     created_via: CreatedVia,
      *     platforms?: array<int, array{social_account_id: string, content_type?: string, meta?: array<string, mixed>}>,
      *     label_ids?: array<int, string>
      * }  $data
@@ -45,6 +50,7 @@ class CreatePost
                 'content' => data_get($data, 'content', ''),
                 'media' => data_get($data, 'media', []),
                 'status' => PostStatus::Draft,
+                'created_via' => data_get($data, 'created_via'),
                 'scheduled_at' => $scheduledAt,
             ]);
 

--- a/app/Actions/Post/CreatePost.php
+++ b/app/Actions/Post/CreatePost.php
@@ -12,6 +12,7 @@ use App\Models\User;
 use App\Models\Workspace;
 use Carbon\Carbon;
 use Illuminate\Support\Facades\DB;
+use InvalidArgumentException;
 
 class CreatePost
 {
@@ -39,18 +40,26 @@ class CreatePost
      *     platforms?: array<int, array{social_account_id: string, content_type?: string, meta?: array<string, mixed>}>,
      *     label_ids?: array<int, string>
      * }  $data
+     *
+     * @throws InvalidArgumentException when created_via is missing or not a CreatedVia case
      */
     public static function execute(Workspace $workspace, User $user, array $data): Post
     {
+        $createdVia = data_get($data, 'created_via');
+
+        if (! $createdVia instanceof CreatedVia) {
+            throw new InvalidArgumentException('created_via must be a CreatedVia enum case.');
+        }
+
         $scheduledAt = self::resolveScheduledAt($data);
 
-        $post = DB::transaction(function () use ($workspace, $user, $data, $scheduledAt): Post {
+        $post = DB::transaction(function () use ($workspace, $user, $data, $scheduledAt, $createdVia): Post {
             $post = $workspace->posts()->create([
                 'user_id' => $user->id,
                 'content' => data_get($data, 'content', ''),
                 'media' => data_get($data, 'media', []),
                 'status' => PostStatus::Draft,
-                'created_via' => data_get($data, 'created_via'),
+                'created_via' => $createdVia,
                 'scheduled_at' => $scheduledAt,
             ]);
 

--- a/app/Actions/Post/CreatePost.php
+++ b/app/Actions/Post/CreatePost.php
@@ -12,7 +12,6 @@ use App\Models\User;
 use App\Models\Workspace;
 use Carbon\Carbon;
 use Illuminate\Support\Facades\DB;
-use InvalidArgumentException;
 
 class CreatePost
 {
@@ -29,37 +28,30 @@ class CreatePost
      * works for REST, MCP, and web callers.
      *
      * `created_via` records which entry point created the post (web, mcp,
-     * api, or automation). Callers must set it explicitly.
+     * api, or automation). Analytical only — defaults to web when omitted
+     * or invalid, and never blocks creation.
      *
      * @param  array{
      *     content?: ?string,
      *     media?: array<int, mixed>,
      *     date?: ?string,
      *     scheduled_at?: ?string,
-     *     created_via: CreatedVia,
+     *     created_via?: CreatedVia,
      *     platforms?: array<int, array{social_account_id: string, content_type?: string, meta?: array<string, mixed>}>,
      *     label_ids?: array<int, string>
      * }  $data
-     *
-     * @throws InvalidArgumentException when created_via is missing or not a CreatedVia case
      */
     public static function execute(Workspace $workspace, User $user, array $data): Post
     {
-        $createdVia = data_get($data, 'created_via');
-
-        if (! $createdVia instanceof CreatedVia) {
-            throw new InvalidArgumentException('created_via must be a CreatedVia enum case.');
-        }
-
         $scheduledAt = self::resolveScheduledAt($data);
 
-        $post = DB::transaction(function () use ($workspace, $user, $data, $scheduledAt, $createdVia): Post {
+        $post = DB::transaction(function () use ($workspace, $user, $data, $scheduledAt): Post {
             $post = $workspace->posts()->create([
                 'user_id' => $user->id,
                 'content' => data_get($data, 'content', ''),
                 'media' => data_get($data, 'media', []),
                 'status' => PostStatus::Draft,
-                'created_via' => $createdVia,
+                'created_via' => self::resolveCreatedVia($data),
                 'scheduled_at' => $scheduledAt,
             ]);
 
@@ -103,6 +95,26 @@ class CreatePost
         PostCreated::dispatch($post);
 
         return $post;
+    }
+
+    /**
+     * Analytical only — never fail creation over a missing/invalid value.
+     *
+     * @param  array<string, mixed>  $data
+     */
+    private static function resolveCreatedVia(array $data): CreatedVia
+    {
+        $value = data_get($data, 'created_via');
+
+        if ($value instanceof CreatedVia) {
+            return $value;
+        }
+
+        if (is_string($value)) {
+            return CreatedVia::tryFrom($value) ?? CreatedVia::Web;
+        }
+
+        return CreatedVia::Web;
     }
 
     /**

--- a/app/Actions/Post/CreatePost.php
+++ b/app/Actions/Post/CreatePost.php
@@ -28,15 +28,15 @@ class CreatePost
      * works for REST, MCP, and web callers.
      *
      * `created_via` records which entry point created the post (web, mcp,
-     * api, or automation). Analytical only — defaults to web when omitted
-     * or invalid, and never blocks creation.
+     * api, or automation). Analytical only — null when omitted or invalid,
+     * and never blocks creation.
      *
      * @param  array{
      *     content?: ?string,
      *     media?: array<int, mixed>,
      *     date?: ?string,
      *     scheduled_at?: ?string,
-     *     created_via?: CreatedVia,
+     *     created_via?: ?CreatedVia,
      *     platforms?: array<int, array{social_account_id: string, content_type?: string, meta?: array<string, mixed>}>,
      *     label_ids?: array<int, string>
      * }  $data
@@ -102,7 +102,7 @@ class CreatePost
      *
      * @param  array<string, mixed>  $data
      */
-    private static function resolveCreatedVia(array $data): CreatedVia
+    private static function resolveCreatedVia(array $data): ?CreatedVia
     {
         $value = data_get($data, 'created_via');
 
@@ -111,10 +111,10 @@ class CreatePost
         }
 
         if (is_string($value)) {
-            return CreatedVia::tryFrom($value) ?? CreatedVia::Web;
+            return CreatedVia::tryFrom($value);
         }
 
-        return CreatedVia::Web;
+        return null;
     }
 
     /**

--- a/app/Actions/Post/DuplicatePost.php
+++ b/app/Actions/Post/DuplicatePost.php
@@ -7,7 +7,6 @@ namespace App\Actions\Post;
 use App\Enums\Post\CreatedVia;
 use App\Enums\Post\Status as PostStatus;
 use App\Enums\PostPlatform\Status as PostPlatformStatus;
-use App\Events\PostCreated;
 use App\Models\Post;
 use App\Models\User;
 use Illuminate\Support\Facades\DB;
@@ -21,7 +20,7 @@ class DuplicatePost
 {
     public static function execute(Post $original, User $user): Post
     {
-        $copy = DB::transaction(function () use ($original, $user): Post {
+        return DB::transaction(function () use ($original, $user): Post {
             $copy = $original->workspace->posts()->create([
                 'user_id' => $user->id,
                 'content' => $original->content,
@@ -57,9 +56,5 @@ class DuplicatePost
 
             return $copy;
         });
-
-        PostCreated::dispatch($copy);
-
-        return $copy;
     }
 }

--- a/app/Actions/Post/DuplicatePost.php
+++ b/app/Actions/Post/DuplicatePost.php
@@ -7,6 +7,7 @@ namespace App\Actions\Post;
 use App\Enums\Post\CreatedVia;
 use App\Enums\Post\Status as PostStatus;
 use App\Enums\PostPlatform\Status as PostPlatformStatus;
+use App\Events\PostCreated;
 use App\Models\Post;
 use App\Models\User;
 use Illuminate\Support\Facades\DB;
@@ -20,7 +21,7 @@ class DuplicatePost
 {
     public static function execute(Post $original, User $user): Post
     {
-        return DB::transaction(function () use ($original, $user): Post {
+        $copy = DB::transaction(function () use ($original, $user): Post {
             $copy = $original->workspace->posts()->create([
                 'user_id' => $user->id,
                 'content' => $original->content,
@@ -56,5 +57,9 @@ class DuplicatePost
 
             return $copy;
         });
+
+        PostCreated::dispatch($copy);
+
+        return $copy;
     }
 }

--- a/app/Actions/Post/DuplicatePost.php
+++ b/app/Actions/Post/DuplicatePost.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Actions\Post;
 
+use App\Enums\Post\CreatedVia;
 use App\Enums\Post\Status as PostStatus;
 use App\Enums\PostPlatform\Status as PostPlatformStatus;
 use App\Models\Post;
@@ -25,6 +26,7 @@ class DuplicatePost
                 'content' => $original->content,
                 'media' => $original->media,
                 'status' => PostStatus::Draft,
+                'created_via' => CreatedVia::Web,
                 'scheduled_at' => null,
                 'published_at' => null,
             ]);

--- a/app/Enums/Post/CreatedVia.php
+++ b/app/Enums/Post/CreatedVia.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Enums\Post;
+
+enum CreatedVia: string
+{
+    case Web = 'web';
+    case Mcp = 'mcp';
+    case Api = 'api';
+    case Automation = 'automation';
+}

--- a/app/Enums/PostHog/PostEvent.php
+++ b/app/Enums/PostHog/PostEvent.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Enums\PostHog;
+
+enum PostEvent: string
+{
+    case Created = 'post.created';
+}

--- a/app/Events/PostCreated.php
+++ b/app/Events/PostCreated.php
@@ -8,10 +8,11 @@ use App\Models\Post;
 use Illuminate\Broadcasting\InteractsWithSockets;
 use Illuminate\Broadcasting\PrivateChannel;
 use Illuminate\Contracts\Broadcasting\ShouldBroadcast;
+use Illuminate\Contracts\Events\ShouldDispatchAfterCommit;
 use Illuminate\Foundation\Events\Dispatchable;
 use Illuminate\Queue\SerializesModels;
 
-class PostCreated implements ShouldBroadcast
+class PostCreated implements ShouldBroadcast, ShouldDispatchAfterCommit
 {
     use Dispatchable, InteractsWithSockets, SerializesModels;
 

--- a/app/Events/PostCreated.php
+++ b/app/Events/PostCreated.php
@@ -8,11 +8,10 @@ use App\Models\Post;
 use Illuminate\Broadcasting\InteractsWithSockets;
 use Illuminate\Broadcasting\PrivateChannel;
 use Illuminate\Contracts\Broadcasting\ShouldBroadcast;
-use Illuminate\Contracts\Events\ShouldDispatchAfterCommit;
 use Illuminate\Foundation\Events\Dispatchable;
 use Illuminate\Queue\SerializesModels;
 
-class PostCreated implements ShouldBroadcast, ShouldDispatchAfterCommit
+class PostCreated implements ShouldBroadcast
 {
     use Dispatchable, InteractsWithSockets, SerializesModels;
 

--- a/app/Http/Controllers/Api/PostController.php
+++ b/app/Http/Controllers/Api/PostController.php
@@ -10,6 +10,7 @@ use App\Actions\Post\HostInlineMedia;
 use App\Actions\Post\UpdatePost;
 use App\Enums\Media\Type as MediaType;
 use App\Enums\Post\Action as PostAction;
+use App\Enums\Post\CreatedVia;
 use App\Http\Requests\Api\Post\AttachMediaFromUrlRequest;
 use App\Http\Requests\Api\Post\StoreMediaRequest;
 use App\Http\Requests\Api\Post\StorePostRequest;
@@ -60,6 +61,8 @@ class PostController extends Controller
                 $data['media'],
             );
         }
+
+        $data['created_via'] = CreatedVia::Api;
 
         $post = CreatePost::execute($workspace, $workspace->owner, $data);
 

--- a/app/Http/Controllers/App/PostController.php
+++ b/app/Http/Controllers/App/PostController.php
@@ -12,6 +12,7 @@ use App\Actions\Post\UpdatePost;
 use App\Ai\Templates\AiContentTemplate;
 use App\Ai\Templates\AiTemplateRegistry;
 use App\Enums\Post\Action as PostAction;
+use App\Enums\Post\CreatedVia;
 use App\Enums\Post\Status as PostStatus;
 use App\Enums\SocialAccount\Platform;
 use App\Http\Requests\App\Post\StorePostRequest;
@@ -189,6 +190,7 @@ class PostController extends Controller
         $post = CreatePost::execute($workspace, $request->user(), [
             'date' => $request->input('date'),
             'media' => $request->input('media', []),
+            'created_via' => CreatedVia::Web,
         ]);
 
         return Inertia::location(route('app.posts.edit', $post));

--- a/app/Http/Controllers/App/PostTemplateController.php
+++ b/app/Http/Controllers/App/PostTemplateController.php
@@ -6,6 +6,7 @@ namespace App\Http\Controllers\App;
 
 use App\Actions\Post\CreatePost;
 use App\Enums\Media\Type as MediaType;
+use App\Enums\Post\CreatedVia;
 use App\Http\Requests\App\PostTemplate\ApplyPostTemplateRequest;
 use App\Http\Requests\App\PostTemplate\IndexPostTemplateRequest;
 use App\Http\Resources\App\PostTemplateResource;
@@ -89,6 +90,7 @@ class PostTemplateController extends Controller
             'content' => $content,
             'media' => $media,
             'date' => $request->input('date'),
+            'created_via' => CreatedVia::Web,
         ]);
 
         return response()->json([

--- a/app/Jobs/Ai/StreamPostCreation.php
+++ b/app/Jobs/Ai/StreamPostCreation.php
@@ -14,6 +14,7 @@ use App\Enums\Ai\ContentStyle;
 use App\Enums\Ai\GeneratorFormat;
 use App\Enums\Notification\Channel as NotificationChannel;
 use App\Enums\Notification\Type as NotificationType;
+use App\Enums\Post\CreatedVia;
 use App\Enums\PostPlatform\ContentType;
 use App\Events\Ai\PostCreationReady;
 use App\Jobs\SendNotification;
@@ -195,6 +196,7 @@ class StreamPostCreation implements ShouldQueue
             'content' => $generated->content,
             'media' => $generated->media,
             'date' => $this->date,
+            'created_via' => CreatedVia::Web,
         ]);
 
         if ($generated->contentType && $socialAccount) {

--- a/app/Jobs/PostHog/TrackPost.php
+++ b/app/Jobs/PostHog/TrackPost.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Jobs\PostHog;
+
+use App\Enums\PostHog\PostEvent;
+use App\Models\Post;
+use App\Services\PostHogService;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+
+class TrackPost implements ShouldQueue
+{
+    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+
+    public int $tries = 3;
+
+    public int $timeout = 30;
+
+    public function __construct(public string $postId)
+    {
+        $this->onQueue('posthog');
+    }
+
+    public function handle(PostHogService $postHog): void
+    {
+        if (! PostHogService::isEnabled()) {
+            return;
+        }
+
+        $post = Post::query()
+            ->with(['workspace.account.plan', 'user'])
+            ->find($this->postId);
+
+        if (! $post) {
+            return;
+        }
+
+        $account = $post->workspace?->account;
+
+        if (! $account) {
+            return;
+        }
+
+        $distinctId = (string) ($post->user_id ?? $account->owner_id);
+
+        if ($distinctId === '') {
+            return;
+        }
+
+        $postHog->capture(
+            $distinctId,
+            PostEvent::Created->value,
+            [
+                'post_id' => (string) $post->id,
+                'workspace_id' => (string) $post->workspace_id,
+                'created_via' => $post->created_via?->value,
+                'status' => $post->status->value,
+            ],
+            $account,
+        );
+    }
+}

--- a/app/Jobs/PostHog/TrackPost.php
+++ b/app/Jobs/PostHog/TrackPost.php
@@ -33,7 +33,7 @@ class TrackPost implements ShouldQueue
         }
 
         $post = Post::query()
-            ->with(['workspace.account.plan', 'user'])
+            ->with(['workspace.account.plan'])
             ->find($this->postId);
 
         if (! $post) {

--- a/app/Listeners/PostHog/TrackPostCreated.php
+++ b/app/Listeners/PostHog/TrackPostCreated.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Listeners\PostHog;
+
+use App\Events\PostCreated;
+use App\Jobs\PostHog\TrackPost;
+use App\Services\PostHogService;
+
+class TrackPostCreated
+{
+    public function handle(PostCreated $event): void
+    {
+        if (! PostHogService::isEnabled()) {
+            return;
+        }
+
+        TrackPost::dispatch((string) $event->post->id);
+    }
+}

--- a/app/Mcp/Tools/Post/CreatePostTool.php
+++ b/app/Mcp/Tools/Post/CreatePostTool.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Mcp\Tools\Post;
 
 use App\Actions\Post\CreatePost;
+use App\Enums\Post\CreatedVia;
 use App\Enums\PostPlatform\ContentType;
 use App\Http\Resources\Api\PostResource;
 use App\Rules\ContentTypeMatchesPlatform;
@@ -40,6 +41,8 @@ class CreatePostTool extends Tool
             'platforms.*.content_type' => ['required', 'string', Rule::in(array_column(ContentType::cases(), 'value')), new ContentTypeMatchesPlatform],
             ...PostPlatformMetaRules::rules(),
         ]);
+
+        $validated['created_via'] = CreatedVia::Mcp;
 
         $post = CreatePost::execute($workspace, $request->user(), $validated);
 

--- a/app/Models/Post.php
+++ b/app/Models/Post.php
@@ -6,6 +6,7 @@ namespace App\Models;
 
 use App\DataTransferObjects\MediaItem;
 use App\Enums\Media\Type;
+use App\Enums\Post\CreatedVia;
 use App\Enums\Post\Status as PostStatus;
 use App\Enums\SocialAccount\Platform;
 use App\Observers\PostObserver;
@@ -34,6 +35,7 @@ class Post extends Model
         'content',
         'media',
         'status',
+        'created_via',
         'scheduled_at',
         'published_at',
     ];
@@ -42,6 +44,7 @@ class Post extends Model
     {
         return [
             'status' => PostStatus::class,
+            'created_via' => CreatedVia::class,
             'media' => 'array',
             'scheduled_at' => 'datetime',
             'published_at' => 'datetime',

--- a/app/Observers/PostObserver.php
+++ b/app/Observers/PostObserver.php
@@ -6,11 +6,18 @@ namespace App\Observers;
 
 use App\Enums\Automation\Trigger\Type as TriggerType;
 use App\Enums\Post\Status as PostStatus;
+use App\Events\PostCreated;
 use App\Jobs\Automation\DispatchPostTriggerAutomationsJob;
 use App\Models\Post;
+use Illuminate\Contracts\Events\ShouldHandleEventsAfterCommit;
 
-class PostObserver
+class PostObserver implements ShouldHandleEventsAfterCommit
 {
+    public function created(Post $post): void
+    {
+        PostCreated::dispatch($post);
+    }
+
     public function saved(Post $post): void
     {
         if (! $post->wasChanged('status')) {
@@ -27,6 +34,6 @@ class PostObserver
             return;
         }
 
-        DispatchPostTriggerAutomationsJob::dispatch($post, $triggerType)->afterCommit();
+        DispatchPostTriggerAutomationsJob::dispatch($post, $triggerType);
     }
 }

--- a/app/Observers/PostObserver.php
+++ b/app/Observers/PostObserver.php
@@ -9,9 +9,8 @@ use App\Enums\Post\Status as PostStatus;
 use App\Events\PostCreated;
 use App\Jobs\Automation\DispatchPostTriggerAutomationsJob;
 use App\Models\Post;
-use Illuminate\Contracts\Events\ShouldHandleEventsAfterCommit;
 
-class PostObserver implements ShouldHandleEventsAfterCommit
+class PostObserver
 {
     public function created(Post $post): void
     {
@@ -34,6 +33,6 @@ class PostObserver implements ShouldHandleEventsAfterCommit
             return;
         }
 
-        DispatchPostTriggerAutomationsJob::dispatch($post, $triggerType);
+        DispatchPostTriggerAutomationsJob::dispatch($post, $triggerType)->afterCommit();
     }
 }

--- a/app/Observers/PostObserver.php
+++ b/app/Observers/PostObserver.php
@@ -9,12 +9,13 @@ use App\Enums\Post\Status as PostStatus;
 use App\Events\PostCreated;
 use App\Jobs\Automation\DispatchPostTriggerAutomationsJob;
 use App\Models\Post;
+use Illuminate\Support\Facades\DB;
 
 class PostObserver
 {
     public function created(Post $post): void
     {
-        PostCreated::dispatch($post);
+        DB::afterCommit(fn () => PostCreated::dispatch($post));
     }
 
     public function saved(Post $post): void

--- a/database/migrations/2026_07_24_141454_add_created_via_to_posts_table.php
+++ b/database/migrations/2026_07_24_141454_add_created_via_to_posts_table.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;

--- a/database/migrations/2026_07_24_141454_add_created_via_to_posts_table.php
+++ b/database/migrations/2026_07_24_141454_add_created_via_to_posts_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('posts', function (Blueprint $table) {
+            $table->string('created_via')->nullable()->after('status');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('posts', function (Blueprint $table) {
+            $table->dropColumn('created_via');
+        });
+    }
+};

--- a/tests/Feature/Actions/Post/CreatePostTest.php
+++ b/tests/Feature/Actions/Post/CreatePostTest.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 use App\Actions\Post\CreatePost;
+use App\Enums\Post\CreatedVia;
 use App\Events\PostCreated;
 use App\Models\User;
 use App\Models\Workspace;
@@ -16,6 +17,7 @@ test('execute dispatches PostCreated with the persisted post', function () {
 
     $post = CreatePost::execute($workspace, $user, [
         'content' => 'Hello world',
+        'created_via' => CreatedVia::Web,
     ]);
 
     Event::assertDispatched(
@@ -24,3 +26,20 @@ test('execute dispatches PostCreated with the persisted post', function () {
             && $event->post->workspace_id === $workspace->id,
     );
 });
+
+test('execute persists created_via for each entry point', function (CreatedVia $createdVia) {
+    $user = User::factory()->create();
+    $workspace = Workspace::factory()->create(['user_id' => $user->id]);
+
+    $post = CreatePost::execute($workspace, $user, [
+        'content' => 'Hello world',
+        'created_via' => $createdVia,
+    ]);
+
+    expect($post->fresh()->created_via)->toBe($createdVia);
+})->with([
+    'web' => CreatedVia::Web,
+    'mcp' => CreatedVia::Mcp,
+    'api' => CreatedVia::Api,
+    'automation' => CreatedVia::Automation,
+]);

--- a/tests/Feature/Actions/Post/CreatePostTest.php
+++ b/tests/Feature/Actions/Post/CreatePostTest.php
@@ -44,11 +44,29 @@ test('execute persists created_via for each entry point', function (CreatedVia $
     'automation' => CreatedVia::Automation,
 ]);
 
-test('execute requires created_via', function () {
+test('execute defaults created_via to web when omitted', function () {
     $user = User::factory()->create();
     $workspace = Workspace::factory()->create(['user_id' => $user->id]);
 
-    CreatePost::execute($workspace, $user, [
+    $post = CreatePost::execute($workspace, $user, [
         'content' => 'Hello world',
     ]);
-})->throws(InvalidArgumentException::class, 'created_via must be a CreatedVia enum case.');
+
+    expect($post->fresh()->created_via)->toBe(CreatedVia::Web);
+});
+
+test('execute defaults created_via to web when null or invalid', function (mixed $createdVia) {
+    $user = User::factory()->create();
+    $workspace = Workspace::factory()->create(['user_id' => $user->id]);
+
+    $post = CreatePost::execute($workspace, $user, [
+        'content' => 'Hello world',
+        'created_via' => $createdVia,
+    ]);
+
+    expect($post->fresh()->created_via)->toBe(CreatedVia::Web);
+})->with([
+    'null' => null,
+    'invalid string' => 'not-a-channel',
+    'integer' => 1,
+]);

--- a/tests/Feature/Actions/Post/CreatePostTest.php
+++ b/tests/Feature/Actions/Post/CreatePostTest.php
@@ -9,7 +9,7 @@ use App\Models\User;
 use App\Models\Workspace;
 use Illuminate\Support\Facades\Event;
 
-test('execute dispatches PostCreated with the persisted post', function () {
+test('execute relies on the observer to dispatch PostCreated', function () {
     Event::fake([PostCreated::class]);
 
     $user = User::factory()->create();

--- a/tests/Feature/Actions/Post/CreatePostTest.php
+++ b/tests/Feature/Actions/Post/CreatePostTest.php
@@ -54,19 +54,3 @@ test('execute leaves created_via null when omitted', function () {
 
     expect($post->fresh()->created_via)->toBeNull();
 });
-
-test('execute leaves created_via null when null or invalid', function (mixed $createdVia) {
-    $user = User::factory()->create();
-    $workspace = Workspace::factory()->create(['user_id' => $user->id]);
-
-    $post = CreatePost::execute($workspace, $user, [
-        'content' => 'Hello world',
-        'created_via' => $createdVia,
-    ]);
-
-    expect($post->fresh()->created_via)->toBeNull();
-})->with([
-    'null' => null,
-    'invalid string' => 'not-a-channel',
-    'integer' => 1,
-]);

--- a/tests/Feature/Actions/Post/CreatePostTest.php
+++ b/tests/Feature/Actions/Post/CreatePostTest.php
@@ -44,7 +44,7 @@ test('execute persists created_via for each entry point', function (CreatedVia $
     'automation' => CreatedVia::Automation,
 ]);
 
-test('execute defaults created_via to web when omitted', function () {
+test('execute leaves created_via null when omitted', function () {
     $user = User::factory()->create();
     $workspace = Workspace::factory()->create(['user_id' => $user->id]);
 
@@ -52,10 +52,10 @@ test('execute defaults created_via to web when omitted', function () {
         'content' => 'Hello world',
     ]);
 
-    expect($post->fresh()->created_via)->toBe(CreatedVia::Web);
+    expect($post->fresh()->created_via)->toBeNull();
 });
 
-test('execute defaults created_via to web when null or invalid', function (mixed $createdVia) {
+test('execute leaves created_via null when null or invalid', function (mixed $createdVia) {
     $user = User::factory()->create();
     $workspace = Workspace::factory()->create(['user_id' => $user->id]);
 
@@ -64,7 +64,7 @@ test('execute defaults created_via to web when null or invalid', function (mixed
         'created_via' => $createdVia,
     ]);
 
-    expect($post->fresh()->created_via)->toBe(CreatedVia::Web);
+    expect($post->fresh()->created_via)->toBeNull();
 })->with([
     'null' => null,
     'invalid string' => 'not-a-channel',

--- a/tests/Feature/Actions/Post/CreatePostTest.php
+++ b/tests/Feature/Actions/Post/CreatePostTest.php
@@ -43,3 +43,12 @@ test('execute persists created_via for each entry point', function (CreatedVia $
     'api' => CreatedVia::Api,
     'automation' => CreatedVia::Automation,
 ]);
+
+test('execute requires created_via', function () {
+    $user = User::factory()->create();
+    $workspace = Workspace::factory()->create(['user_id' => $user->id]);
+
+    CreatePost::execute($workspace, $user, [
+        'content' => 'Hello world',
+    ]);
+})->throws(InvalidArgumentException::class, 'created_via must be a CreatedVia enum case.');

--- a/tests/Feature/Actions/Post/DuplicatePostTest.php
+++ b/tests/Feature/Actions/Post/DuplicatePostTest.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Actions\Post\DuplicatePost;
+use App\Enums\Post\CreatedVia;
+use App\Enums\Post\Status as PostStatus;
+use App\Models\Post;
+use App\Models\User;
+use App\Models\Workspace;
+
+test('execute clones the post as a draft created via web', function () {
+    $user = User::factory()->create();
+    $workspace = Workspace::factory()->create(['user_id' => $user->id]);
+    $original = Post::factory()->create([
+        'workspace_id' => $workspace->id,
+        'user_id' => $user->id,
+        'content' => 'Original content',
+        'created_via' => CreatedVia::Api,
+        'status' => PostStatus::Published,
+    ]);
+
+    $copy = DuplicatePost::execute($original, $user);
+
+    expect($copy->id)->not->toBe($original->id)
+        ->and($copy->content)->toBe('Original content')
+        ->and($copy->status)->toBe(PostStatus::Draft)
+        ->and($copy->created_via)->toBe(CreatedVia::Web)
+        ->and($copy->scheduled_at)->toBeNull()
+        ->and($copy->published_at)->toBeNull();
+});

--- a/tests/Feature/Actions/Post/DuplicatePostTest.php
+++ b/tests/Feature/Actions/Post/DuplicatePostTest.php
@@ -5,9 +5,11 @@ declare(strict_types=1);
 use App\Actions\Post\DuplicatePost;
 use App\Enums\Post\CreatedVia;
 use App\Enums\Post\Status as PostStatus;
+use App\Events\PostCreated;
 use App\Models\Post;
 use App\Models\User;
 use App\Models\Workspace;
+use Illuminate\Support\Facades\Event;
 
 test('execute clones the post as a draft created via web', function () {
     $user = User::factory()->create();
@@ -28,4 +30,22 @@ test('execute clones the post as a draft created via web', function () {
         ->and($copy->created_via)->toBe(CreatedVia::Web)
         ->and($copy->scheduled_at)->toBeNull()
         ->and($copy->published_at)->toBeNull();
+});
+
+test('execute dispatches PostCreated for the duplicated post', function () {
+    Event::fake([PostCreated::class]);
+
+    $user = User::factory()->create();
+    $workspace = Workspace::factory()->create(['user_id' => $user->id]);
+    $original = Post::factory()->create([
+        'workspace_id' => $workspace->id,
+        'user_id' => $user->id,
+    ]);
+
+    $copy = DuplicatePost::execute($original, $user);
+
+    Event::assertDispatched(
+        PostCreated::class,
+        fn (PostCreated $event) => $event->post->id === $copy->id,
+    );
 });

--- a/tests/Feature/Actions/Post/DuplicatePostTest.php
+++ b/tests/Feature/Actions/Post/DuplicatePostTest.php
@@ -32,15 +32,15 @@ test('execute clones the post as a draft created via web', function () {
         ->and($copy->published_at)->toBeNull();
 });
 
-test('execute dispatches PostCreated for the duplicated post', function () {
-    Event::fake([PostCreated::class]);
-
+test('execute relies on the observer to dispatch PostCreated for the duplicate', function () {
     $user = User::factory()->create();
     $workspace = Workspace::factory()->create(['user_id' => $user->id]);
     $original = Post::factory()->create([
         'workspace_id' => $workspace->id,
         'user_id' => $user->id,
     ]);
+
+    Event::fake([PostCreated::class]);
 
     $copy = DuplicatePost::execute($original, $user);
 

--- a/tests/Feature/Ai/StreamPostCreationTest.php
+++ b/tests/Feature/Ai/StreamPostCreationTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 use App\Ai\Agents\PostContentGenerator;
 use App\Ai\Agents\PostContentHumanizer;
+use App\Enums\Post\CreatedVia;
 use App\Enums\PostPlatform\ContentType;
 use App\Enums\UserWorkspace\Role;
 use App\Jobs\Ai\StreamPostCreation;
@@ -111,7 +112,8 @@ test('tweet_card template stores the tweet_text as post content and attaches a m
     $post = $this->user->currentWorkspace->posts()->latest()->first();
 
     expect($post->content)->toBe('Hello world\n\nSecond para.')
-        ->and($post->media)->toHaveCount(1);
+        ->and($post->media)->toHaveCount(1)
+        ->and($post->created_via)->toBe(CreatedVia::Web);
 
     $platform = PostPlatform::where('social_account_id', $this->account->id)->firstOrFail();
 

--- a/tests/Feature/Api/PostApiTest.php
+++ b/tests/Feature/Api/PostApiTest.php
@@ -78,6 +78,23 @@ it('creates a post', function () {
     expect($post->created_via)->toBe(CreatedVia::Api);
 });
 
+it('ignores a client-supplied created_via and always records api', function () {
+    $this->withHeaders(['Authorization' => 'Bearer '.$this->plainToken])
+        ->postJson(route('api.posts.store'), [
+            'created_via' => 'web',
+            'platforms' => [
+                [
+                    'social_account_id' => $this->socialAccount->id,
+                    'content_type' => 'linkedin_post',
+                ],
+            ],
+        ])
+        ->assertCreated();
+
+    $post = Post::where('workspace_id', $this->workspace->id)->first();
+    expect($post->created_via)->toBe(CreatedVia::Api);
+});
+
 it('creates a post with content, media, and labels', function () {
     $label = WorkspaceLabel::factory()->create(['workspace_id' => $this->workspace->id]);
 

--- a/tests/Feature/Api/PostApiTest.php
+++ b/tests/Feature/Api/PostApiTest.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use App\Enums\Post\CreatedVia;
 use App\Enums\Post\Status as PostStatus;
 use App\Enums\PostPlatform\ContentType;
 use App\Enums\SocialAccount\Platform;
@@ -72,7 +73,9 @@ it('creates a post', function () {
         ->assertCreated()
         ->assertJsonPath('status', PostStatus::Draft->value);
 
-    expect(Post::where('workspace_id', $this->workspace->id)->count())->toBe(1);
+    $post = Post::where('workspace_id', $this->workspace->id)->first();
+    expect($post)->not->toBeNull();
+    expect($post->created_via)->toBe(CreatedVia::Api);
 });
 
 it('creates a post with content, media, and labels', function () {

--- a/tests/Feature/Automation/Node/GenerateNodeTest.php
+++ b/tests/Feature/Automation/Node/GenerateNodeTest.php
@@ -7,6 +7,7 @@ use App\Ai\Agents\PostContentGenerator;
 use App\Ai\Agents\PostContentHumanizer;
 use App\Enums\Ai\ContentStyle;
 use App\Enums\Ai\GeneratorFormat;
+use App\Enums\Post\CreatedVia;
 use App\Enums\Post\Status as PostStatus;
 use App\Enums\PostPlatform\ContentType;
 use App\Models\Automation;
@@ -47,6 +48,7 @@ it('creates a draft post and writes generated output to run context', function (
     $post = Post::find($run->generated_post_id);
     expect($post)->not->toBeNull();
     expect($post->status)->toBe(PostStatus::Draft);
+    expect($post->created_via)->toBe(CreatedVia::Automation);
 });
 
 it('applies brand voice by default', function () {

--- a/tests/Feature/Jobs/PostHog/TrackPostTest.php
+++ b/tests/Feature/Jobs/PostHog/TrackPostTest.php
@@ -1,0 +1,96 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Enums\Post\CreatedVia;
+use App\Enums\PostHog\PostEvent;
+use App\Jobs\PostHog\SendEvent;
+use App\Jobs\PostHog\TrackPost;
+use App\Models\Account;
+use App\Models\Post;
+use App\Models\User;
+use App\Models\Workspace;
+use App\Services\PostHogService;
+use Illuminate\Support\Facades\Queue;
+use Illuminate\Support\Str;
+
+beforeEach(function () {
+    config(['services.posthog.enabled' => true, 'services.posthog.api_key' => 'phc_test_key']);
+
+    $this->account = Account::factory()->create();
+    $this->user = User::factory()->create(['account_id' => $this->account->id]);
+    $this->account->update(['owner_id' => $this->user->id]);
+    $this->workspace = Workspace::factory()->create([
+        'account_id' => $this->account->id,
+        'user_id' => $this->user->id,
+    ]);
+});
+
+test('job is queued on the posthog queue', function () {
+    $job = new TrackPost((string) Str::uuid());
+
+    expect($job->queue)->toBe('posthog');
+});
+
+test('handle captures post.created with created_via and account group', function () {
+    Queue::fake();
+
+    $post = Post::factory()->create([
+        'workspace_id' => $this->workspace->id,
+        'user_id' => $this->user->id,
+        'created_via' => CreatedVia::Api,
+    ]);
+
+    (new TrackPost((string) $post->id))->handle(app(PostHogService::class));
+
+    Queue::assertPushed(SendEvent::class, function ($job) use ($post) {
+        return $job->method === 'capture'
+            && $job->payload['event'] === PostEvent::Created->value
+            && $job->payload['distinctId'] === (string) $this->user->id
+            && $job->payload['properties']['post_id'] === (string) $post->id
+            && $job->payload['properties']['workspace_id'] === (string) $this->workspace->id
+            && $job->payload['properties']['created_via'] === CreatedVia::Api->value
+            && $job->payload['properties']['$groups']['account'] === (string) $this->account->id;
+    });
+});
+
+test('handle falls back to account owner when post has no user', function () {
+    Queue::fake();
+
+    $post = Post::factory()->create([
+        'workspace_id' => $this->workspace->id,
+        'user_id' => null,
+        'created_via' => CreatedVia::Mcp,
+    ]);
+
+    (new TrackPost((string) $post->id))->handle(app(PostHogService::class));
+
+    Queue::assertPushed(
+        SendEvent::class,
+        fn ($job) => $job->payload['distinctId'] === (string) $this->user->id
+            && $job->payload['properties']['created_via'] === CreatedVia::Mcp->value,
+    );
+});
+
+test('handle returns silently when post does not exist', function () {
+    Queue::fake();
+
+    (new TrackPost((string) Str::uuid()))->handle(app(PostHogService::class));
+
+    Queue::assertNothingPushed();
+});
+
+test('handle does not push when PostHog is disabled', function () {
+    config(['services.posthog.api_key' => null]);
+    Queue::fake();
+
+    $post = Post::factory()->create([
+        'workspace_id' => $this->workspace->id,
+        'user_id' => $this->user->id,
+        'created_via' => CreatedVia::Web,
+    ]);
+
+    (new TrackPost((string) $post->id))->handle(app(PostHogService::class));
+
+    Queue::assertNotPushed(SendEvent::class);
+});

--- a/tests/Feature/Listeners/PostHog/TrackPostCreatedTest.php
+++ b/tests/Feature/Listeners/PostHog/TrackPostCreatedTest.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Enums\Post\CreatedVia;
+use App\Events\PostCreated;
+use App\Jobs\PostHog\TrackPost;
+use App\Listeners\PostHog\TrackPostCreated;
+use App\Models\Account;
+use App\Models\Post;
+use App\Models\User;
+use App\Models\Workspace;
+use Illuminate\Support\Facades\Bus;
+
+beforeEach(function () {
+    config(['services.posthog.enabled' => true, 'services.posthog.api_key' => 'phc_test_key']);
+
+    $this->account = Account::factory()->create();
+    $this->user = User::factory()->create(['account_id' => $this->account->id]);
+    $this->account->update(['owner_id' => $this->user->id]);
+    $this->workspace = Workspace::factory()->create([
+        'account_id' => $this->account->id,
+        'user_id' => $this->user->id,
+    ]);
+});
+
+test('listener dispatches TrackPost with the post id', function () {
+    $post = Post::factory()->create([
+        'workspace_id' => $this->workspace->id,
+        'user_id' => $this->user->id,
+        'created_via' => CreatedVia::Web,
+    ]);
+
+    Bus::fake();
+
+    (new TrackPostCreated)->handle(new PostCreated($post));
+
+    Bus::assertDispatched(
+        TrackPost::class,
+        fn ($job) => $job->postId === (string) $post->id,
+    );
+});
+
+test('listener is wired to the PostCreated event via auto-discovery', function () {
+    $post = Post::factory()->create([
+        'workspace_id' => $this->workspace->id,
+        'user_id' => $this->user->id,
+        'created_via' => CreatedVia::Automation,
+    ]);
+
+    Bus::fake();
+
+    PostCreated::dispatch($post);
+
+    Bus::assertDispatched(TrackPost::class);
+});
+
+test('listener does not dispatch when PostHog is disabled', function () {
+    config(['services.posthog.enabled' => false]);
+
+    $post = Post::factory()->create([
+        'workspace_id' => $this->workspace->id,
+        'user_id' => $this->user->id,
+    ]);
+
+    Bus::fake();
+
+    (new TrackPostCreated)->handle(new PostCreated($post));
+
+    Bus::assertNotDispatched(TrackPost::class);
+});

--- a/tests/Feature/Mcp/PostToolTest.php
+++ b/tests/Feature/Mcp/PostToolTest.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use App\Enums\Post\CreatedVia;
 use App\Enums\SocialAccount\Platform;
 use App\Enums\UserWorkspace\Role;
 use App\Mcp\Servers\TryPostServer;
@@ -109,7 +110,9 @@ test('create post with content and date', function () {
                 ->etc();
         });
 
-    expect(Post::where('workspace_id', $this->workspace->id)->count())->toBe(1);
+    $post = Post::where('workspace_id', $this->workspace->id)->first();
+    expect($post)->not->toBeNull();
+    expect($post->created_via)->toBe(CreatedVia::Mcp);
 });
 
 test('create post with platforms enables only those', function () {

--- a/tests/Feature/Observers/PostObserverTest.php
+++ b/tests/Feature/Observers/PostObserverTest.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Events\PostCreated;
+use App\Models\Post;
+use App\Models\User;
+use App\Models\Workspace;
+use Illuminate\Support\Facades\Event;
+
+test('creating a post dispatches PostCreated via the observer', function () {
+    Event::fake([PostCreated::class]);
+
+    $user = User::factory()->create();
+    $workspace = Workspace::factory()->create(['user_id' => $user->id]);
+
+    $post = Post::factory()->create([
+        'workspace_id' => $workspace->id,
+        'user_id' => $user->id,
+    ]);
+
+    Event::assertDispatched(
+        PostCreated::class,
+        fn (PostCreated $event) => $event->post->id === $post->id,
+    );
+});
+
+test('creating a post quietly does not dispatch PostCreated', function () {
+    Event::fake([PostCreated::class]);
+
+    $user = User::factory()->create();
+    $workspace = Workspace::factory()->create(['user_id' => $user->id]);
+
+    Post::factory()->createQuietly([
+        'workspace_id' => $workspace->id,
+        'user_id' => $user->id,
+    ]);
+
+    Event::assertNotDispatched(PostCreated::class);
+});

--- a/tests/Feature/PostControllerTest.php
+++ b/tests/Feature/PostControllerTest.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use App\Enums\Post\CreatedVia;
 use App\Enums\Post\Status as PostStatus;
 use App\Enums\PostPlatform\ContentType;
 use App\Enums\PostPlatform\Status;
@@ -257,6 +258,7 @@ test('store post creates draft and redirects to edit', function () {
     $post = Post::where('workspace_id', $this->workspace->id)->first();
     expect($post)->not->toBeNull();
     expect($post->status)->toBe(PostStatus::Draft);
+    expect($post->created_via)->toBe(CreatedVia::Web);
     expect($post->postPlatforms)->toHaveCount(1);
 });
 

--- a/tests/Feature/PostTemplateControllerTest.php
+++ b/tests/Feature/PostTemplateControllerTest.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use App\Enums\Post\CreatedVia;
 use App\Enums\UserWorkspace\Role;
 use App\Models\Account;
 use App\Models\SocialAccount;
@@ -72,6 +73,9 @@ test('apply creates post and returns post_id and redirect_url', function () {
 
     expect($response->json('post_id'))->toBeString();
     expect($response->json('redirect_url'))->toContain('edit');
+
+    $post = $this->workspace->posts()->find($response->json('post_id'));
+    expect($post->created_via)->toBe(CreatedVia::Web);
 });
 
 test('apply interpolates brand_name in content', function () {


### PR DESCRIPTION
## Summary
- Add nullable `posts.created_via` with `CreatedVia` enum (`web`, `mcp`, `api`, `automation`)
- Thread the value through `CreatePost` and every creation entry point (web/templates/AI, API, MCP, automations)
- Cover persistence in action + channel feature tests; legacy posts remain `null`

## Test plan
- [ ] Run `php artisan migrate`
- [ ] Create a post from the web UI → `created_via = web`
- [ ] Create via API `POST /posts` → `created_via = api`
- [ ] Create via MCP `CreatePostTool` → `created_via = mcp`
- [ ] Run an automation generate node → `created_via = automation`
- [ ] Confirm existing posts stay `null`


Made with [Cursor](https://cursor.com)