### PR TITLE
add openrouter to eligible ai providers

### DIFF
--- a/app/Ai/Agents/BrandAnalyzer.php
+++ b/app/Ai/Agents/BrandAnalyzer.php
@@ -32,6 +32,7 @@ class BrandAnalyzer implements Agent, HasStructuredOutput
         return match (config('ai.default')) {
             'openai' => Lab::OpenAI,
             'anthropic' => Lab::Anthropic,
+            'openrouter' => Lab::OpenRouter,
             default => Lab::Gemini,
         };
     }

--- a/app/Ai/Agents/PostContentGenerator.php
+++ b/app/Ai/Agents/PostContentGenerator.php
@@ -115,6 +115,7 @@ class PostContentGenerator implements Agent, HasStructuredOutput
         return match (config('ai.default')) {
             'openai' => Lab::OpenAI,
             'anthropic' => Lab::Anthropic,
+            'openrouter' => Lab::OpenRouter,
             default => Lab::Gemini,
         };
     }

--- a/app/Ai/Agents/PostContentHumanizer.php
+++ b/app/Ai/Agents/PostContentHumanizer.php
@@ -78,6 +78,7 @@ class PostContentHumanizer implements Agent, HasStructuredOutput
         return match (config('ai.default')) {
             'openai' => Lab::OpenAI,
             'anthropic' => Lab::Anthropic,
+            'openrouter' => Lab::OpenRouter,
             default => Lab::Gemini,
         };
     }

--- a/app/Ai/Agents/PostContentReviewer.php
+++ b/app/Ai/Agents/PostContentReviewer.php
@@ -49,6 +49,7 @@ class PostContentReviewer implements Agent, HasStructuredOutput
         return match (config('ai.default')) {
             'openai' => Lab::OpenAI,
             'anthropic' => Lab::Anthropic,
+            'openrouter' => Lab::OpenRouter,
             default => Lab::Gemini,
         };
     }

--- a/app/Ai/Agents/PostContentStreamer.php
+++ b/app/Ai/Agents/PostContentStreamer.php
@@ -47,6 +47,7 @@ class PostContentStreamer implements Agent
         return match (config('ai.default')) {
             'openai' => Lab::OpenAI,
             'anthropic' => Lab::Anthropic,
+            'openrouter' => Lab::OpenRouter,
             default => Lab::Gemini,
         };
     }

--- a/app/Ai/Agents/PostImageRegenerator.php
+++ b/app/Ai/Agents/PostImageRegenerator.php
@@ -53,6 +53,7 @@ class PostImageRegenerator implements Agent, HasStructuredOutput
         return match (config('ai.default')) {
             'openai' => Lab::OpenAI,
             'anthropic' => Lab::Anthropic,
+            'openrouter' => Lab::OpenRouter,
             default => Lab::Gemini,
         };
     }

--- a/app/Services/Brand/BrandAnalyzerRunner.php
+++ b/app/Services/Brand/BrandAnalyzerRunner.php
@@ -19,6 +19,7 @@ final class BrandAnalyzerRunner
         return match (config('ai.default')) {
             'openai' => ! empty(config('services.openai.api_key')),
             'gemini' => ! empty(config('services.gemini.api_key')),
+            'openrouter' => ! empty(config('services.openrouter.api_key')),
             default => false,
         };
     }


### PR DESCRIPTION
I don't get why you need this block of code everywhere, but I needed a quick fix to use openrouter, so here you go.

IMHO The best fix would be to get rid of this code block in all files and do a sanity check on `config('ai.default')` during bootstrap and show a proper warning if no/wrong provider is set.