### PR TITLE
Use laravel/ai default provider for OpenRouter

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -171,12 +171,14 @@ DISCORD_CLIENT_REDIRECT="${APP_URL}/accounts/discord/callback"
 OPENAI_API_KEY=
 ANTHROPIC_API_KEY=
 GEMINI_API_KEY=
+OPENROUTER_API_KEY=
 ELEVENLABS_API_KEY=
 
 # AI Provider Selection
-# text:  openai | anthropic | gemini | xai | groq | mistral | deepseek | ...
-# image: openai | gemini | xai
+# text:  openai | anthropic | gemini | openrouter | xai | groq | mistral | deepseek | ...
+# image: openai | gemini | xai | openrouter
 # audio: openai | elevenlabs
+# OpenRouter is a first-class laravel/ai provider (AI_TEXT_PROVIDER=openrouter + OPENROUTER_API_KEY).
 AI_TEXT_PROVIDER=openai
 AI_TEXT_MODEL=gpt-5.4
 AI_IMAGE_PROVIDER=openai

--- a/app/Ai/Agents/BrandAnalyzer.php
+++ b/app/Ai/Agents/BrandAnalyzer.php
@@ -9,7 +9,6 @@ use App\Enums\Workspace\ContentLanguage;
 use Illuminate\Contracts\JsonSchema\JsonSchema;
 use Laravel\Ai\Contracts\Agent;
 use Laravel\Ai\Contracts\HasStructuredOutput;
-use Laravel\Ai\Enums\Lab;
 use Laravel\Ai\Promptable;
 
 class BrandAnalyzer implements Agent, HasStructuredOutput
@@ -25,15 +24,6 @@ class BrandAnalyzer implements Agent, HasStructuredOutput
                 ->map(fn (string $code) => "`{$code}`")
                 ->implode(', '),
         ])->render();
-    }
-
-    public function provider(): Lab
-    {
-        return match (config('ai.default')) {
-            'openai' => Lab::OpenAI,
-            'anthropic' => Lab::Anthropic,
-            default => Lab::Gemini,
-        };
     }
 
     public function model(): string

--- a/app/Ai/Agents/PostContentGenerator.php
+++ b/app/Ai/Agents/PostContentGenerator.php
@@ -14,7 +14,6 @@ use Illuminate\Contracts\JsonSchema\JsonSchema;
 use Laravel\Ai\Attributes\Temperature;
 use Laravel\Ai\Contracts\Agent;
 use Laravel\Ai\Contracts\HasStructuredOutput;
-use Laravel\Ai\Enums\Lab;
 use Laravel\Ai\Promptable;
 
 #[Temperature(0.7)]
@@ -108,15 +107,6 @@ class PostContentGenerator implements Agent, HasStructuredOutput
             'image_body' => $schema->string()->description('1-2 short sentences (max 25 words) overlaid below the image_title. Expands the hook just enough to compel reading the caption.')->required(),
             'image_keywords' => $schema->array()->items($schema->string())->description('2-4 search keywords for Unsplash for the single image.')->required(),
         ];
-    }
-
-    public function provider(): Lab
-    {
-        return match (config('ai.default')) {
-            'openai' => Lab::OpenAI,
-            'anthropic' => Lab::Anthropic,
-            default => Lab::Gemini,
-        };
     }
 
     public function model(): string

--- a/app/Ai/Agents/PostContentHumanizer.php
+++ b/app/Ai/Agents/PostContentHumanizer.php
@@ -11,7 +11,6 @@ use Illuminate\Contracts\JsonSchema\JsonSchema;
 use Laravel\Ai\Attributes\Temperature;
 use Laravel\Ai\Contracts\Agent;
 use Laravel\Ai\Contracts\HasStructuredOutput;
-use Laravel\Ai\Enums\Lab;
 use Laravel\Ai\Promptable;
 
 /**
@@ -71,15 +70,6 @@ class PostContentHumanizer implements Agent, HasStructuredOutput
             'image_title' => $schema->string()->description('The humanized image overlay title.')->required(),
             'image_body' => $schema->string()->description('The humanized image overlay body.')->required(),
         ];
-    }
-
-    public function provider(): Lab
-    {
-        return match (config('ai.default')) {
-            'openai' => Lab::OpenAI,
-            'anthropic' => Lab::Anthropic,
-            default => Lab::Gemini,
-        };
     }
 
     public function model(): string

--- a/app/Ai/Agents/PostContentReviewer.php
+++ b/app/Ai/Agents/PostContentReviewer.php
@@ -9,7 +9,6 @@ use Illuminate\Contracts\JsonSchema\JsonSchema;
 use Laravel\Ai\Attributes\Temperature;
 use Laravel\Ai\Contracts\Agent;
 use Laravel\Ai\Contracts\HasStructuredOutput;
-use Laravel\Ai\Enums\Lab;
 use Laravel\Ai\Promptable;
 
 #[Temperature(0.2)]
@@ -42,15 +41,6 @@ class PostContentReviewer implements Agent, HasStructuredOutput
                 ->description('Up to 8 grammar/spelling/clarity suggestions. Empty array if the text is fine.')
                 ->required(),
         ];
-    }
-
-    public function provider(): Lab
-    {
-        return match (config('ai.default')) {
-            'openai' => Lab::OpenAI,
-            'anthropic' => Lab::Anthropic,
-            default => Lab::Gemini,
-        };
     }
 
     public function model(): string

--- a/app/Ai/Agents/PostContentStreamer.php
+++ b/app/Ai/Agents/PostContentStreamer.php
@@ -8,7 +8,6 @@ use App\Enums\Ai\GeneratorFormat;
 use App\Models\Workspace;
 use Laravel\Ai\Attributes\Temperature;
 use Laravel\Ai\Contracts\Agent;
-use Laravel\Ai\Enums\Lab;
 use Laravel\Ai\Promptable;
 
 /**
@@ -40,15 +39,6 @@ class PostContentStreamer implements Agent
             'format' => GeneratorFormat::Single->value,
             'slide_count' => 1,
         ])->render();
-    }
-
-    public function provider(): Lab
-    {
-        return match (config('ai.default')) {
-            'openai' => Lab::OpenAI,
-            'anthropic' => Lab::Anthropic,
-            default => Lab::Gemini,
-        };
     }
 
     public function model(): string

--- a/app/Ai/Agents/PostImageRegenerator.php
+++ b/app/Ai/Agents/PostImageRegenerator.php
@@ -9,7 +9,6 @@ use Illuminate\Contracts\JsonSchema\JsonSchema;
 use Laravel\Ai\Attributes\Temperature;
 use Laravel\Ai\Contracts\Agent;
 use Laravel\Ai\Contracts\HasStructuredOutput;
-use Laravel\Ai\Enums\Lab;
 use Laravel\Ai\Promptable;
 
 #[Temperature(0.25)]
@@ -46,15 +45,6 @@ class PostImageRegenerator implements Agent, HasStructuredOutput
                 ->description('Set to image_only (change visual only), text_only (change text only), or both (change visual and text).')
                 ->required(),
         ];
-    }
-
-    public function provider(): Lab
-    {
-        return match (config('ai.default')) {
-            'openai' => Lab::OpenAI,
-            'anthropic' => Lab::Anthropic,
-            default => Lab::Gemini,
-        };
     }
 
     public function model(): string

--- a/app/Http/Middleware/App/HandleInertiaRequests.php
+++ b/app/Http/Middleware/App/HandleInertiaRequests.php
@@ -9,6 +9,7 @@ use App\Http\Resources\App\HandleInertiaRequests\AuthAccountResource;
 use App\Http\Resources\App\HandleInertiaRequests\AuthPlanResource;
 use App\Http\Resources\App\HandleInertiaRequests\AuthUserResource;
 use App\Http\Resources\App\HandleInertiaRequests\AuthWorkspaceResource;
+use App\Support\AiConfiguration;
 use Illuminate\Http\Request;
 use Inertia\Middleware;
 
@@ -57,7 +58,7 @@ class HandleInertiaRequests extends Middleware
                 'code' => $code,
                 'name' => $name,
             ])->values()->all(),
-            'aiEnabled' => ! empty(config('services.gemini.api_key')) || ! empty(config('services.openai.api_key')),
+            'aiEnabled' => AiConfiguration::isTextProviderConfigured(),
             'selfHosted' => $isSelfHosted,
             'googleAuthEnabled' => config('trypost.google_auth_enabled'),
             'githubAuthEnabled' => config('trypost.github_auth_enabled'),

--- a/app/Services/Brand/BrandAnalyzerRunner.php
+++ b/app/Services/Brand/BrandAnalyzerRunner.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Services\Brand;
 
 use App\Ai\Agents\BrandAnalyzer;
+use App\Support\AiConfiguration;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Str;
 use League\HTMLToMarkdown\HtmlConverter;
@@ -16,11 +17,7 @@ final class BrandAnalyzerRunner
 
     public function isAvailable(): bool
     {
-        return match (config('ai.default')) {
-            'openai' => ! empty(config('services.openai.api_key')),
-            'gemini' => ! empty(config('services.gemini.api_key')),
-            default => false,
-        };
+        return AiConfiguration::isTextProviderConfigured();
     }
 
     public function analyze(string $bodyHtml): ?LlmBrandAnalysis

--- a/app/Support/AiConfiguration.php
+++ b/app/Support/AiConfiguration.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Support;
+
+/**
+ * Helpers for reading the Laravel AI SDK provider configuration.
+ *
+ * Agents intentionally do not override provider() — Promptable falls back to
+ * config('ai.default'), which already includes first-class drivers such as
+ * OpenRouter. Availability checks must therefore look at ai.providers.*.key,
+ * not the legacy services.* mirrors.
+ */
+final class AiConfiguration
+{
+    /**
+     * Whether the configured default text provider has an API key.
+     */
+    public static function isTextProviderConfigured(): bool
+    {
+        $provider = (string) config('ai.default');
+
+        return filled(config("ai.providers.{$provider}.key"));
+    }
+}

--- a/tests/Feature/Ai/AutofillBrandTest.php
+++ b/tests/Feature/Ai/AutofillBrandTest.php
@@ -10,8 +10,10 @@ use Illuminate\Support\Facades\Http;
 
 beforeEach(function () {
     // Run tests without LLM credentials so the deterministic fallback is exercised.
-    config()->set('services.gemini.api_key', '');
-    config()->set('services.openai.api_key', '');
+    config()->set('ai.providers.gemini.key', '');
+    config()->set('ai.providers.openai.key', '');
+    config()->set('ai.providers.openrouter.key', '');
+    config()->set('ai.providers.anthropic.key', '');
 
     $this->autofill = fn (string $url) => app(AutofillBrand::class)($url);
 });
@@ -354,7 +356,7 @@ test('throws when upstream site returns an error', function () {
 });
 
 test('when llm is configured, polishes description/tone/language/voice_notes via BrandAnalyzer', function () {
-    config()->set('services.gemini.api_key', 'fake-key');
+    config()->set('ai.providers.gemini.key', 'fake-key');
     config()->set('ai.default', 'gemini');
 
     Http::fake([
@@ -390,8 +392,38 @@ test('when llm is configured, polishes description/tone/language/voice_notes via
     expect($result->toArray()['brand_voice_traits'])->toBe(['third_person', 'direct', 'no_hype']);
 });
 
+test('openrouter as default text provider enables BrandAnalyzer', function () {
+    config()->set('ai.default', 'openrouter');
+    config()->set('ai.providers.openrouter.key', 'sk-or-v1-test');
+
+    Http::fake([
+        'example.com' => Http::response(<<<'HTML'
+            <html lang="en">
+            <head>
+              <title>OpenRouter Co</title>
+              <meta name="description" content="Terse blurb.">
+            </head>
+            <body><main><p>OpenRouter Co ships AI through one key.</p></main></body>
+            </html>
+        HTML, 200),
+    ]);
+
+    BrandAnalyzer::fake([
+        [
+            'description' => 'OpenRouter Co ships AI through one key.',
+            'language' => 'en',
+            'voice_traits' => ['third_person', 'direct'],
+        ],
+    ]);
+
+    $result = ($this->autofill)('https://example.com');
+
+    expect($result->description)->toBe('OpenRouter Co ships AI through one key.');
+    expect($result->toArray()['brand_voice_traits'])->toBe(['third_person', 'direct']);
+});
+
 test('LLM language detection wins and carries any supported language, not just en/es/pt-BR', function () {
-    config()->set('services.gemini.api_key', 'fake-key');
+    config()->set('ai.providers.gemini.key', 'fake-key');
     config()->set('ai.default', 'gemini');
 
     // The <html lang> declares "en", so the deterministic extractor yields 'en'.
@@ -448,7 +480,7 @@ test('when llm is not configured, falls back to meta tags only', function () {
 });
 
 test('falls back to meta tags when BrandAnalyzer throws', function () {
-    config()->set('services.gemini.api_key', 'fake-key');
+    config()->set('ai.providers.gemini.key', 'fake-key');
     config()->set('ai.default', 'gemini');
 
     Http::fake([

--- a/tests/Feature/WorkspaceControllerTest.php
+++ b/tests/Feature/WorkspaceControllerTest.php
@@ -567,7 +567,7 @@ test('autofillBrand is always allowed even without a subscription', function () 
 
 test('autofillBrand never records AI usage even when the LLM runs', function () {
     config(['trypost.self_hosted' => false]);
-    config()->set('services.gemini.api_key', 'fake-key');
+    config()->set('ai.providers.gemini.key', 'fake-key');
     config()->set('ai.default', 'gemini');
 
     Http::fake([

--- a/tests/Unit/Services/Brand/BrandAnalyzerRunnerTest.php
+++ b/tests/Unit/Services/Brand/BrandAnalyzerRunnerTest.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Ai\Agents\BrandAnalyzer;
+use App\Ai\Agents\PostContentGenerator;
+use App\Ai\Agents\PostContentHumanizer;
+use App\Ai\Agents\PostContentReviewer;
+use App\Ai\Agents\PostContentStreamer;
+use App\Ai\Agents\PostImageRegenerator;
+use App\Services\Brand\BrandAnalyzerRunner;
+
+test('isAvailable follows ai.providers for the configured default including openrouter', function () {
+    $runner = app(BrandAnalyzerRunner::class);
+
+    config()->set('ai.default', 'openrouter');
+    config()->set('ai.providers.openrouter.key', '');
+
+    expect($runner->isAvailable())->toBeFalse();
+
+    config()->set('ai.providers.openrouter.key', 'sk-or-v1-test');
+
+    expect($runner->isAvailable())->toBeTrue();
+});
+
+test('agents do not override provider so laravel/ai uses config ai.default', function (string $agent) {
+    expect(method_exists($agent, 'provider'))->toBeFalse();
+})->with([
+    BrandAnalyzer::class,
+    PostContentGenerator::class,
+    PostContentHumanizer::class,
+    PostContentReviewer::class,
+    PostContentStreamer::class,
+    PostImageRegenerator::class,
+]);

--- a/tests/Unit/Support/AiConfigurationTest.php
+++ b/tests/Unit/Support/AiConfigurationTest.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Support\AiConfiguration;
+
+test('isTextProviderConfigured is true when the default provider has a key', function (string $provider) {
+    config()->set('ai.default', $provider);
+    config()->set("ai.providers.{$provider}.key", 'fake-key');
+
+    expect(AiConfiguration::isTextProviderConfigured())->toBeTrue();
+})->with([
+    'openai',
+    'gemini',
+    'anthropic',
+    'openrouter',
+]);
+
+test('isTextProviderConfigured is false when the default provider key is empty', function () {
+    config()->set('ai.default', 'openrouter');
+    config()->set('ai.providers.openrouter.key', '');
+
+    expect(AiConfiguration::isTextProviderConfigured())->toBeFalse();
+});
+
+test('isTextProviderConfigured ignores keys on non-default providers', function () {
+    config()->set('ai.default', 'openrouter');
+    config()->set('ai.providers.openrouter.key', '');
+    config()->set('ai.providers.openai.key', 'fake-key');
+
+    expect(AiConfiguration::isTextProviderConfigured())->toBeFalse();
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

OpenRouter is a first-class provider in the Laravel AI SDK ([docs](https://laravel.com/docs/13.x/ai-sdk)): set `OPENROUTER_API_KEY` and use `openrouter` as the configured provider. No custom driver wiring is needed.

Our agents were blocking that path. Each one overrode `provider()` with:

```php
match (config('ai.default')) {
    'openai' => Lab::OpenAI,
    'anthropic' => Lab::Anthropic,
    default => Lab::Gemini,
};
```

So `AI_TEXT_PROVIDER=openrouter` was remapped to Gemini. Per the SDK, when an agent omits `provider()`, `Promptable` already falls back to `config('ai.default')`.

## Changes

- Remove the duplicated `provider()` overrides from all AI agents.
- Gate text-AI availability (`BrandAnalyzerRunner`, shared `aiEnabled`) on `ai.providers.{default}.key` via `App\Support\AiConfiguration`.
- Document `OPENROUTER_API_KEY` / `openrouter` in `.env.example`.
- Add/update tests for OpenRouter availability and that agents no longer override `provider()`.

## Usage

```env
AI_TEXT_PROVIDER=openrouter
AI_TEXT_MODEL=openai/gpt-4o-mini
OPENROUTER_API_KEY=sk-or-v1-...
```

Related: #216 (alternative approach that patches each match instead of using the SDK default).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bfdf67dd-7b18-4974-a7e2-d1966c8f031b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bfdf67dd-7b18-4974-a7e2-d1966c8f031b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

