### PR TITLE
Scope MCP OAuth tokens to user + workspace (#222)

### DIFF
--- a/app/Actions/AccessToken/BackfillMcpOAuthWorkspaces.php
+++ b/app/Actions/AccessToken/BackfillMcpOAuthWorkspaces.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Actions\AccessToken;
+
+use App\Models\AccessToken;
+use App\Models\User;
+use Illuminate\Support\Facades\DB;
+
+/**
+ * Assign existing MCP OAuth tokens (workspace_id null) to a workspace, or revoke
+ * them when no confident mapping exists.
+ *
+ * @return array{bound: int, revoked: int}
+ */
+class BackfillMcpOAuthWorkspaces
+{
+    /**
+     * @return array{bound: int, revoked: int}
+     */
+    public static function execute(): array
+    {
+        $bound = 0;
+        $revoked = 0;
+
+        AccessToken::query()
+            ->whereNull('workspace_id')
+            ->where('revoked', false)
+            ->whereHas(
+                'client',
+                fn ($client) => $client
+                    ->where('revoked', false)
+                    ->whereJsonDoesntContain('grant_types', 'personal_access'),
+            )
+            ->orderBy('id')
+            ->chunkById(100, function ($tokens) use (&$bound, &$revoked): void {
+                foreach ($tokens as $token) {
+                    $workspaceId = self::resolveWorkspaceId($token);
+
+                    if ($workspaceId === null) {
+                        self::revoke($token);
+                        $revoked++;
+
+                        continue;
+                    }
+
+                    $token->forceFill(['workspace_id' => $workspaceId])->saveQuietly();
+                    $bound++;
+                }
+            });
+
+        return ['bound' => $bound, 'revoked' => $revoked];
+    }
+
+    private static function resolveWorkspaceId(AccessToken $token): ?string
+    {
+        $user = User::query()->find($token->user_id);
+
+        if ($user === null) {
+            return null;
+        }
+
+        if ($user->current_workspace_id) {
+            $current = $user->accountWorkspaces()
+                ->where('workspaces.id', $user->current_workspace_id)
+                ->first();
+
+            if ($current) {
+                return (string) $current->id;
+            }
+        }
+
+        $fallback = $user->accountWorkspaces()
+            ->orderBy('workspaces.created_at')
+            ->first();
+
+        return $fallback?->id ? (string) $fallback->id : null;
+    }
+
+    private static function revoke(AccessToken $token): void
+    {
+        DB::table('oauth_refresh_tokens')
+            ->where('access_token_id', $token->id)
+            ->update(['revoked' => true]);
+
+        $token->forceFill(['revoked' => true])->saveQuietly();
+    }
+}

--- a/app/Actions/AccessToken/BackfillMcpOAuthWorkspaces.php
+++ b/app/Actions/AccessToken/BackfillMcpOAuthWorkspaces.php
@@ -6,7 +6,8 @@ namespace App\Actions\AccessToken;
 
 use App\Models\AccessToken;
 use App\Models\User;
-use Illuminate\Support\Facades\DB;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Support\Collection;
 
 /**
  * Assign existing MCP OAuth tokens (workspace_id null) to a workspace, or revoke
@@ -29,18 +30,27 @@ class BackfillMcpOAuthWorkspaces
             ->where('revoked', false)
             ->whereHas(
                 'client',
-                fn ($client) => $client
+                fn (Builder $client): Builder => $client
                     ->where('revoked', false)
                     ->whereJsonDoesntContain('grant_types', 'personal_access'),
             )
             ->orderBy('id')
-            ->chunkById(100, function ($tokens) use (&$bound, &$revoked): void {
+            ->chunkById(100, function (Collection $tokens) use (&$bound, &$revoked): void {
+                $users = User::query()
+                    ->whereIn('id', $tokens->pluck('user_id')->unique()->filter()->all())
+                    ->with('workspaces')
+                    ->get()
+                    ->keyBy('id');
+
+                $toRevoke = collect();
+
                 foreach ($tokens as $token) {
-                    $workspaceId = self::resolveWorkspaceId($token);
+                    $workspaceId = self::resolveWorkspaceId(
+                        $users->get($token->user_id),
+                    );
 
                     if ($workspaceId === null) {
-                        self::revoke($token);
-                        $revoked++;
+                        $toRevoke->push($token);
 
                         continue;
                     }
@@ -48,42 +58,39 @@ class BackfillMcpOAuthWorkspaces
                     $token->forceFill(['workspace_id' => $workspaceId])->saveQuietly();
                     $bound++;
                 }
+
+                if ($toRevoke->isNotEmpty()) {
+                    RevokeAccessTokens::execute($toRevoke);
+                    $revoked += $toRevoke->count();
+                }
             });
 
         return ['bound' => $bound, 'revoked' => $revoked];
     }
 
-    private static function resolveWorkspaceId(AccessToken $token): ?string
+    private static function resolveWorkspaceId(?User $user): ?string
     {
-        $user = User::query()->find($token->user_id);
-
         if ($user === null) {
             return null;
         }
 
+        $accountWorkspaces = $user->workspaces
+            ->where('account_id', $user->account_id)
+            ->sortBy('created_at')
+            ->values();
+
+        if ($accountWorkspaces->isEmpty()) {
+            return null;
+        }
+
         if ($user->current_workspace_id) {
-            $current = $user->accountWorkspaces()
-                ->where('workspaces.id', $user->current_workspace_id)
-                ->first();
+            $current = $accountWorkspaces->firstWhere('id', $user->current_workspace_id);
 
             if ($current) {
                 return (string) $current->id;
             }
         }
 
-        $fallback = $user->accountWorkspaces()
-            ->orderBy('workspaces.created_at')
-            ->first();
-
-        return $fallback?->id ? (string) $fallback->id : null;
-    }
-
-    private static function revoke(AccessToken $token): void
-    {
-        DB::table('oauth_refresh_tokens')
-            ->where('access_token_id', $token->id)
-            ->update(['revoked' => true]);
-
-        $token->forceFill(['revoked' => true])->saveQuietly();
+        return (string) $accountWorkspaces->first()->id;
     }
 }

--- a/app/Actions/AccessToken/RevokeAccessTokens.php
+++ b/app/Actions/AccessToken/RevokeAccessTokens.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Actions\AccessToken;
+
+use App\Models\AccessToken;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\DB;
+
+class RevokeAccessTokens
+{
+    /**
+     * @param  Collection<int, AccessToken>|list<AccessToken>|AccessToken  $tokens
+     */
+    public static function execute(Collection|array|AccessToken $tokens): void
+    {
+        $tokens = Collection::wrap($tokens)
+            ->filter(fn (mixed $token): bool => $token instanceof AccessToken)
+            ->values();
+
+        if ($tokens->isEmpty()) {
+            return;
+        }
+
+        $tokenIds = $tokens->pluck('id');
+
+        DB::table('oauth_refresh_tokens')
+            ->whereIn('access_token_id', $tokenIds)
+            ->update(['revoked' => true]);
+
+        $tokens->each(function (AccessToken $token): void {
+            if ($token->revoked) {
+                return;
+            }
+
+            $token->revoke();
+        });
+    }
+}

--- a/app/Actions/Invite/RemoveMember.php
+++ b/app/Actions/Invite/RemoveMember.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Actions\Invite;
 
+use App\Actions\AccessToken\RevokeAccessTokens;
 use App\Actions\User\ReassignCurrentWorkspace;
 use App\Actions\User\SettleStrandedMember;
 use App\Actions\User\StrandedSettlement;
@@ -41,7 +42,13 @@ class RemoveMember
             // Workspace-scoped API keys and MCP OAuth grants must not keep
             // working after membership ends (even if the user remains on
             // another workspace of the same account).
-            self::revokeWorkspaceTokens($user, $workspace);
+            RevokeAccessTokens::execute(
+                AccessToken::query()
+                    ->where('user_id', $user->id)
+                    ->where('workspace_id', $workspace->id)
+                    ->where('revoked', false)
+                    ->get(),
+            );
 
             if ($user->current_workspace_id === $workspace->id) {
                 ReassignCurrentWorkspace::forUserAwayFrom($user, $workspace);
@@ -59,28 +66,5 @@ class RemoveMember
         });
 
         $settlement->flush();
-    }
-
-    private static function revokeWorkspaceTokens(User $user, Workspace $workspace): void
-    {
-        $tokens = AccessToken::query()
-            ->where('user_id', $user->id)
-            ->where('workspace_id', $workspace->id)
-            ->where('revoked', false)
-            ->get();
-
-        if ($tokens->isEmpty()) {
-            return;
-        }
-
-        $tokenIds = $tokens->pluck('id');
-
-        DB::table('oauth_refresh_tokens')
-            ->whereIn('access_token_id', $tokenIds)
-            ->update(['revoked' => true]);
-
-        $tokens->each(function (AccessToken $token): void {
-            $token->forceFill(['revoked' => true])->saveQuietly();
-        });
     }
 }

--- a/app/Actions/Invite/RemoveMember.php
+++ b/app/Actions/Invite/RemoveMember.php
@@ -7,6 +7,7 @@ namespace App\Actions\Invite;
 use App\Actions\User\ReassignCurrentWorkspace;
 use App\Actions\User\SettleStrandedMember;
 use App\Actions\User\StrandedSettlement;
+use App\Models\AccessToken;
 use App\Models\Account;
 use App\Models\User;
 use App\Models\Workspace;
@@ -37,6 +38,11 @@ class RemoveMember
 
             $user->refresh();
 
+            // Workspace-scoped API keys and MCP OAuth grants must not keep
+            // working after membership ends (even if the user remains on
+            // another workspace of the same account).
+            self::revokeWorkspaceTokens($user, $workspace);
+
             if ($user->current_workspace_id === $workspace->id) {
                 ReassignCurrentWorkspace::forUserAwayFrom($user, $workspace);
                 $user->refresh();
@@ -53,5 +59,28 @@ class RemoveMember
         });
 
         $settlement->flush();
+    }
+
+    private static function revokeWorkspaceTokens(User $user, Workspace $workspace): void
+    {
+        $tokens = AccessToken::query()
+            ->where('user_id', $user->id)
+            ->where('workspace_id', $workspace->id)
+            ->where('revoked', false)
+            ->get();
+
+        if ($tokens->isEmpty()) {
+            return;
+        }
+
+        $tokenIds = $tokens->pluck('id');
+
+        DB::table('oauth_refresh_tokens')
+            ->whereIn('access_token_id', $tokenIds)
+            ->update(['revoked' => true]);
+
+        $tokens->each(function (AccessToken $token): void {
+            $token->forceFill(['revoked' => true])->saveQuietly();
+        });
     }
 }

--- a/app/Http/Controllers/Api/ApiKeyController.php
+++ b/app/Http/Controllers/Api/ApiKeyController.php
@@ -16,9 +16,11 @@ class ApiKeyController extends Controller
 {
     public function index(Request $request): AnonymousResourceCollection
     {
-        $tokens = AccessToken::where('user_id', $request->user()->id)
+        $tokens = AccessToken::query()
+            ->where('user_id', $request->user()->id)
             ->where('workspace_id', $request->user()->currentWorkspace->id)
             ->where('revoked', false)
+            ->personalAccess()
             ->latest()
             ->get();
 
@@ -46,9 +48,11 @@ class ApiKeyController extends Controller
 
     public function destroy(Request $request, string $tokenId): JsonResponse
     {
-        $token = AccessToken::where('id', $tokenId)
+        $token = AccessToken::query()
+            ->where('id', $tokenId)
             ->where('user_id', $request->user()->id)
             ->where('workspace_id', $request->user()->currentWorkspace->id)
+            ->personalAccess()
             ->first();
 
         if (! $token) {

--- a/app/Http/Controllers/App/ApiKeyController.php
+++ b/app/Http/Controllers/App/ApiKeyController.php
@@ -22,9 +22,11 @@ class ApiKeyController extends Controller
 
         $this->authorize('manageTeam', $workspace);
 
-        $tokens = AccessToken::where('user_id', $request->user()->id)
+        $tokens = AccessToken::query()
+            ->where('user_id', $request->user()->id)
             ->where('workspace_id', $workspace->id)
             ->where('revoked', false)
+            ->personalAccess()
             ->latest()
             ->get()
             ->map(fn (AccessToken $token) => [
@@ -78,9 +80,11 @@ class ApiKeyController extends Controller
 
         $this->authorize('manageTeam', $workspace);
 
-        $token = AccessToken::where('id', $tokenId)
+        $token = AccessToken::query()
+            ->where('id', $tokenId)
             ->where('user_id', $request->user()->id)
             ->where('workspace_id', $workspace->id)
+            ->personalAccess()
             ->first();
 
         if (! $token) {

--- a/app/Http/Middleware/Api/LoadWorkspaceFromToken.php
+++ b/app/Http/Middleware/Api/LoadWorkspaceFromToken.php
@@ -20,14 +20,19 @@ class LoadWorkspaceFromToken
             return response()->json(['message' => 'Token not found.'], Response::HTTP_UNAUTHORIZED);
         }
 
-        // Personal API tokens (created from settings) bind to a specific
-        // workspace at creation. OAuth tokens (e.g. ChatGPT MCP) don't —
-        // they follow the user's current workspace.
+        // Personal API keys and MCP OAuth grants both bind to a workspace at
+        // issue time. Resolve from the token — never from the user's current
+        // workspace switcher (that would let a multi-workspace agent silently
+        // act on the wrong tenant).
         $workspace = $token->workspace_id
-            ? Workspace::find($token->workspace_id)
-            : $user->currentWorkspace;
+            ? Workspace::query()->find($token->workspace_id)
+            : null;
 
         if (! $workspace) {
+            return response()->json(['message' => 'No workspace selected.'], Response::HTTP_UNAUTHORIZED);
+        }
+
+        if (! $user->belongsToWorkspace($workspace)) {
             return response()->json(['message' => 'No workspace selected.'], Response::HTTP_UNAUTHORIZED);
         }
 

--- a/app/Listeners/BindWorkspaceToAccessToken.php
+++ b/app/Listeners/BindWorkspaceToAccessToken.php
@@ -4,13 +4,14 @@ declare(strict_types=1);
 
 namespace App\Listeners;
 
+use App\Actions\AccessToken\RevokeAccessTokens;
 use App\Models\AccessToken;
 use App\Models\User;
 use App\Models\Workspace;
 use App\Passport\AuthCode;
 use App\Passport\OAuthPayloadDecryptor;
-use Illuminate\Support\Facades\DB;
 use Laravel\Passport\Events\AccessTokenCreated;
+use League\OAuth2\Server\Exception\OAuthServerException;
 
 /**
  * Bind MCP OAuth access tokens to a workspace (mirroring personal API keys).
@@ -40,9 +41,11 @@ class BindWorkspaceToAccessToken
         $workspaceId = $this->resolveWorkspaceId($event);
 
         if ($workspaceId === null) {
-            $this->revoke($token);
+            RevokeAccessTokens::execute($token);
 
-            return;
+            throw OAuthServerException::invalidGrant(
+                'Unable to bind this connection to a workspace. Reconnect from a workspace you belong to.',
+            );
         }
 
         $token->forceFill(['workspace_id' => $workspaceId])->saveQuietly();
@@ -128,43 +131,35 @@ class BindWorkspaceToAccessToken
             ? (string) $user->current_workspace_id
             : null;
 
-        if ($candidateId !== null && $this->userBelongsToWorkspace($userId, $candidateId)) {
+        if ($candidateId !== null && $this->userBelongsToWorkspace($user, $candidateId)) {
             return $candidateId;
         }
 
         $fallback = $user->accountWorkspaces()->orderBy('workspaces.created_at')->first();
 
-        if ($fallback === null) {
-            return null;
-        }
-
-        return $this->userBelongsToWorkspace($userId, (string) $fallback->id)
-            ? (string) $fallback->id
-            : null;
+        return $fallback?->id ? (string) $fallback->id : null;
     }
 
-    private function userBelongsToWorkspace(?string $userId, string $workspaceId): bool
+    private function userBelongsToWorkspace(User|string|null $user, string $workspaceId): bool
     {
-        if (! $userId) {
+        if ($user === null) {
             return false;
         }
 
-        $user = User::query()->find($userId);
+        if (is_string($user)) {
+            $user = User::query()->find($user);
+        }
+
+        if (! $user instanceof User) {
+            return false;
+        }
+
         $workspace = Workspace::query()->find($workspaceId);
 
-        if ($user === null || $workspace === null) {
+        if ($workspace === null) {
             return false;
         }
 
         return $user->belongsToWorkspace($workspace);
-    }
-
-    private function revoke(AccessToken $token): void
-    {
-        DB::table('oauth_refresh_tokens')
-            ->where('access_token_id', $token->id)
-            ->update(['revoked' => true]);
-
-        $token->forceFill(['revoked' => true])->saveQuietly();
     }
 }

--- a/app/Listeners/BindWorkspaceToAccessToken.php
+++ b/app/Listeners/BindWorkspaceToAccessToken.php
@@ -8,6 +8,7 @@ use App\Models\AccessToken;
 use App\Models\User;
 use App\Models\Workspace;
 use App\Passport\AuthCode;
+use App\Passport\OAuthPayloadDecryptor;
 use Illuminate\Support\Facades\DB;
 use Laravel\Passport\Events\AccessTokenCreated;
 
@@ -15,11 +16,13 @@ use Laravel\Passport\Events\AccessTokenCreated;
  * Bind MCP OAuth access tokens to a workspace (mirroring personal API keys).
  *
  * Authorization-code grants copy workspace_id from the auth code captured at
- * consent. Refresh grants inherit the previous token's workspace so switching
+ * consent. Refresh grants inherit the refreshed token's workspace so switching
  * the user's current workspace cannot silently retarget an existing connection.
  */
 class BindWorkspaceToAccessToken
 {
+    public function __construct(private OAuthPayloadDecryptor $decryptor) {}
+
     public function handle(AccessTokenCreated $event): void
     {
         $token = AccessToken::query()->find($event->tokenId);
@@ -34,7 +37,7 @@ class BindWorkspaceToAccessToken
             return;
         }
 
-        $workspaceId = $this->resolveWorkspaceId($event, $token);
+        $workspaceId = $this->resolveWorkspaceId($event);
 
         if ($workspaceId === null) {
             $this->revoke($token);
@@ -45,12 +48,12 @@ class BindWorkspaceToAccessToken
         $token->forceFill(['workspace_id' => $workspaceId])->saveQuietly();
     }
 
-    private function resolveWorkspaceId(AccessTokenCreated $event, AccessToken $token): ?string
+    private function resolveWorkspaceId(AccessTokenCreated $event): ?string
     {
         $grantType = request()->input('grant_type');
 
         if ($grantType === 'refresh_token') {
-            return $this->workspaceFromPreviousToken($event);
+            return $this->workspaceFromRefreshedToken();
         }
 
         if ($grantType === 'authorization_code') {
@@ -72,22 +75,37 @@ class BindWorkspaceToAccessToken
             return null;
         }
 
-        $authCode = AuthCode::query()->find($code);
+        // League encrypts the redirect `code`; the DB id lives in auth_code_id.
+        $payload = $this->decryptor->decrypt($code);
+        $authCodeId = data_get($payload, 'auth_code_id');
+
+        if (! is_string($authCodeId) || $authCodeId === '') {
+            return null;
+        }
+
+        $authCode = AuthCode::query()->find($authCodeId);
 
         return $authCode?->workspace_id
             ? (string) $authCode->workspace_id
             : null;
     }
 
-    private function workspaceFromPreviousToken(AccessTokenCreated $event): ?string
+    private function workspaceFromRefreshedToken(): ?string
     {
-        $previous = AccessToken::query()
-            ->where('user_id', $event->userId)
-            ->where('client_id', $event->clientId)
-            ->where('id', '!=', $event->tokenId)
-            ->whereNotNull('workspace_id')
-            ->latest('created_at')
-            ->first();
+        $refreshToken = request()->input('refresh_token');
+
+        if (! is_string($refreshToken) || $refreshToken === '') {
+            return null;
+        }
+
+        $payload = $this->decryptor->decrypt($refreshToken);
+        $accessTokenId = data_get($payload, 'access_token_id');
+
+        if (! is_string($accessTokenId) || $accessTokenId === '') {
+            return null;
+        }
+
+        $previous = AccessToken::query()->find($accessTokenId);
 
         return $previous?->workspace_id
             ? (string) $previous->workspace_id
@@ -116,7 +134,13 @@ class BindWorkspaceToAccessToken
 
         $fallback = $user->accountWorkspaces()->orderBy('workspaces.created_at')->first();
 
-        return $fallback?->id ? (string) $fallback->id : null;
+        if ($fallback === null) {
+            return null;
+        }
+
+        return $this->userBelongsToWorkspace($userId, (string) $fallback->id)
+            ? (string) $fallback->id
+            : null;
     }
 
     private function userBelongsToWorkspace(?string $userId, string $workspaceId): bool

--- a/app/Listeners/BindWorkspaceToAccessToken.php
+++ b/app/Listeners/BindWorkspaceToAccessToken.php
@@ -1,0 +1,146 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Listeners;
+
+use App\Models\AccessToken;
+use App\Models\User;
+use App\Models\Workspace;
+use App\Passport\AuthCode;
+use Illuminate\Support\Facades\DB;
+use Laravel\Passport\Events\AccessTokenCreated;
+
+/**
+ * Bind MCP OAuth access tokens to a workspace (mirroring personal API keys).
+ *
+ * Authorization-code grants copy workspace_id from the auth code captured at
+ * consent. Refresh grants inherit the previous token's workspace so switching
+ * the user's current workspace cannot silently retarget an existing connection.
+ */
+class BindWorkspaceToAccessToken
+{
+    public function handle(AccessTokenCreated $event): void
+    {
+        $token = AccessToken::query()->find($event->tokenId);
+
+        if ($token === null || $token->workspace_id !== null) {
+            return;
+        }
+
+        $token->loadMissing('client');
+
+        if ($token->client === null || $token->client->hasGrantType('personal_access')) {
+            return;
+        }
+
+        $workspaceId = $this->resolveWorkspaceId($event, $token);
+
+        if ($workspaceId === null) {
+            $this->revoke($token);
+
+            return;
+        }
+
+        $token->forceFill(['workspace_id' => $workspaceId])->saveQuietly();
+    }
+
+    private function resolveWorkspaceId(AccessTokenCreated $event, AccessToken $token): ?string
+    {
+        $grantType = request()->input('grant_type');
+
+        if ($grantType === 'refresh_token') {
+            return $this->workspaceFromPreviousToken($event);
+        }
+
+        if ($grantType === 'authorization_code') {
+            $fromAuthCode = $this->workspaceFromAuthCode();
+
+            if ($fromAuthCode !== null && $this->userBelongsToWorkspace($event->userId, $fromAuthCode)) {
+                return $fromAuthCode;
+            }
+        }
+
+        return $this->workspaceFromUser($event->userId);
+    }
+
+    private function workspaceFromAuthCode(): ?string
+    {
+        $code = request()->input('code');
+
+        if (! is_string($code) || $code === '') {
+            return null;
+        }
+
+        $authCode = AuthCode::query()->find($code);
+
+        return $authCode?->workspace_id
+            ? (string) $authCode->workspace_id
+            : null;
+    }
+
+    private function workspaceFromPreviousToken(AccessTokenCreated $event): ?string
+    {
+        $previous = AccessToken::query()
+            ->where('user_id', $event->userId)
+            ->where('client_id', $event->clientId)
+            ->where('id', '!=', $event->tokenId)
+            ->whereNotNull('workspace_id')
+            ->latest('created_at')
+            ->first();
+
+        return $previous?->workspace_id
+            ? (string) $previous->workspace_id
+            : null;
+    }
+
+    private function workspaceFromUser(?string $userId): ?string
+    {
+        if (! $userId) {
+            return null;
+        }
+
+        $user = User::query()->find($userId);
+
+        if ($user === null) {
+            return null;
+        }
+
+        $candidateId = $user->current_workspace_id
+            ? (string) $user->current_workspace_id
+            : null;
+
+        if ($candidateId !== null && $this->userBelongsToWorkspace($userId, $candidateId)) {
+            return $candidateId;
+        }
+
+        $fallback = $user->accountWorkspaces()->orderBy('workspaces.created_at')->first();
+
+        return $fallback?->id ? (string) $fallback->id : null;
+    }
+
+    private function userBelongsToWorkspace(?string $userId, string $workspaceId): bool
+    {
+        if (! $userId) {
+            return false;
+        }
+
+        $user = User::query()->find($userId);
+        $workspace = Workspace::query()->find($workspaceId);
+
+        if ($user === null || $workspace === null) {
+            return false;
+        }
+
+        return $user->belongsToWorkspace($workspace);
+    }
+
+    private function revoke(AccessToken $token): void
+    {
+        DB::table('oauth_refresh_tokens')
+            ->where('access_token_id', $token->id)
+            ->update(['revoked' => true]);
+
+        $token->forceFill(['revoked' => true])->saveQuietly();
+    }
+}

--- a/app/Mcp/Tools/ApiKey/DeleteApiKeyTool.php
+++ b/app/Mcp/Tools/ApiKey/DeleteApiKeyTool.php
@@ -21,12 +21,13 @@ class DeleteApiKeyTool extends Tool
     {
         $validated = $request->validate(['api_key_id' => ['required', 'string']]);
 
-        // workspace_id filter excludes OAuth-flow tokens (which have null
-        // workspace_id), so the caller can't accidentally revoke their own
-        // ChatGPT/MCP session token through this tool.
-        $token = AccessToken::where('user_id', $request->user()->id)
+        // personalAccess() excludes MCP OAuth grants so the caller can't
+        // accidentally revoke their own ChatGPT/MCP session through this tool.
+        $token = AccessToken::query()
+            ->where('user_id', $request->user()->id)
             ->where('workspace_id', $request->user()->current_workspace_id)
             ->where('revoked', false)
+            ->personalAccess()
             ->find(data_get($validated, 'api_key_id'));
 
         if (! $token) {

--- a/app/Mcp/Tools/ApiKey/ListApiKeysTool.php
+++ b/app/Mcp/Tools/ApiKey/ListApiKeysTool.php
@@ -19,12 +19,14 @@ class ListApiKeysTool extends Tool
 {
     public function handle(Request $request): ResponseFactory
     {
-        // Filtering by workspace_id excludes OAuth-flow tokens (whose
-        // workspace_id is null and resolved at request time via
-        // LoadWorkspaceFromToken middleware).
-        $tokens = AccessToken::where('user_id', $request->user()->id)
+        // personalAccess() excludes MCP OAuth grants (which are also
+        // workspace-bound after issue #222 — workspace_id alone is no longer
+        // a reliable discriminator).
+        $tokens = AccessToken::query()
+            ->where('user_id', $request->user()->id)
             ->where('workspace_id', $request->user()->current_workspace_id)
             ->where('revoked', false)
+            ->personalAccess()
             ->latest()
             ->get();
 

--- a/app/Models/AccessToken.php
+++ b/app/Models/AccessToken.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Models;
 
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Laravel\Passport\Token;
 
@@ -40,5 +41,60 @@ class AccessToken extends Token
     public function workspace(): BelongsTo
     {
         return $this->belongsTo(Workspace::class);
+    }
+
+    /**
+     * Personal access API keys (created from settings / API / MCP tools).
+     *
+     * @param  Builder<static>  $query
+     * @return Builder<static>
+     */
+    public function scopePersonalAccess(Builder $query): Builder
+    {
+        return $query->whereHas(
+            'client',
+            fn (Builder $client): Builder => $client
+                ->whereJsonContains('grant_types', 'personal_access'),
+        );
+    }
+
+    /**
+     * Active OAuth grants used by MCP clients (excludes personal access API keys).
+     *
+     * @param  Builder<static>  $query
+     * @return Builder<static>
+     */
+    public function scopeActiveMcpOAuth(Builder $query): Builder
+    {
+        return $query
+            ->where('revoked', false)
+            ->where(function (Builder $expires): void {
+                $expires->whereNull('expires_at')
+                    ->orWhere('expires_at', '>', now());
+            })
+            ->whereHas(
+                'client',
+                fn (Builder $client): Builder => $client
+                    ->where('revoked', false)
+                    ->whereJsonDoesntContain('grant_types', 'personal_access'),
+            );
+    }
+
+    /**
+     * Whether this token belongs to an MCP OAuth client (not a personal access API key).
+     */
+    public function isMcpOAuthGrant(): bool
+    {
+        $this->loadMissing('client');
+
+        if ($this->client === null || $this->client->revoked || $this->client->hasGrantType('personal_access')) {
+            return false;
+        }
+
+        if ($this->expires_at !== null && $this->expires_at->isPast()) {
+            return false;
+        }
+
+        return true;
     }
 }

--- a/app/Passport/AuthCode.php
+++ b/app/Passport/AuthCode.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Passport;
+
+use App\Models\Workspace;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Laravel\Passport\AuthCode as PassportAuthCode;
+
+class AuthCode extends PassportAuthCode
+{
+    /**
+     * @return array<string, string>
+     */
+    protected function casts(): array
+    {
+        return [
+            'revoked' => 'bool',
+            'expires_at' => 'datetime',
+        ];
+    }
+
+    public function workspace(): BelongsTo
+    {
+        return $this->belongsTo(Workspace::class);
+    }
+}

--- a/app/Passport/AuthCodeRepository.php
+++ b/app/Passport/AuthCodeRepository.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Passport;
+
+use App\Models\User;
+use Illuminate\Support\Facades\Auth;
+use Laravel\Passport\Bridge\AuthCodeRepository as PassportAuthCodeRepository;
+use Laravel\Passport\Passport;
+use League\OAuth2\Server\Entities\AuthCodeEntityInterface;
+
+/**
+ * Persists the authorizing user's current workspace on the auth code so the
+ * subsequent token exchange (no browser session) can bind the access token.
+ */
+class AuthCodeRepository extends PassportAuthCodeRepository
+{
+    public function persistNewAuthCode(AuthCodeEntityInterface $authCodeEntity): void
+    {
+        Passport::authCode()->forceFill([
+            'id' => $authCodeEntity->getIdentifier(),
+            'user_id' => $authCodeEntity->getUserIdentifier(),
+            'client_id' => $authCodeEntity->getClient()->getIdentifier(),
+            'workspace_id' => $this->resolveWorkspaceId($authCodeEntity->getUserIdentifier()),
+            'scopes' => json_encode($authCodeEntity->getScopes()),
+            'revoked' => false,
+            'expires_at' => $authCodeEntity->getExpiryDateTime(),
+        ])->save();
+    }
+
+    private function resolveWorkspaceId(?string $userId): ?string
+    {
+        $fromSession = session('oauth_connecting_workspace_id');
+
+        if (is_string($fromSession) && $fromSession !== '') {
+            return $fromSession;
+        }
+
+        $user = Auth::user();
+
+        if ($user instanceof User && $user->current_workspace_id) {
+            return (string) $user->current_workspace_id;
+        }
+
+        if (! $userId) {
+            return null;
+        }
+
+        $persisted = User::query()->find($userId);
+
+        return $persisted?->current_workspace_id
+            ? (string) $persisted->current_workspace_id
+            : null;
+    }
+}

--- a/app/Passport/AuthCodeRepository.php
+++ b/app/Passport/AuthCodeRepository.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Passport;
 
 use App\Models\User;
+use App\Models\Workspace;
 use Illuminate\Support\Facades\Auth;
 use Laravel\Passport\Bridge\AuthCodeRepository as PassportAuthCodeRepository;
 use Laravel\Passport\Passport;
@@ -13,6 +14,9 @@ use League\OAuth2\Server\Entities\AuthCodeEntityInterface;
 /**
  * Persists the authorizing user's current workspace on the auth code so the
  * subsequent token exchange (no browser session) can bind the access token.
+ *
+ * Always reads Auth::user() at consent time (including Passport silent
+ * re-consent) — never a stale session value from a prior authorize visit.
  */
 class AuthCodeRepository extends PassportAuthCodeRepository
 {
@@ -31,26 +35,30 @@ class AuthCodeRepository extends PassportAuthCodeRepository
 
     private function resolveWorkspaceId(?string $userId): ?string
     {
-        $fromSession = session('oauth_connecting_workspace_id');
-
-        if (is_string($fromSession) && $fromSession !== '') {
-            return $fromSession;
-        }
-
         $user = Auth::user();
 
-        if ($user instanceof User && $user->current_workspace_id) {
-            return (string) $user->current_workspace_id;
+        if (! $user instanceof User && $userId) {
+            $user = User::query()->find($userId);
         }
 
-        if (! $userId) {
+        if (! $user instanceof User) {
             return null;
         }
 
-        $persisted = User::query()->find($userId);
-
-        return $persisted?->current_workspace_id
-            ? (string) $persisted->current_workspace_id
+        $candidateId = $user->current_workspace_id
+            ? (string) $user->current_workspace_id
             : null;
+
+        if ($candidateId === null) {
+            return null;
+        }
+
+        $workspace = Workspace::query()->find($candidateId);
+
+        if ($workspace === null || ! $user->belongsToWorkspace($workspace)) {
+            return null;
+        }
+
+        return $candidateId;
     }
 }

--- a/app/Passport/OAuthPayloadDecryptor.php
+++ b/app/Passport/OAuthPayloadDecryptor.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Passport;
+
+use Defuse\Crypto\Crypto;
+use Illuminate\Contracts\Encryption\Encrypter;
+use Laravel\Passport\Passport;
+use Throwable;
+
+/**
+ * Decrypt League OAuth2 auth-code / refresh-token request payloads using the
+ * same key Passport passes to AuthorizationServer.
+ */
+class OAuthPayloadDecryptor
+{
+    public function __construct(private Encrypter $encrypter) {}
+
+    /**
+     * @return array<string, mixed>|null
+     */
+    public function decrypt(string $encrypted): ?array
+    {
+        try {
+            $json = Crypto::decryptWithPassword(
+                $encrypted,
+                Passport::tokenEncryptionKey($this->encrypter),
+            );
+        } catch (Throwable) {
+            return null;
+        }
+
+        $payload = json_decode($json, true);
+
+        return is_array($payload) ? $payload : null;
+    }
+
+    /**
+     * Encrypt a payload the same way League's CryptTrait does (for tests).
+     *
+     * @param  array<string, mixed>  $payload
+     */
+    public function encrypt(array $payload): string
+    {
+        return Crypto::encryptWithPassword(
+            json_encode($payload, JSON_THROW_ON_ERROR),
+            Passport::tokenEncryptionKey($this->encrypter),
+        );
+    }
+}

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -116,15 +116,10 @@ class AppServiceProvider extends ServiceProvider
 
         Passport::authorizationView(function (array $parameters) {
             $user = data_get($parameters, 'user');
-            $workspace = $user?->currentWorkspace;
-
-            if ($workspace?->id) {
-                session(['oauth_connecting_workspace_id' => $workspace->id]);
-            }
 
             return view('mcp.authorize', [
                 ...$parameters,
-                'workspace' => $workspace,
+                'workspace' => $user?->currentWorkspace,
             ]);
         });
 

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Providers;
 
+use App\Listeners\BindWorkspaceToAccessToken;
 use App\Listeners\StripeEventListener;
 use App\Models\AccessToken;
 use App\Models\Account;
@@ -29,6 +30,8 @@ use App\Models\Workspace;
 use App\Models\WorkspaceInvite;
 use App\Models\WorkspaceLabel;
 use App\Models\WorkspaceSignature;
+use App\Passport\AuthCode;
+use App\Passport\AuthCodeRepository;
 use App\Services\PostHogService;
 use App\Services\PostTemplate\Registry as PostTemplateRegistry;
 use App\Socialite\DiscordProvider;
@@ -53,6 +56,8 @@ use Laravel\Cashier\Cashier;
 use Laravel\Cashier\Events\WebhookReceived;
 use Laravel\Nightwatch\Facades\Nightwatch;
 use Laravel\Nightwatch\Records\CacheEvent;
+use Laravel\Passport\Bridge\AuthCodeRepository as PassportAuthCodeRepository;
+use Laravel\Passport\Events\AccessTokenCreated;
 use Laravel\Passport\Passport;
 use Laravel\Socialite\Facades\Socialite;
 use Laravel\Socialite\Two\GoogleProvider;
@@ -71,6 +76,8 @@ class AppServiceProvider extends ServiceProvider
     public function register(): void
     {
         $this->app->singleton(PostTemplateRegistry::class);
+
+        $this->app->bind(PassportAuthCodeRepository::class, AuthCodeRepository::class);
 
         if ($this->app->environment('local') && class_exists(\Laravel\Telescope\TelescopeServiceProvider::class)) {
             $this->app->register(\Laravel\Telescope\TelescopeServiceProvider::class);
@@ -101,12 +108,27 @@ class AppServiceProvider extends ServiceProvider
     protected function configurePassport(): void
     {
         Passport::useTokenModel(AccessToken::class);
+        Passport::useAuthCodeModel(AuthCode::class);
 
         Passport::tokensCan([
             'mcp:use' => 'Use MCP server',
         ]);
 
-        Passport::authorizationView('mcp.authorize');
+        Passport::authorizationView(function (array $parameters) {
+            $user = data_get($parameters, 'user');
+            $workspace = $user?->currentWorkspace;
+
+            if ($workspace?->id) {
+                session(['oauth_connecting_workspace_id' => $workspace->id]);
+            }
+
+            return view('mcp.authorize', [
+                ...$parameters,
+                'workspace' => $workspace,
+            ]);
+        });
+
+        Event::listen(AccessTokenCreated::class, BindWorkspaceToAccessToken::class);
     }
 
     protected function configureMorphMap(): void

--- a/database/migrations/2026_08_02_135740_add_workspace_id_to_oauth_auth_codes_table.php
+++ b/database/migrations/2026_08_02_135740_add_workspace_id_to_oauth_auth_codes_table.php
@@ -1,0 +1,36 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('oauth_auth_codes', function (Blueprint $table) {
+            $table->foreignUuid('workspace_id')
+                ->nullable()
+                ->after('client_id')
+                ->index();
+
+            $table->foreign('workspace_id')
+                ->references('id')
+                ->on('workspaces')
+                ->nullOnDelete();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('oauth_auth_codes', function (Blueprint $table) {
+            $table->dropForeign(['workspace_id']);
+            $table->dropColumn('workspace_id');
+        });
+    }
+
+    public function getConnection(): ?string
+    {
+        return $this->connection ?? config('passport.connection');
+    }
+};

--- a/database/migrations/2026_08_02_135741_backfill_mcp_oauth_token_workspaces.php
+++ b/database/migrations/2026_08_02_135741_backfill_mcp_oauth_token_workspaces.php
@@ -1,0 +1,17 @@
+<?php
+
+use App\Actions\AccessToken\BackfillMcpOAuthWorkspaces;
+use Illuminate\Database\Migrations\Migration;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        BackfillMcpOAuthWorkspaces::execute();
+    }
+
+    public function down(): void
+    {
+        // Irreversible data migration — bound tokens keep their workspace_id.
+    }
+};

--- a/resources/views/mcp/authorize.blade.php
+++ b/resources/views/mcp/authorize.blade.php
@@ -69,9 +69,18 @@
             <!-- Content -->
             <div class="p-6 pt-0 space-y-4">
                 <!-- User Info -->
-                <div class="rounded-lg border p-4 bg-muted/50">
-                    <p class="text-sm text-muted-foreground mb-2">Logged in as:</p>
-                    <p class="font-medium">{{ $user->email }}</p>
+                <div class="rounded-lg border p-4 bg-muted/50 space-y-3">
+                    <div>
+                        <p class="text-sm text-muted-foreground mb-2">Logged in as:</p>
+                        <p class="font-medium">{{ $user->email }}</p>
+                    </div>
+                    @if($workspace)
+                        <div>
+                            <p class="text-sm text-muted-foreground mb-2">Workspace:</p>
+                            <p class="font-medium">{{ $workspace->name }}</p>
+                            <p class="text-xs text-muted-foreground mt-1">This connection will only access this workspace.</p>
+                        </div>
+                    @endif
                 </div>
 
                 <!-- Scopes / Permissions -->

--- a/tests/Feature/Actions/Invite/RemoveMemberTest.php
+++ b/tests/Feature/Actions/Invite/RemoveMemberTest.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 use App\Actions\Invite\RemoveMember;
+use App\Models\AccessToken;
 use App\Models\User;
 
 test('remove member clears current workspace when it was the removed membership', function () {
@@ -55,4 +56,29 @@ test('remove member prefers another workspace on the same account', function () 
 
     expect($member->account_id)->toBe($owner->account_id);
     expect($member->current_workspace_id)->toBe($sharedB->id);
+});
+
+test('remove member revokes workspace-scoped api keys and mcp oauth tokens', function () {
+    [
+        'member' => $member,
+        'shared_workspaces' => [$workspace, $other],
+    ] = strandedMemberOnSharedAccount(
+        sharedWorkspaces: 2,
+        setMemberCurrent: true,
+    );
+
+    $pat = $member->createToken('API Key')->token;
+    $pat->forceFill(['workspace_id' => $workspace->id])->saveQuietly();
+
+    $otherPat = $member->createToken('Other Key')->token;
+    $otherPat->forceFill(['workspace_id' => $other->id])->saveQuietly();
+
+    $mcp = mcpAccessToken($member, mcpOauthClient(), $workspace);
+
+    RemoveMember::execute($workspace, $member->id);
+
+    expect(AccessToken::query()->find($pat->id)->revoked)->toBeTrue();
+    expect(AccessToken::query()->find($mcp->id)->revoked)->toBeTrue();
+    expect(AccessToken::query()->find($otherPat->id)->revoked)->toBeFalse();
+    expect(User::find($member->id))->not->toBeNull();
 });

--- a/tests/Feature/BackfillMcpOAuthWorkspaceTest.php
+++ b/tests/Feature/BackfillMcpOAuthWorkspaceTest.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Actions\AccessToken\BackfillMcpOAuthWorkspaces;
+use App\Enums\UserWorkspace\Role;
+use App\Models\User;
+use App\Models\Workspace;
+
+test('backfill binds mcp oauth tokens to the users current workspace', function () {
+    $user = User::factory()->create();
+    $workspace = Workspace::factory()->create([
+        'account_id' => $user->account_id,
+        'user_id' => $user->id,
+    ]);
+    $workspace->members()->attach($user->id, ['role' => Role::Admin->value]);
+    $user->update(['current_workspace_id' => $workspace->id]);
+
+    $clientId = mcpOauthClient();
+    $token = mcpAccessToken($user, $clientId, workspace: null);
+
+    $result = BackfillMcpOAuthWorkspaces::execute();
+
+    expect($result['bound'])->toBe(1);
+    expect($result['revoked'])->toBe(0);
+    expect($token->refresh()->workspace_id)->toBe($workspace->id);
+});
+
+test('backfill falls back to the first account workspace when current is missing', function () {
+    $user = User::factory()->create();
+    $workspace = Workspace::factory()->create([
+        'account_id' => $user->account_id,
+        'user_id' => $user->id,
+    ]);
+    $workspace->members()->attach($user->id, ['role' => Role::Admin->value]);
+    $user->update(['current_workspace_id' => null]);
+
+    $clientId = mcpOauthClient();
+    $token = mcpAccessToken($user, $clientId, workspace: null);
+
+    $result = BackfillMcpOAuthWorkspaces::execute();
+
+    expect($result['bound'])->toBe(1);
+    expect($token->refresh()->workspace_id)->toBe($workspace->id);
+});
+
+test('backfill revokes tokens that cannot be mapped to a workspace', function () {
+    $user = User::factory()->create();
+    $user->update(['current_workspace_id' => null]);
+
+    $clientId = mcpOauthClient();
+    $token = mcpAccessToken($user, $clientId, workspace: null);
+
+    $result = BackfillMcpOAuthWorkspaces::execute();
+
+    expect($result['bound'])->toBe(0);
+    expect($result['revoked'])->toBe(1);
+    expect($token->refresh()->revoked)->toBeTrue();
+    expect($token->refresh()->workspace_id)->toBeNull();
+});
+
+test('backfill ignores personal access tokens with null workspace', function () {
+    $user = User::factory()->create();
+    $result = $user->createToken('PAT');
+    $token = $result->token;
+    $token->forceFill(['workspace_id' => null])->saveQuietly();
+
+    $stats = BackfillMcpOAuthWorkspaces::execute();
+
+    expect($stats['bound'])->toBe(0);
+    expect($stats['revoked'])->toBe(0);
+    expect($token->fresh()->revoked)->toBeFalse();
+    expect($token->fresh()->workspace_id)->toBeNull();
+});

--- a/tests/Feature/BackfillMcpOAuthWorkspaceTest.php
+++ b/tests/Feature/BackfillMcpOAuthWorkspaceTest.php
@@ -72,3 +72,25 @@ test('backfill ignores personal access tokens with null workspace', function () 
     expect($token->fresh()->revoked)->toBeFalse();
     expect($token->fresh()->workspace_id)->toBeNull();
 });
+
+test('backfill falls back when current workspace membership was removed', function () {
+    $user = User::factory()->create();
+    $current = Workspace::factory()->create([
+        'account_id' => $user->account_id,
+        'user_id' => $user->id,
+    ]);
+    $fallback = Workspace::factory()->create([
+        'account_id' => $user->account_id,
+        'user_id' => $user->id,
+    ]);
+    $fallback->members()->attach($user->id, ['role' => Role::Admin->value]);
+    $user->update(['current_workspace_id' => $current->id]);
+
+    $clientId = mcpOauthClient();
+    $token = mcpAccessToken($user, $clientId, workspace: null);
+
+    $result = BackfillMcpOAuthWorkspaces::execute();
+
+    expect($result['bound'])->toBe(1);
+    expect($token->refresh()->workspace_id)->toBe($fallback->id);
+});

--- a/tests/Feature/BindWorkspaceToAccessTokenTest.php
+++ b/tests/Feature/BindWorkspaceToAccessTokenTest.php
@@ -9,6 +9,7 @@ use App\Models\User;
 use App\Models\Workspace;
 use App\Passport\AuthCode;
 use App\Passport\AuthCodeRepository;
+use App\Passport\OAuthPayloadDecryptor;
 use Illuminate\Support\Str;
 use Laravel\Passport\Events\AccessTokenCreated;
 use League\OAuth2\Server\Entities\AuthCodeEntityInterface;
@@ -25,13 +26,14 @@ beforeEach(function () {
     $this->user->update(['current_workspace_id' => $this->workspace->id]);
     $this->user->refresh();
     $this->clientId = mcpOauthClient();
+    $this->decryptor = app(OAuthPayloadDecryptor::class);
 });
 
-test('authorization code grant binds workspace from the auth code', function () {
-    $code = Str::random(80);
+test('authorization code grant binds workspace from the encrypted auth code payload', function () {
+    $authCodeId = Str::random(80);
 
     AuthCode::query()->forceCreate([
-        'id' => $code,
+        'id' => $authCodeId,
         'user_id' => $this->user->id,
         'client_id' => $this->clientId,
         'workspace_id' => $this->workspace->id,
@@ -40,16 +42,28 @@ test('authorization code grant binds workspace from the auth code', function () 
         'expires_at' => now()->addMinutes(10),
     ]);
 
-    $token = mcpAccessToken($this->user, $this->clientId, workspace: null);
+    // User switched workspace between consent and token exchange — auth code wins.
+    $otherWorkspace = Workspace::factory()->create([
+        'account_id' => $this->user->account_id,
+        'user_id' => $this->user->id,
+    ]);
+    $otherWorkspace->members()->attach($this->user->id, ['role' => Role::Admin->value]);
+    $this->user->update(['current_workspace_id' => $otherWorkspace->id]);
 
-    expect($token->workspace_id)->toBeNull();
+    $token = mcpAccessToken($this->user, $this->clientId, workspace: null);
 
     request()->merge([
         'grant_type' => 'authorization_code',
-        'code' => $code,
+        'code' => $this->decryptor->encrypt([
+            'client_id' => $this->clientId,
+            'auth_code_id' => $authCodeId,
+            'user_id' => (string) $this->user->id,
+            'scopes' => [],
+            'expire_time' => now()->addMinutes(10)->timestamp,
+        ]),
     ]);
 
-    (new BindWorkspaceToAccessToken)->handle(new AccessTokenCreated(
+    app(BindWorkspaceToAccessToken::class)->handle(new AccessTokenCreated(
         $token->id,
         (string) $this->user->id,
         $this->clientId,
@@ -58,7 +72,7 @@ test('authorization code grant binds workspace from the auth code', function () 
     expect($token->refresh()->workspace_id)->toBe($this->workspace->id);
 });
 
-test('refresh grant inherits workspace from the previous token', function () {
+test('refresh grant inherits workspace from the refreshed access token id', function () {
     $previous = mcpAccessToken($this->user, $this->clientId, $this->workspace);
 
     $otherWorkspace = Workspace::factory()->create([
@@ -66,13 +80,26 @@ test('refresh grant inherits workspace from the previous token', function () {
         'user_id' => $this->user->id,
     ]);
     $otherWorkspace->members()->attach($this->user->id, ['role' => Role::Admin->value]);
+
+    // Newer grant on another workspace for the same client must not win.
+    mcpAccessToken($this->user, $this->clientId, $otherWorkspace);
     $this->user->update(['current_workspace_id' => $otherWorkspace->id]);
 
     $refreshed = mcpAccessToken($this->user, $this->clientId, workspace: null);
 
-    request()->merge(['grant_type' => 'refresh_token']);
+    request()->merge([
+        'grant_type' => 'refresh_token',
+        'refresh_token' => $this->decryptor->encrypt([
+            'client_id' => $this->clientId,
+            'refresh_token_id' => Str::random(80),
+            'access_token_id' => $previous->id,
+            'scopes' => [],
+            'user_id' => (string) $this->user->id,
+            'expire_time' => now()->addMonth()->timestamp,
+        ]),
+    ]);
 
-    (new BindWorkspaceToAccessToken)->handle(new AccessTokenCreated(
+    app(BindWorkspaceToAccessToken::class)->handle(new AccessTokenCreated(
         $refreshed->id,
         (string) $this->user->id,
         $this->clientId,
@@ -90,7 +117,7 @@ test('personal access tokens are left alone for controllers to bind', function (
 
     request()->merge(['grant_type' => 'personal_access']);
 
-    (new BindWorkspaceToAccessToken)->handle(new AccessTokenCreated(
+    app(BindWorkspaceToAccessToken::class)->handle(new AccessTokenCreated(
         $token->id,
         (string) $this->user->id,
         (string) $token->client_id,
@@ -120,6 +147,54 @@ test('auth code repository captures the authorizing user current workspace', fun
     expect($stored->workspace_id)->toBe($this->workspace->id);
 });
 
+test('auth code repository uses current workspace on silent reconsent after switch', function () {
+    $otherWorkspace = Workspace::factory()->create([
+        'account_id' => $this->user->account_id,
+        'user_id' => $this->user->id,
+        'name' => 'Workspace B',
+    ]);
+    $otherWorkspace->members()->attach($this->user->id, ['role' => Role::Admin->value]);
+    $this->user->update(['current_workspace_id' => $otherWorkspace->id]);
+    $this->actingAs($this->user->fresh());
+
+    $client = Mockery::mock(ClientEntityInterface::class);
+    $client->shouldReceive('getIdentifier')->andReturn($this->clientId);
+
+    $entity = Mockery::mock(AuthCodeEntityInterface::class);
+    $entity->shouldReceive('getIdentifier')->andReturn(Str::random(80));
+    $entity->shouldReceive('getUserIdentifier')->andReturn((string) $this->user->id);
+    $entity->shouldReceive('getClient')->andReturn($client);
+    $entity->shouldReceive('getScopes')->andReturn([]);
+    $entity->shouldReceive('getExpiryDateTime')->andReturn(now()->addMinutes(10)->toDateTimeImmutable());
+
+    app(AuthCodeRepository::class)->persistNewAuthCode($entity);
+
+    $stored = AuthCode::query()->where('client_id', $this->clientId)->first();
+
+    expect($stored->workspace_id)->toBe($otherWorkspace->id);
+});
+
+test('auth code repository rejects a current workspace the user no longer belongs to', function () {
+    $this->workspace->members()->detach($this->user->id);
+    $this->actingAs($this->user->fresh());
+
+    $client = Mockery::mock(ClientEntityInterface::class);
+    $client->shouldReceive('getIdentifier')->andReturn($this->clientId);
+
+    $entity = Mockery::mock(AuthCodeEntityInterface::class);
+    $entity->shouldReceive('getIdentifier')->andReturn(Str::random(80));
+    $entity->shouldReceive('getUserIdentifier')->andReturn((string) $this->user->id);
+    $entity->shouldReceive('getClient')->andReturn($client);
+    $entity->shouldReceive('getScopes')->andReturn([]);
+    $entity->shouldReceive('getExpiryDateTime')->andReturn(now()->addMinutes(10)->toDateTimeImmutable());
+
+    app(AuthCodeRepository::class)->persistNewAuthCode($entity);
+
+    $stored = AuthCode::query()->where('client_id', $this->clientId)->first();
+
+    expect($stored->workspace_id)->toBeNull();
+});
+
 test('oauth grant without a resolvable workspace is revoked', function () {
     $this->user->update(['current_workspace_id' => null]);
     $this->workspace->members()->detach($this->user->id);
@@ -128,7 +203,7 @@ test('oauth grant without a resolvable workspace is revoked', function () {
 
     request()->merge(['grant_type' => 'authorization_code']);
 
-    (new BindWorkspaceToAccessToken)->handle(new AccessTokenCreated(
+    app(BindWorkspaceToAccessToken::class)->handle(new AccessTokenCreated(
         $token->id,
         (string) $this->user->id,
         $this->clientId,

--- a/tests/Feature/BindWorkspaceToAccessTokenTest.php
+++ b/tests/Feature/BindWorkspaceToAccessTokenTest.php
@@ -14,6 +14,7 @@ use Illuminate\Support\Str;
 use Laravel\Passport\Events\AccessTokenCreated;
 use League\OAuth2\Server\Entities\AuthCodeEntityInterface;
 use League\OAuth2\Server\Entities\ClientEntityInterface;
+use League\OAuth2\Server\Exception\OAuthServerException;
 use Mockery;
 
 beforeEach(function () {
@@ -195,7 +196,7 @@ test('auth code repository rejects a current workspace the user no longer belong
     expect($stored->workspace_id)->toBeNull();
 });
 
-test('oauth grant without a resolvable workspace is revoked', function () {
+test('oauth grant without a resolvable workspace fails the grant and revokes the token', function () {
     $this->user->update(['current_workspace_id' => null]);
     $this->workspace->members()->detach($this->user->id);
 
@@ -203,11 +204,11 @@ test('oauth grant without a resolvable workspace is revoked', function () {
 
     request()->merge(['grant_type' => 'authorization_code']);
 
-    app(BindWorkspaceToAccessToken::class)->handle(new AccessTokenCreated(
+    expect(fn () => app(BindWorkspaceToAccessToken::class)->handle(new AccessTokenCreated(
         $token->id,
         (string) $this->user->id,
         $this->clientId,
-    ));
+    )))->toThrow(OAuthServerException::class);
 
     expect($token->refresh()->revoked)->toBeTrue();
     expect($token->refresh()->workspace_id)->toBeNull();

--- a/tests/Feature/BindWorkspaceToAccessTokenTest.php
+++ b/tests/Feature/BindWorkspaceToAccessTokenTest.php
@@ -1,0 +1,139 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Enums\UserWorkspace\Role;
+use App\Listeners\BindWorkspaceToAccessToken;
+use App\Models\AccessToken;
+use App\Models\User;
+use App\Models\Workspace;
+use App\Passport\AuthCode;
+use App\Passport\AuthCodeRepository;
+use Illuminate\Support\Str;
+use Laravel\Passport\Events\AccessTokenCreated;
+use League\OAuth2\Server\Entities\AuthCodeEntityInterface;
+use League\OAuth2\Server\Entities\ClientEntityInterface;
+use Mockery;
+
+beforeEach(function () {
+    $this->user = User::factory()->create();
+    $this->workspace = Workspace::factory()->create([
+        'account_id' => $this->user->account_id,
+        'user_id' => $this->user->id,
+    ]);
+    $this->workspace->members()->attach($this->user->id, ['role' => Role::Admin->value]);
+    $this->user->update(['current_workspace_id' => $this->workspace->id]);
+    $this->user->refresh();
+    $this->clientId = mcpOauthClient();
+});
+
+test('authorization code grant binds workspace from the auth code', function () {
+    $code = Str::random(80);
+
+    AuthCode::query()->forceCreate([
+        'id' => $code,
+        'user_id' => $this->user->id,
+        'client_id' => $this->clientId,
+        'workspace_id' => $this->workspace->id,
+        'scopes' => '[]',
+        'revoked' => true,
+        'expires_at' => now()->addMinutes(10),
+    ]);
+
+    $token = mcpAccessToken($this->user, $this->clientId, workspace: null);
+
+    expect($token->workspace_id)->toBeNull();
+
+    request()->merge([
+        'grant_type' => 'authorization_code',
+        'code' => $code,
+    ]);
+
+    (new BindWorkspaceToAccessToken)->handle(new AccessTokenCreated(
+        $token->id,
+        (string) $this->user->id,
+        $this->clientId,
+    ));
+
+    expect($token->refresh()->workspace_id)->toBe($this->workspace->id);
+});
+
+test('refresh grant inherits workspace from the previous token', function () {
+    $previous = mcpAccessToken($this->user, $this->clientId, $this->workspace);
+
+    $otherWorkspace = Workspace::factory()->create([
+        'account_id' => $this->user->account_id,
+        'user_id' => $this->user->id,
+    ]);
+    $otherWorkspace->members()->attach($this->user->id, ['role' => Role::Admin->value]);
+    $this->user->update(['current_workspace_id' => $otherWorkspace->id]);
+
+    $refreshed = mcpAccessToken($this->user, $this->clientId, workspace: null);
+
+    request()->merge(['grant_type' => 'refresh_token']);
+
+    (new BindWorkspaceToAccessToken)->handle(new AccessTokenCreated(
+        $refreshed->id,
+        (string) $this->user->id,
+        $this->clientId,
+    ));
+
+    expect($refreshed->refresh()->workspace_id)->toBe($previous->workspace_id);
+    expect($refreshed->refresh()->workspace_id)->not->toBe($otherWorkspace->id);
+});
+
+test('personal access tokens are left alone for controllers to bind', function () {
+    $result = $this->user->createToken('PAT');
+    $token = AccessToken::query()->find($result->token->id);
+
+    expect($token->workspace_id)->toBeNull();
+
+    request()->merge(['grant_type' => 'personal_access']);
+
+    (new BindWorkspaceToAccessToken)->handle(new AccessTokenCreated(
+        $token->id,
+        (string) $this->user->id,
+        (string) $token->client_id,
+    ));
+
+    expect($token->refresh()->workspace_id)->toBeNull();
+});
+
+test('auth code repository captures the authorizing user current workspace', function () {
+    $this->actingAs($this->user);
+
+    $client = Mockery::mock(ClientEntityInterface::class);
+    $client->shouldReceive('getIdentifier')->andReturn($this->clientId);
+
+    $entity = Mockery::mock(AuthCodeEntityInterface::class);
+    $entity->shouldReceive('getIdentifier')->andReturn(Str::random(80));
+    $entity->shouldReceive('getUserIdentifier')->andReturn((string) $this->user->id);
+    $entity->shouldReceive('getClient')->andReturn($client);
+    $entity->shouldReceive('getScopes')->andReturn([]);
+    $entity->shouldReceive('getExpiryDateTime')->andReturn(now()->addMinutes(10)->toDateTimeImmutable());
+
+    app(AuthCodeRepository::class)->persistNewAuthCode($entity);
+
+    $stored = AuthCode::query()->where('client_id', $this->clientId)->first();
+
+    expect($stored)->not->toBeNull();
+    expect($stored->workspace_id)->toBe($this->workspace->id);
+});
+
+test('oauth grant without a resolvable workspace is revoked', function () {
+    $this->user->update(['current_workspace_id' => null]);
+    $this->workspace->members()->detach($this->user->id);
+
+    $token = mcpAccessToken($this->user, $this->clientId, workspace: null);
+
+    request()->merge(['grant_type' => 'authorization_code']);
+
+    (new BindWorkspaceToAccessToken)->handle(new AccessTokenCreated(
+        $token->id,
+        (string) $this->user->id,
+        $this->clientId,
+    ));
+
+    expect($token->refresh()->revoked)->toBeTrue();
+    expect($token->refresh()->workspace_id)->toBeNull();
+});

--- a/tests/Feature/LoadWorkspaceFromTokenTest.php
+++ b/tests/Feature/LoadWorkspaceFromTokenTest.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Enums\UserWorkspace\Role;
+use App\Models\AccessToken;
+use App\Models\User;
+use App\Models\Workspace;
+
+beforeEach(function () {
+    $this->user = User::factory()->create();
+    $this->workspaceA = Workspace::factory()->create([
+        'account_id' => $this->user->account_id,
+        'user_id' => $this->user->id,
+        'name' => 'Workspace A',
+    ]);
+    $this->workspaceB = Workspace::factory()->create([
+        'account_id' => $this->user->account_id,
+        'user_id' => $this->user->id,
+        'name' => 'Workspace B',
+    ]);
+    $this->workspaceA->members()->attach($this->user->id, ['role' => Role::Admin->value]);
+    $this->workspaceB->members()->attach($this->user->id, ['role' => Role::Admin->value]);
+    $this->user->update(['current_workspace_id' => $this->workspaceA->id]);
+});
+
+test('token uses its bound workspace even when the user switched current workspace', function () {
+    $plain = passportToken($this->user, $this->workspaceA);
+
+    $this->user->update(['current_workspace_id' => $this->workspaceB->id]);
+
+    $this->withHeaders(['Authorization' => "Bearer {$plain}"])
+        ->getJson(route('api.workspace.show'))
+        ->assertOk()
+        ->assertJsonPath('id', $this->workspaceA->id)
+        ->assertJsonPath('name', 'Workspace A');
+});
+
+test('token without workspace_id is rejected', function () {
+    $result = $this->user->createToken('Unbound');
+    $plain = $result->accessToken;
+
+    AccessToken::query()
+        ->whereKey($result->token->id)
+        ->update(['workspace_id' => null]);
+
+    $this->withHeaders(['Authorization' => "Bearer {$plain}"])
+        ->getJson(route('api.workspace.show'))
+        ->assertUnauthorized()
+        ->assertJsonPath('message', 'No workspace selected.');
+});
+
+test('token bound to a workspace the user no longer belongs to is rejected', function () {
+    $plain = passportToken($this->user, $this->workspaceA);
+
+    $this->workspaceA->members()->detach($this->user->id);
+    $this->user->update(['current_workspace_id' => $this->workspaceB->id]);
+
+    $this->withHeaders(['Authorization' => "Bearer {$plain}"])
+        ->getJson(route('api.workspace.show'))
+        ->assertUnauthorized()
+        ->assertJsonPath('message', 'No workspace selected.');
+});

--- a/tests/Feature/Mcp/ApiKeyToolTest.php
+++ b/tests/Feature/Mcp/ApiKeyToolTest.php
@@ -51,15 +51,12 @@ test('list api keys returns wrapped api_keys array with ApiKeyResource shape', f
         });
 });
 
-test('list api keys excludes OAuth tokens (workspace_id null)', function () {
+test('list api keys excludes MCP OAuth tokens even when workspace-bound', function () {
     // Personal Access Token (workspace bound)
     attachToken($this->user, $this->workspace);
 
-    // OAuth-flow token (workspace_id null — like ChatGPT MCP session)
-    $oauthResult = $this->user->createToken('OAuth Session');
-    AccessToken::find($oauthResult->token->id)
-        ->forceFill(['workspace_id' => null])
-        ->saveQuietly();
+    // MCP OAuth grant bound to the same workspace — must not appear as an API key
+    mcpAccessToken($this->user, mcpOauthClient(), $this->workspace);
 
     $response = TryPostServer::actingAs($this->user)
         ->tool(ListApiKeysTool::class, []);

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -9,6 +9,8 @@ use App\Models\Plan;
 use App\Models\User;
 use App\Models\Workspace;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
 use Tests\BrowserTestCase;
 use Tests\TestCase;
 
@@ -114,6 +116,48 @@ function createApiTestToken(array $overrides = []): array
 function feedFixture(string $name): string
 {
     return file_get_contents(base_path("tests/fixtures/feeds/{$name}.xml"));
+}
+
+/**
+ * Insert a Passport OAuth client used by MCP connectors (not personal access).
+ */
+function mcpOauthClient(string $name = 'My Agent'): string
+{
+    $id = (string) Str::uuid();
+
+    DB::table('oauth_clients')->insert([
+        'id' => $id,
+        'name' => $name,
+        'secret' => null,
+        'provider' => null,
+        'redirect_uris' => '[]',
+        'grant_types' => json_encode(['authorization_code', 'refresh_token']),
+        'revoked' => false,
+        'created_at' => now(),
+        'updated_at' => now(),
+    ]);
+
+    return $id;
+}
+
+/**
+ * Create an active OAuth access token for MCP connection tests.
+ */
+function mcpAccessToken(User $user, string $clientId, ?Workspace $workspace = null): AccessToken
+{
+    $token = new AccessToken;
+    $token->forceFill([
+        'id' => Str::random(80),
+        'user_id' => $user->id,
+        'client_id' => $clientId,
+        'workspace_id' => $workspace?->id,
+        'name' => 'MCP',
+        'scopes' => [],
+        'revoked' => false,
+        'expires_at' => now()->addYear(),
+    ])->save();
+
+    return $token->refresh();
 }
 
 /**

--- a/tests/Unit/AccessTokenScopesTest.php
+++ b/tests/Unit/AccessTokenScopesTest.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Enums\UserWorkspace\Role;
+use App\Models\AccessToken;
+use App\Models\User;
+use App\Models\Workspace;
+
+test('personalAccess scope only returns personal access api keys', function () {
+    $user = User::factory()->create();
+    $workspace = Workspace::factory()->create([
+        'account_id' => $user->account_id,
+        'user_id' => $user->id,
+    ]);
+    $workspace->members()->attach($user->id, ['role' => Role::Admin->value]);
+
+    $pat = $user->createToken('PAT')->token;
+    $pat->forceFill(['workspace_id' => $workspace->id])->saveQuietly();
+
+    $oauth = mcpAccessToken($user, mcpOauthClient(), $workspace);
+
+    $ids = AccessToken::query()->personalAccess()->pluck('id');
+
+    expect($ids)->toContain($pat->id);
+    expect($ids)->not->toContain($oauth->id);
+});
+
+test('activeMcpOAuth scope only returns non-revoked oauth grants', function () {
+    $user = User::factory()->create();
+    $workspace = Workspace::factory()->create([
+        'account_id' => $user->account_id,
+        'user_id' => $user->id,
+    ]);
+    $workspace->members()->attach($user->id, ['role' => Role::Admin->value]);
+
+    $pat = $user->createToken('PAT')->token;
+    $pat->forceFill(['workspace_id' => $workspace->id])->saveQuietly();
+
+    $active = mcpAccessToken($user, mcpOauthClient('Active'), $workspace);
+    $revoked = mcpAccessToken($user, mcpOauthClient('Revoked'), $workspace);
+    $revoked->forceFill(['revoked' => true])->saveQuietly();
+
+    $ids = AccessToken::query()->activeMcpOAuth()->pluck('id');
+
+    expect($ids)->toContain($active->id);
+    expect($ids)->not->toContain($revoked->id);
+    expect($ids)->not->toContain($pat->id);
+});
+
+test('isMcpOAuthGrant distinguishes oauth from personal access', function () {
+    $user = User::factory()->create();
+    $workspace = Workspace::factory()->create([
+        'account_id' => $user->account_id,
+        'user_id' => $user->id,
+    ]);
+
+    $pat = AccessToken::query()->find($user->createToken('PAT')->token->id);
+    $oauth = mcpAccessToken($user, mcpOauthClient(), $workspace);
+
+    expect($pat->isMcpOAuthGrant())->toBeFalse();
+    expect($oauth->isMcpOAuthGrant())->toBeTrue();
+});

--- a/tests/Unit/RevokeAccessTokensTest.php
+++ b/tests/Unit/RevokeAccessTokensTest.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Actions\AccessToken\RevokeAccessTokens;
+use App\Enums\UserWorkspace\Role;
+use App\Models\AccessToken;
+use App\Models\User;
+use App\Models\Workspace;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
+
+test('revokes access tokens and their refresh tokens', function () {
+    $user = User::factory()->create();
+    $workspace = Workspace::factory()->create([
+        'account_id' => $user->account_id,
+        'user_id' => $user->id,
+    ]);
+    $workspace->members()->attach($user->id, ['role' => Role::Admin->value]);
+
+    $token = mcpAccessToken($user, mcpOauthClient(), $workspace);
+    $refreshId = Str::random(80);
+
+    DB::table('oauth_refresh_tokens')->insert([
+        'id' => $refreshId,
+        'access_token_id' => $token->id,
+        'revoked' => false,
+        'expires_at' => now()->addMonth(),
+    ]);
+
+    RevokeAccessTokens::execute($token);
+
+    expect(AccessToken::query()->find($token->id)->revoked)->toBeTrue();
+    expect(DB::table('oauth_refresh_tokens')->where('id', $refreshId)->value('revoked'))->toBeTrue();
+});
+
+test('ignores already revoked tokens without error', function () {
+    $user = User::factory()->create();
+    $token = mcpAccessToken($user, mcpOauthClient());
+    $token->forceFill(['revoked' => true])->saveQuietly();
+
+    RevokeAccessTokens::execute([$token]);
+
+    expect(AccessToken::query()->find($token->id)->revoked)->toBeTrue();
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #222.

## Summary

MCP OAuth tokens (Claude/ChatGPT connectors) are now scoped to **user + workspace**, matching personal API keys. Requests resolve the workspace from the token instead of the user's `current_workspace_id`, so a multi-workspace agent cannot silently act on the wrong tenant.

## Decisions

| Item | Decision |
|---|---|
| Capture workspace at connect | Bind to `Auth::user()->current_workspace_id` at consent (including silent re-consent) + membership check. |
| Persist across code→token | `oauth_auth_codes.workspace_id`; listener decrypts League's encrypted `code` (`auth_code_id`) and copies workspace. |
| Refresh tokens | Decrypt `refresh_token` → inherit that specific `access_token_id`'s workspace. |
| Bind failure | Revoke the token and throw `invalid_grant` (no success response with a dead token). |
| Null after backfill | Fail closed in middleware. |
| Partial member removal | `RemoveMember` revokes that user's tokens for the removed workspace via shared `RevokeAccessTokens`. |
| API key list/delete | Filter by `personalAccess()` grant type. |
| Onboarding / settings UI | Follow-up after #204 (not on `main` yet). |

## Review hardening

- Decrypt auth-code / refresh-token payloads (League encrypts them).
- Silent re-consent uses current workspace, not stale session.
- Refresh inherits the refreshed token, not “latest for client”.
- Unbindable grants fail with `invalid_grant`.
- Shared revoke helper for access + refresh tokens.
- Backfill eager-loads users/workspaces (no N+1).

## Test plan

- [x] Encrypted auth-code binding (consent workspace wins over later switch)
- [x] Refresh inherits refreshed token workspace amid sibling grants
- [x] Silent re-consent after workspace switch
- [x] Auth code rejects non-member current workspace
- [x] Unbindable grant → `invalid_grant` + revoked token
- [x] Middleware: bound / null / non-member
- [x] Backfill bind / fallback / left-current / revoke / ignore PATs
- [x] `RevokeAccessTokens` revokes refresh tokens
- [x] API key list excludes workspace-bound MCP OAuth
- [x] RemoveMember revokes only that workspace's tokens
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-52bd557c-2805-4a92-9682-2273a0d85fec?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-52bd557c-2805-4a92-9682-2273a0d85fec&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

