### PR TITLE
fix: skip removed social accounts when duplicating posts

### DIFF
--- a/app/Actions/Post/DuplicatePost.php
+++ b/app/Actions/Post/DuplicatePost.php
@@ -16,9 +16,9 @@ use Illuminate\Support\Facades\DB;
  * into a fresh Draft. The new post is owned by the actor and unscheduled —
  * the user picks a new date in the editor.
  *
- * Platform rows whose social account was removed (null social_account_id /
- * missing relation — typical after disconnect keeps published history) are
- * skipped so the draft never carries unpublishable orphan channels.
+ * Only platform rows with a still-existing social account are copied
+ * (`whereHas('socialAccount')`), so orphan history rows left after disconnect
+ * never land on the new draft.
  */
 class DuplicatePost
 {
@@ -35,13 +35,11 @@ class DuplicatePost
                 'published_at' => null,
             ]);
 
-            $original->loadMissing('postPlatforms.socialAccount');
+            $platforms = $original->postPlatforms()
+                ->whereHas('socialAccount')
+                ->get();
 
-            foreach ($original->postPlatforms as $platform) {
-                if ($platform->social_account_id === null || $platform->socialAccount === null) {
-                    continue;
-                }
-
+            foreach ($platforms as $platform) {
                 $copy->postPlatforms()->create([
                     'social_account_id' => $platform->social_account_id,
                     'platform' => $platform->platform,

--- a/app/Actions/Post/DuplicatePost.php
+++ b/app/Actions/Post/DuplicatePost.php
@@ -12,9 +12,13 @@ use App\Models\User;
 use Illuminate\Support\Facades\DB;
 
 /**
- * Clones a Post (and its enabled platform rows + label associations) into a
- * fresh Draft. The new post is owned by the actor and unscheduled — the user
- * picks a new date in the editor.
+ * Clones a Post (and its still-connected platform rows + label associations)
+ * into a fresh Draft. The new post is owned by the actor and unscheduled —
+ * the user picks a new date in the editor.
+ *
+ * Platform rows whose social account was removed (null social_account_id /
+ * missing relation — typical after disconnect keeps published history) are
+ * skipped so the draft never carries unpublishable orphan channels.
  */
 class DuplicatePost
 {
@@ -31,7 +35,13 @@ class DuplicatePost
                 'published_at' => null,
             ]);
 
+            $original->loadMissing('postPlatforms.socialAccount');
+
             foreach ($original->postPlatforms as $platform) {
+                if ($platform->social_account_id === null || $platform->socialAccount === null) {
+                    continue;
+                }
+
                 $copy->postPlatforms()->create([
                     'social_account_id' => $platform->social_account_id,
                     'platform' => $platform->platform,

--- a/tests/Feature/Actions/Post/DuplicatePostTest.php
+++ b/tests/Feature/Actions/Post/DuplicatePostTest.php
@@ -5,8 +5,12 @@ declare(strict_types=1);
 use App\Actions\Post\DuplicatePost;
 use App\Enums\Post\CreatedVia;
 use App\Enums\Post\Status as PostStatus;
+use App\Enums\PostPlatform\Status as PostPlatformStatus;
+use App\Enums\SocialAccount\Platform;
 use App\Events\PostCreated;
 use App\Models\Post;
+use App\Models\PostPlatform;
+use App\Models\SocialAccount;
 use App\Models\User;
 use App\Models\Workspace;
 use Illuminate\Support\Facades\Event;
@@ -48,4 +52,80 @@ test('execute relies on the observer to dispatch PostCreated for the duplicate',
         PostCreated::class,
         fn (PostCreated $event) => $event->post->id === $copy->id,
     );
+});
+
+test('execute skips platform rows whose social account was removed', function () {
+    $user = User::factory()->create();
+    $workspace = Workspace::factory()->create(['user_id' => $user->id]);
+    $liveAccount = SocialAccount::factory()->create([
+        'workspace_id' => $workspace->id,
+        'platform' => Platform::X,
+        'display_name' => 'Live Account',
+        'username' => 'live_user',
+    ]);
+
+    $original = Post::factory()->create([
+        'workspace_id' => $workspace->id,
+        'user_id' => $user->id,
+        'status' => PostStatus::Published,
+    ]);
+
+    PostPlatform::factory()->x()->published()->create([
+        'post_id' => $original->id,
+        'social_account_id' => $liveAccount->id,
+        'platform_name' => 'Live Account',
+        'platform_username' => 'live_user',
+        'platform_avatar' => 'avatars/live.jpg',
+        'enabled' => true,
+    ]);
+
+    // History row left after disconnect: FK nullOnDelete + snapshot fields.
+    PostPlatform::factory()->tiktok()->published()->create([
+        'post_id' => $original->id,
+        'social_account_id' => null,
+        'platform_name' => 'Removed Account',
+        'platform_username' => 'gone_user',
+        'platform_avatar' => 'avatars/orphan.jpg',
+        'enabled' => true,
+    ]);
+
+    $copy = DuplicatePost::execute($original->load(['postPlatforms', 'labels']), $user);
+
+    $copiedPlatforms = $copy->postPlatforms()->get();
+
+    expect($copiedPlatforms)->toHaveCount(1)
+        ->and($copiedPlatforms->first()->social_account_id)->toBe($liveAccount->id)
+        ->and($copiedPlatforms->first()->platform)->toBe(Platform::X)
+        ->and($copiedPlatforms->first()->platform_name)->toBe('Live Account')
+        ->and($copiedPlatforms->first()->status)->toBe(PostPlatformStatus::Pending)
+        ->and($copiedPlatforms->first()->enabled)->toBeTrue();
+});
+
+test('execute copies only platforms that still have a social account relation', function () {
+    $user = User::factory()->create();
+    $workspace = Workspace::factory()->create(['user_id' => $user->id]);
+    $account = SocialAccount::factory()->create(['workspace_id' => $workspace->id]);
+
+    $original = Post::factory()->create([
+        'workspace_id' => $workspace->id,
+        'user_id' => $user->id,
+        'status' => PostStatus::Published,
+    ]);
+
+    $platform = PostPlatform::factory()->published()->create([
+        'post_id' => $original->id,
+        'social_account_id' => $account->id,
+        'platform_name' => $account->display_name,
+        'platform_username' => $account->username,
+        'enabled' => true,
+    ]);
+
+    $account->delete();
+    $platform->refresh();
+
+    expect($platform->social_account_id)->toBeNull();
+
+    $copy = DuplicatePost::execute($original->fresh(['postPlatforms', 'labels']), $user);
+
+    expect($copy->postPlatforms)->toHaveCount(0);
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

When duplicating a published post after a social account was disconnected, the draft kept orphan `post_platform` rows (`social_account_id = null` with snapshot name/username/avatar). Name/username still showed, but the avatar broke in the Channels UI because the editor falls back to a raw storage path.

`DuplicatePost` now only copies platform rows that still have a social account, via `whereHas('socialAccount')`. Existing connected accounts are still copied; current workspace accounts continue to be added via `SyncPostPlatforms` when opening the editor.

## Test plan

- [x] `php artisan test --compact tests/Feature/Actions/Post/DuplicatePostTest.php`
- [ ] Manually: disconnect an account used on a published post → duplicate that post → orphan channel should not appear in Publish to; remaining live accounts still appear
- [ ] Manually: reconnect/add a new account → reopen the draft editor → new account appears via sync
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-45240fd8-f962-46a1-8ba1-0fd9589bcae6?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-45240fd8-f962-46a1-8ba1-0fd9589bcae6&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

