### PR TITLE
Bump Inertia to laravel 3.3.1 and vue3 3.6.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,7 @@
     "require": {
         "php": "^8.2",
         "google/apiclient": "^2.19",
-        "inertiajs/inertia-laravel": "^3.0",
+        "inertiajs/inertia-laravel": "^3.3.1",
         "intervention/image": "^4.0",
         "laravel/ai": "^0.5.1",
         "laravel/boost": "^2.5",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "d2abd6288d12131200c2297189b1f11f",
+    "content-hash": "4ba4c5a08545fe4b07331917b736e469",
     "packages": [
         {
             "name": "aws/aws-crt-php",
@@ -1774,35 +1774,34 @@
         },
         {
             "name": "inertiajs/inertia-laravel",
-            "version": "v3.1.0",
+            "version": "v3.3.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/inertiajs/inertia-laravel.git",
-                "reference": "f588ce4a5beb25d166f4e372bac0c7f46a4f52ac"
+                "reference": "7bfd75e352938b703180574b943d81963555a0aa"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/inertiajs/inertia-laravel/zipball/f588ce4a5beb25d166f4e372bac0c7f46a4f52ac",
-                "reference": "f588ce4a5beb25d166f4e372bac0c7f46a4f52ac",
+                "url": "https://api.github.com/repos/inertiajs/inertia-laravel/zipball/7bfd75e352938b703180574b943d81963555a0aa",
+                "reference": "7bfd75e352938b703180574b943d81963555a0aa",
                 "shasum": ""
             },
             "require": {
                 "ext-json": "*",
-                "laravel/framework": "^11.0|^12.0|^13.0",
+                "laravel/framework": "^11.35|^12.0|^13.0",
                 "php": "^8.2.0",
                 "symfony/console": "^7.0|^8.0"
             },
             "conflict": {
-                "laravel/boost": "<2.2.0"
+                "laravel/boost": "<2.5.0"
             },
             "require-dev": {
-                "guzzlehttp/guzzle": "^7.2",
+                "guzzlehttp/guzzle": "^7.15.2|^8.0",
                 "larastan/larastan": "^3.0",
                 "laravel/pint": "^1.16",
                 "mockery/mockery": "^1.3.3",
                 "orchestra/testbench": "^9.2|^10.0|^11.0",
-                "phpunit/phpunit": "^11.5|^12.0",
-                "roave/security-advisories": "dev-master"
+                "phpunit/phpunit": "^11.5|^12.0"
             },
             "suggest": {
                 "ext-pcntl": "Recommended when running the Inertia SSR server via the `inertia:start-ssr` artisan command."
@@ -1841,9 +1840,9 @@
             ],
             "support": {
                 "issues": "https://github.com/inertiajs/inertia-laravel/issues",
-                "source": "https://github.com/inertiajs/inertia-laravel/tree/v3.1.0"
+                "source": "https://github.com/inertiajs/inertia-laravel/tree/v3.3.1"
             },
-            "time": "2026-04-30T15:30:29+00:00"
+            "time": "2026-08-04T21:58:51+00:00"
         },
         {
             "name": "intervention/gif",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
                 "@codemirror/lang-json": "^6.0.2",
                 "@codemirror/state": "^6.5.4",
                 "@codemirror/view": "^6.39.17",
-                "@inertiajs/vue3": "^3.0.0",
+                "@inertiajs/vue3": "^3.6.1",
                 "@tabler/icons-vue": "^3.36.1",
                 "@tailwindcss/typography": "^0.5.19",
                 "@vue-flow/background": "^1.3.2",
@@ -740,9 +740,9 @@
             }
         },
         "node_modules/@inertiajs/core": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/@inertiajs/core/-/core-3.0.0.tgz",
-            "integrity": "sha512-LkdXfOXJGLIFQeqirO66lQ401ciO1f7yEiQV7ZWFbt9f2ElgilSkm6aOXLbPwHJF77h27jdtja0OJDS8+l7Svw==",
+            "version": "3.6.1",
+            "resolved": "https://registry.npmjs.org/@inertiajs/core/-/core-3.6.1.tgz",
+            "integrity": "sha512-h6+qqkKfpcoZvxWENy/F5yyiD00PIm8lK+ruQkt6HGk4d3N0LMS9GeUbWVQ4+TDZzIxP/vQLurPktnYvDhYeew==",
             "license": "MIT",
             "dependencies": {
                 "@jridgewell/trace-mapping": "^0.3.31",
@@ -750,7 +750,7 @@
                 "laravel-precognition": "^2.0.0"
             },
             "peerDependencies": {
-                "axios": "^1.13.2"
+                "axios": "^1.15.2"
             },
             "peerDependenciesMeta": {
                 "axios": {
@@ -759,12 +759,12 @@
             }
         },
         "node_modules/@inertiajs/vue3": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/@inertiajs/vue3/-/vue3-3.0.0.tgz",
-            "integrity": "sha512-OBlIDGxTYiFf+aD0GriQePQ78xlFbHhWpreILTfI8rQBc4h0fK++INAjpdGQuJquMRVFC8ayap6I5xQ7mvRfHw==",
+            "version": "3.6.1",
+            "resolved": "https://registry.npmjs.org/@inertiajs/vue3/-/vue3-3.6.1.tgz",
+            "integrity": "sha512-7M76W7uw1DqxWR5O+OV7Yg23yITTDcRxuO7KCdQhI58rp9+OTv2BZId7ePSBmqahYOeXUZbTfZfVoS2O6/hijA==",
             "license": "MIT",
             "dependencies": {
-                "@inertiajs/core": "3.0.0",
+                "@inertiajs/core": "3.6.1",
                 "es-toolkit": "^1.33.0",
                 "laravel-precognition": "^2.0.0"
             },
@@ -5175,13 +5175,14 @@
             }
         },
         "node_modules/es-toolkit": {
-            "version": "1.45.1",
-            "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.45.1.tgz",
-            "integrity": "sha512-/jhoOj/Fx+A+IIyDNOvO3TItGmlMKhtX8ISAHKE90c4b/k1tqaqEZ+uUqfpU8DMnW5cgNJv606zS55jGvza0Xw==",
+            "version": "1.50.0",
+            "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.50.0.tgz",
+            "integrity": "sha512-OyZKhUVvEep9ITEiwHn8GKnMRQIVqoSIX7WnRbkWgJkllCujilqP2rD0u979tkl8wqyc8ICwlc1UBVv/Sl1G6w==",
             "license": "MIT",
             "workspaces": [
                 "docs",
-                "benchmarks"
+                "benchmarks",
+                "tests/types"
             ]
         },
         "node_modules/escalade": {

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
         "@codemirror/lang-json": "^6.0.2",
         "@codemirror/state": "^6.5.4",
         "@codemirror/view": "^6.39.17",
-        "@inertiajs/vue3": "^3.0.0",
+        "@inertiajs/vue3": "^3.6.1",
         "@tabler/icons-vue": "^3.36.1",
         "@tailwindcss/typography": "^0.5.19",
         "@vue-flow/background": "^1.3.2",


### PR DESCRIPTION
## Summary
- Bumps `inertiajs/inertia-laravel` from 3.1.0 → **3.3.1** (DevTools, Guzzle 8, Boost 2.5 support, version-mismatch asset header).
- Bumps `@inertiajs/vue3` / `@inertiajs/core` from 3.0.0 → **3.6.1** so the client stays aligned with the adapter.
- Dependency-only change; no app code edits.

## Test plan
- [x] `composer show inertiajs/inertia-laravel` reports 3.3.1
- [x] `npm ls @inertiajs/vue3` reports 3.6.1
- [x] `npm run build` succeeds
- [x] Smoke: login, navigate settings/posts, MCP settings poll still refreshes
- [x] CI backend + quality + e2e green

Made with [Cursor](https://cursor.com)