### PR TITLE
Fix Facebook Page connect pagination (#212)

### DIFF
--- a/app/Enums/SocialAccount/Platform.php
+++ b/app/Enums/SocialAccount/Platform.php
@@ -392,6 +392,20 @@ enum Platform: string
     }
 
     /**
+     * OAuth entry points for the Instagram connect dialog. Only enabled methods
+     * are returned so self-hosters who disable one variant do not see that option.
+     *
+     * @return list<string>
+     */
+    public static function instagramConnectMethods(): array
+    {
+        return array_values(array_filter([
+            self::Instagram->isEnabled() ? self::Instagram->value : null,
+            self::InstagramFacebook->isEnabled() ? self::InstagramFacebook->value : null,
+        ]));
+    }
+
+    /**
      * Connectable platforms shaped for Inertia account/onboarding grids.
      * Sorted alphabetically by label (ASC, case-insensitive).
      *
@@ -414,10 +428,7 @@ enum Platform: string
                 ];
 
                 if ($platform === self::Instagram) {
-                    $option['connect_methods'] = array_values(array_filter([
-                        self::Instagram->isEnabled() ? self::Instagram->value : null,
-                        self::InstagramFacebook->isEnabled() ? self::InstagramFacebook->value : null,
-                    ]));
+                    $option['connect_methods'] = self::instagramConnectMethods();
                 }
 
                 return $option;

--- a/app/Enums/SocialAccount/Platform.php
+++ b/app/Enums/SocialAccount/Platform.php
@@ -395,19 +395,33 @@ enum Platform: string
      * Connectable platforms shaped for Inertia account/onboarding grids.
      * Sorted alphabetically by label (ASC, case-insensitive).
      *
-     * @return list<array{value: string, label: string, color: string, network: string}>
+     * Instagram includes `connect_methods` so the connect dialog only lists
+     * OAuth entry points that are actually enabled (self-hosters may disable one).
+     *
+     * @return list<array{value: string, label: string, color: string, network: string, connect_methods?: list<string>}>
      */
     public static function connectableOptions(): array
     {
         return collect(self::cases())
             ->filter(fn (self $platform): bool => $platform->isConnectable())
             ->sortBy(fn (self $platform): string => mb_strtolower($platform->label()))
-            ->map(fn (self $platform): array => [
-                'value' => $platform->value,
-                'label' => $platform->label(),
-                'color' => $platform->color(),
-                'network' => $platform->network(),
-            ])
+            ->map(function (self $platform): array {
+                $option = [
+                    'value' => $platform->value,
+                    'label' => $platform->label(),
+                    'color' => $platform->color(),
+                    'network' => $platform->network(),
+                ];
+
+                if ($platform === self::Instagram) {
+                    $option['connect_methods'] = array_values(array_filter([
+                        self::Instagram->isEnabled() ? self::Instagram->value : null,
+                        self::InstagramFacebook->isEnabled() ? self::InstagramFacebook->value : null,
+                    ]));
+                }
+
+                return $option;
+            })
             ->values()
             ->all();
     }

--- a/app/Enums/SocialAccount/Platform.php
+++ b/app/Enums/SocialAccount/Platform.php
@@ -61,7 +61,7 @@ enum Platform: string
             self::TikTok => 'TikTok',
             self::YouTube => 'YouTube Shorts',
             self::Facebook => 'Facebook Page',
-            self::Instagram => 'Instagram (Standalone)',
+            self::Instagram => 'Instagram',
             self::InstagramFacebook => 'Instagram (Facebook Business)',
             self::Threads => 'Threads',
             self::Pinterest => 'Pinterest',
@@ -376,17 +376,36 @@ enum Platform: string
 
     /**
      * Whether this platform gets its own "Connect" card in the accounts grid.
-     * LinkedIn company pages are reached through the unified LinkedIn connect
-     * flow's identity picker, never a standalone card. The single LinkedIn card
-     * stands for the whole network, so it shows whenever the profile OR the
-     * company-page capability is enabled (self-hosters may run with only one).
+     * LinkedIn company pages and Instagram-via-Facebook are reached through the
+     * unified network card (identity picker / method dialog), never a standalone
+     * card. That card stands for the whole network, so it shows whenever any
+     * variant capability is enabled (self-hosters may run with only one).
      */
     public function isConnectable(): bool
     {
         return match ($this) {
-            self::LinkedInPage => false,
+            self::LinkedInPage, self::InstagramFacebook => false,
             self::LinkedIn => self::LinkedIn->isEnabled() || self::LinkedInPage->isEnabled(),
+            self::Instagram => self::Instagram->isEnabled() || self::InstagramFacebook->isEnabled(),
             default => $this->isEnabled(),
+        };
+    }
+
+    /**
+     * OAuth/connect entry points offered when the user clicks this card.
+     * Most platforms have a single method; Instagram offers Login and/or
+     * Facebook Pages depending on which capabilities are enabled.
+     *
+     * @return list<string>
+     */
+    public function connectMethods(): array
+    {
+        return match ($this) {
+            self::Instagram => array_values(array_filter([
+                self::Instagram->isEnabled() ? self::Instagram->value : null,
+                self::InstagramFacebook->isEnabled() ? self::InstagramFacebook->value : null,
+            ])),
+            default => $this->isEnabled() ? [$this->value] : [],
         };
     }
 
@@ -394,7 +413,7 @@ enum Platform: string
      * Connectable platforms shaped for Inertia account/onboarding grids.
      * Sorted alphabetically by label (ASC, case-insensitive).
      *
-     * @return list<array{value: string, label: string, color: string, network: string}>
+     * @return list<array{value: string, label: string, color: string, network: string, connect_methods: list<string>}>
      */
     public static function connectableOptions(): array
     {
@@ -406,6 +425,7 @@ enum Platform: string
                 'label' => $platform->label(),
                 'color' => $platform->color(),
                 'network' => $platform->network(),
+                'connect_methods' => $platform->connectMethods(),
             ])
             ->values()
             ->all();

--- a/app/Enums/SocialAccount/Platform.php
+++ b/app/Enums/SocialAccount/Platform.php
@@ -392,28 +392,10 @@ enum Platform: string
     }
 
     /**
-     * OAuth/connect entry points offered when the user clicks this card.
-     * Most platforms have a single method; Instagram offers Login and/or
-     * Facebook Pages depending on which capabilities are enabled.
-     *
-     * @return list<string>
-     */
-    public function connectMethods(): array
-    {
-        return match ($this) {
-            self::Instagram => array_values(array_filter([
-                self::Instagram->isEnabled() ? self::Instagram->value : null,
-                self::InstagramFacebook->isEnabled() ? self::InstagramFacebook->value : null,
-            ])),
-            default => $this->isEnabled() ? [$this->value] : [],
-        };
-    }
-
-    /**
      * Connectable platforms shaped for Inertia account/onboarding grids.
      * Sorted alphabetically by label (ASC, case-insensitive).
      *
-     * @return list<array{value: string, label: string, color: string, network: string, connect_methods: list<string>}>
+     * @return list<array{value: string, label: string, color: string, network: string}>
      */
     public static function connectableOptions(): array
     {
@@ -425,7 +407,6 @@ enum Platform: string
                 'label' => $platform->label(),
                 'color' => $platform->color(),
                 'network' => $platform->network(),
-                'connect_methods' => $platform->connectMethods(),
             ])
             ->values()
             ->all();

--- a/app/Exceptions/Social/IncompleteGraphPaginationException.php
+++ b/app/Exceptions/Social/IncompleteGraphPaginationException.php
@@ -8,17 +8,13 @@ use RuntimeException;
 use Throwable;
 
 /**
- * Thrown when a Meta Graph edge was only partially fetched (a later page failed
- * after earlier pages succeeded). Callers must not treat the partial list as complete
- * — e.g. auto-connecting when count === 1 would recreate missed-Page bugs.
+ * Thrown when a Meta Graph edge was only partially fetched. Callers must not
+ * treat a truncated list as complete (e.g. auto-connect when count === 1).
  */
 class IncompleteGraphPaginationException extends RuntimeException
 {
-    public function __construct(
-        string $message = 'Meta Graph pagination did not complete.',
-        int $code = 0,
-        ?Throwable $previous = null,
-    ) {
-        parent::__construct($message, $code, $previous);
+    public function __construct(?Throwable $previous = null)
+    {
+        parent::__construct('Meta Graph pagination did not complete.', previous: $previous);
     }
 }

--- a/app/Exceptions/Social/IncompleteGraphPaginationException.php
+++ b/app/Exceptions/Social/IncompleteGraphPaginationException.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Exceptions\Social;
+
+use RuntimeException;
+use Throwable;
+
+/**
+ * Thrown when a Meta Graph edge was only partially fetched (a later page failed
+ * after earlier pages succeeded). Callers must not treat the partial list as complete
+ * — e.g. auto-connecting when count === 1 would recreate missed-Page bugs.
+ */
+class IncompleteGraphPaginationException extends RuntimeException
+{
+    public function __construct(
+        string $message = 'Meta Graph pagination did not complete.',
+        int $code = 0,
+        ?Throwable $previous = null,
+    ) {
+        parent::__construct($message, $code, $previous);
+    }
+}

--- a/app/Exceptions/Social/IncompleteMetaGraphPaginationException.php
+++ b/app/Exceptions/Social/IncompleteMetaGraphPaginationException.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace App\Services\Social\Meta;
+namespace App\Exceptions\Social;
 
 use RuntimeException;
 use Throwable;
@@ -11,7 +11,7 @@ use Throwable;
  * Thrown when a Meta Graph edge was only partially fetched. Callers must not
  * treat a truncated list as complete (e.g. auto-connect when count === 1).
  */
-class IncompletePaginationException extends RuntimeException
+class IncompleteMetaGraphPaginationException extends RuntimeException
 {
     public function __construct(?Throwable $previous = null)
     {

--- a/app/Exceptions/Social/IncompleteMetaGraphPaginationException.php
+++ b/app/Exceptions/Social/IncompleteMetaGraphPaginationException.php
@@ -8,8 +8,10 @@ use RuntimeException;
 use Throwable;
 
 /**
- * Thrown when a Meta Graph edge was only partially fetched. Callers must not
- * treat a truncated list as complete (e.g. auto-connect when count === 1).
+ * Thrown when a Meta Graph edge could not be fully fetched — the first page
+ * failed, a later page failed, or pagination stopped pathologically. Callers
+ * must not treat this as an empty or complete list (e.g. "no pages" or
+ * auto-connect when count === 1).
  */
 class IncompleteMetaGraphPaginationException extends RuntimeException
 {

--- a/app/Http/Controllers/Auth/FacebookController.php
+++ b/app/Http/Controllers/Auth/FacebookController.php
@@ -6,7 +6,6 @@ namespace App\Http\Controllers\Auth;
 
 use App\Enums\SocialAccount\Platform as SocialPlatform;
 use App\Enums\SocialAccount\Status;
-use App\Exceptions\Social\IncompleteGraphPaginationException;
 use App\Exceptions\SocialAccount\NetworkAlreadyConnectedException;
 use App\Models\Workspace;
 use App\Services\Social\Meta\GraphPaginator;
@@ -269,32 +268,20 @@ class FacebookController extends SocialController
 
     private function fetchPages(string $userToken): array
     {
-        try {
-            $pages = GraphPaginator::all(
-                config('trypost.platforms.facebook.graph_api').'/me/accounts',
-                [
-                    'access_token' => $userToken,
-                    'fields' => 'id,name,username,picture{url},access_token',
-                    'limit' => 100,
-                ],
-            );
-
-            return collect($pages)->map(fn ($page) => [
-                'id' => data_get($page, 'id'),
-                'name' => data_get($page, 'name'),
-                'username' => data_get($page, 'username', null),
-                'picture' => data_get($page, 'picture.data.url'),
-                'access_token' => data_get($page, 'access_token'),
-            ])->toArray();
-        } catch (IncompleteGraphPaginationException $e) {
-            throw $e;
-        } catch (\Exception $e) {
-            Log::error('Facebook pages fetch error', [
-                'error' => $e->getMessage(),
-            ]);
-
-            return [];
-        }
+        return collect(GraphPaginator::all(
+            config('trypost.platforms.facebook.graph_api').'/me/accounts',
+            [
+                'access_token' => $userToken,
+                'fields' => 'id,name,username,picture{url},access_token',
+                'limit' => 100,
+            ],
+        ))->map(fn (array $page) => [
+            'id' => data_get($page, 'id'),
+            'name' => data_get($page, 'name'),
+            'username' => data_get($page, 'username'),
+            'picture' => data_get($page, 'picture.data.url'),
+            'access_token' => data_get($page, 'access_token'),
+        ])->all();
     }
 
     private function graphVersion(): string

--- a/app/Http/Controllers/Auth/FacebookController.php
+++ b/app/Http/Controllers/Auth/FacebookController.php
@@ -289,6 +289,6 @@ class FacebookController extends SocialController
 
     private function graphVersion(): string
     {
-        return basename((string) Uri::of((string) config('trypost.platforms.facebook.graph_api'))->path());
+        return Uri::of(str(config('trypost.platforms.facebook.graph_api')))->path();
     }
 }

--- a/app/Http/Controllers/Auth/FacebookController.php
+++ b/app/Http/Controllers/Auth/FacebookController.php
@@ -141,25 +141,19 @@ class FacebookController extends SocialController
         }
     }
 
-    public function selectPage(Request $request)
+    public function selectPage(Request $request): InertiaResponse
     {
         $oauthData = session('facebook_oauth');
         $workspaceId = session('social_connect_workspace');
 
         if (! $oauthData || ! $workspaceId) {
-            session()->flash('flash.banner', __('accounts.flash.session_expired'));
-            session()->flash('flash.bannerStyle', 'danger');
-
-            return redirect()->route('app.accounts');
+            return $this->popupCallback(false, __('accounts.popup_callback.session_expired'), $this->platform->value);
         }
 
         $workspace = Workspace::find($workspaceId);
 
         if (! $workspace) {
-            session()->flash('flash.banner', __('accounts.flash.workspace_not_found'));
-            session()->flash('flash.bannerStyle', 'danger');
-
-            return redirect()->route('app.accounts');
+            return $this->popupCallback(false, __('accounts.popup_callback.workspace_not_found'), $this->platform->value);
         }
 
         $pages = collect(data_get($oauthData, 'pages'))

--- a/app/Http/Controllers/Auth/FacebookController.php
+++ b/app/Http/Controllers/Auth/FacebookController.php
@@ -289,6 +289,6 @@ class FacebookController extends SocialController
 
     private function graphVersion(): string
     {
-        return Uri::of(str(config('trypost.platforms.facebook.graph_api')))->path();
+        return Uri::of(config('trypost.platforms.facebook.graph_api'))->path();
     }
 }

--- a/app/Http/Controllers/Auth/FacebookController.php
+++ b/app/Http/Controllers/Auth/FacebookController.php
@@ -6,6 +6,7 @@ namespace App\Http\Controllers\Auth;
 
 use App\Enums\SocialAccount\Platform as SocialPlatform;
 use App\Enums\SocialAccount\Status;
+use App\Exceptions\Social\IncompleteGraphPaginationException;
 use App\Exceptions\SocialAccount\NetworkAlreadyConnectedException;
 use App\Models\Workspace;
 use App\Services\Social\Meta\GraphPaginator;
@@ -285,6 +286,8 @@ class FacebookController extends SocialController
                 'picture' => data_get($page, 'picture.data.url'),
                 'access_token' => data_get($page, 'access_token'),
             ])->toArray();
+        } catch (IncompleteGraphPaginationException $e) {
+            throw $e;
         } catch (\Exception $e) {
             Log::error('Facebook pages fetch error', [
                 'error' => $e->getMessage(),

--- a/app/Http/Controllers/Auth/FacebookController.php
+++ b/app/Http/Controllers/Auth/FacebookController.php
@@ -268,14 +268,16 @@ class FacebookController extends SocialController
 
     private function fetchPages(string $userToken): array
     {
-        return collect(GraphPaginator::all(
+        $pages = GraphPaginator::all(
             config('trypost.platforms.facebook.graph_api').'/me/accounts',
             [
                 'access_token' => $userToken,
                 'fields' => 'id,name,username,picture{url},access_token',
                 'limit' => 100,
             ],
-        ))->map(fn (array $page) => [
+        );
+
+        return collect($pages)->map(fn (array $page) => [
             'id' => data_get($page, 'id'),
             'name' => data_get($page, 'name'),
             'username' => data_get($page, 'username'),

--- a/app/Http/Controllers/Auth/FacebookController.php
+++ b/app/Http/Controllers/Auth/FacebookController.php
@@ -8,6 +8,7 @@ use App\Enums\SocialAccount\Platform as SocialPlatform;
 use App\Enums\SocialAccount\Status;
 use App\Exceptions\SocialAccount\NetworkAlreadyConnectedException;
 use App\Models\Workspace;
+use App\Services\Social\Meta\GraphPaginator;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Arr;
@@ -268,23 +269,16 @@ class FacebookController extends SocialController
     private function fetchPages(string $userToken): array
     {
         try {
-            $response = Http::get(config('trypost.platforms.facebook.graph_api').'/me/accounts', [
-                'access_token' => $userToken,
-                'fields' => 'id,name,username,picture{url},access_token',
-            ]);
+            $pages = GraphPaginator::all(
+                config('trypost.platforms.facebook.graph_api').'/me/accounts',
+                [
+                    'access_token' => $userToken,
+                    'fields' => 'id,name,username,picture{url},access_token',
+                    'limit' => 100,
+                ],
+            );
 
-            if ($response->failed()) {
-                Log::error('Facebook pages fetch failed', [
-                    'status' => $response->status(),
-                    'body' => $response->body(),
-                ]);
-
-                return [];
-            }
-
-            $data = $response->json();
-
-            return collect(data_get($data, 'data', []))->map(fn ($page) => [
+            return collect($pages)->map(fn ($page) => [
                 'id' => data_get($page, 'id'),
                 'name' => data_get($page, 'name'),
                 'username' => data_get($page, 'username', null),

--- a/app/Http/Controllers/Auth/FacebookController.php
+++ b/app/Http/Controllers/Auth/FacebookController.php
@@ -14,6 +14,7 @@ use Illuminate\Http\Request;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Uri;
 use Inertia\Inertia;
 use Inertia\Response as InertiaResponse;
 use Laravel\Socialite\Facades\Socialite;
@@ -288,6 +289,6 @@ class FacebookController extends SocialController
 
     private function graphVersion(): string
     {
-        return basename((string) parse_url((string) config('trypost.platforms.facebook.graph_api'), PHP_URL_PATH));
+        return basename((string) Uri::of((string) config('trypost.platforms.facebook.graph_api'))->path());
     }
 }

--- a/app/Http/Controllers/Auth/InstagramFacebookController.php
+++ b/app/Http/Controllers/Auth/InstagramFacebookController.php
@@ -6,7 +6,6 @@ namespace App\Http\Controllers\Auth;
 
 use App\Enums\SocialAccount\Platform as SocialPlatform;
 use App\Enums\SocialAccount\Status;
-use App\Exceptions\Social\IncompleteGraphPaginationException;
 use App\Exceptions\SocialAccount\NetworkAlreadyConnectedException;
 use App\Models\Workspace;
 use App\Services\Social\Meta\GraphPaginator;
@@ -236,56 +235,35 @@ class InstagramFacebookController extends SocialController
 
     private function fetchPagesWithInstagram(string $userToken): array
     {
-        try {
-            $graphApi = (string) config('trypost.platforms.instagram-facebook.graph_api');
+        $graphApi = (string) config('trypost.platforms.instagram-facebook.graph_api');
 
-            $pages = GraphPaginator::all(
-                "{$graphApi}/me/accounts",
-                [
-                    'access_token' => $userToken,
-                    'fields' => 'id,name,username,picture{url},access_token,instagram_business_account',
-                    'limit' => 100,
-                ],
-            );
-
-            $results = [];
-
-            foreach ($pages as $page) {
-                $igAccountId = data_get($page, 'instagram_business_account.id');
-
-                if (! $igAccountId) {
-                    continue;
-                }
-
-                // Fetch IG account details (no custom timeout — match prior behavior; a throw
-                // here would wipe the whole list via the outer catch).
-                $igResponse = Http::get("{$graphApi}/{$igAccountId}", [
-                    'access_token' => data_get($page, 'access_token'),
+        return collect(GraphPaginator::all("{$graphApi}/me/accounts", [
+            'access_token' => $userToken,
+            'fields' => 'id,name,username,picture{url},access_token,instagram_business_account',
+            'limit' => 100,
+        ]))->filter(fn (array $page) => filled(data_get($page, 'instagram_business_account.id')))
+            ->map(function (array $page) use ($graphApi) {
+                $igId = data_get($page, 'instagram_business_account.id');
+                $token = data_get($page, 'access_token');
+                $ig = Http::get("{$graphApi}/{$igId}", [
+                    'access_token' => $token,
                     'fields' => 'username,name,profile_picture_url',
                 ]);
+                $igData = $ig->successful() ? $ig->json() : [];
 
-                $igData = $igResponse->successful() ? $igResponse->json() : [];
-
-                $results[] = [
+                return [
                     'page_id' => data_get($page, 'id'),
                     'page_name' => data_get($page, 'name'),
                     'page_picture' => data_get($page, 'picture.data.url'),
-                    'page_access_token' => data_get($page, 'access_token'),
-                    'ig_id' => $igAccountId,
+                    'page_access_token' => $token,
+                    'ig_id' => $igId,
                     'ig_username' => data_get($igData, 'username'),
                     'ig_name' => data_get($igData, 'name'),
                     'ig_picture' => data_get($igData, 'profile_picture_url'),
                 ];
-            }
-
-            return $results;
-        } catch (IncompleteGraphPaginationException $e) {
-            throw $e;
-        } catch (\Exception $e) {
-            Log::error('Instagram via Facebook pages fetch error', ['error' => $e->getMessage()]);
-
-            return [];
-        }
+            })
+            ->values()
+            ->all();
     }
 
     private function graphVersion(): string

--- a/app/Http/Controllers/Auth/InstagramFacebookController.php
+++ b/app/Http/Controllers/Auth/InstagramFacebookController.php
@@ -8,6 +8,7 @@ use App\Enums\SocialAccount\Platform as SocialPlatform;
 use App\Enums\SocialAccount\Status;
 use App\Exceptions\SocialAccount\NetworkAlreadyConnectedException;
 use App\Models\Workspace;
+use App\Services\Social\Meta\GraphPaginator;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Arr;
@@ -237,21 +238,15 @@ class InstagramFacebookController extends SocialController
         try {
             $graphApi = (string) config('trypost.platforms.instagram-facebook.graph_api');
 
-            $response = Http::get($graphApi.'/me/accounts', [
-                'access_token' => $userToken,
-                'fields' => 'id,name,username,picture{url},access_token,instagram_business_account',
-            ]);
+            $pages = GraphPaginator::all(
+                "{$graphApi}/me/accounts",
+                [
+                    'access_token' => $userToken,
+                    'fields' => 'id,name,username,picture{url},access_token,instagram_business_account',
+                    'limit' => 100,
+                ],
+            );
 
-            if ($response->failed()) {
-                Log::error('Instagram via Facebook pages fetch failed', [
-                    'status' => $response->status(),
-                    'body' => $response->body(),
-                ]);
-
-                return [];
-            }
-
-            $pages = data_get($response->json(), 'data', []);
             $results = [];
 
             foreach ($pages as $page) {
@@ -262,10 +257,12 @@ class InstagramFacebookController extends SocialController
                 }
 
                 // Fetch IG account details
-                $igResponse = Http::get("{$graphApi}/{$igAccountId}", [
-                    'access_token' => data_get($page, 'access_token'),
-                    'fields' => 'username,name,profile_picture_url',
-                ]);
+                $igResponse = Http::timeout(15)
+                    ->connectTimeout(5)
+                    ->get("{$graphApi}/{$igAccountId}", [
+                        'access_token' => data_get($page, 'access_token'),
+                        'fields' => 'username,name,profile_picture_url',
+                    ]);
 
                 $igData = $igResponse->successful() ? $igResponse->json() : [];
 

--- a/app/Http/Controllers/Auth/InstagramFacebookController.php
+++ b/app/Http/Controllers/Auth/InstagramFacebookController.php
@@ -6,6 +6,7 @@ namespace App\Http\Controllers\Auth;
 
 use App\Enums\SocialAccount\Platform as SocialPlatform;
 use App\Enums\SocialAccount\Status;
+use App\Exceptions\Social\IncompleteGraphPaginationException;
 use App\Exceptions\SocialAccount\NetworkAlreadyConnectedException;
 use App\Models\Workspace;
 use App\Services\Social\Meta\GraphPaginator;
@@ -256,13 +257,12 @@ class InstagramFacebookController extends SocialController
                     continue;
                 }
 
-                // Fetch IG account details
-                $igResponse = Http::timeout(15)
-                    ->connectTimeout(5)
-                    ->get("{$graphApi}/{$igAccountId}", [
-                        'access_token' => data_get($page, 'access_token'),
-                        'fields' => 'username,name,profile_picture_url',
-                    ]);
+                // Fetch IG account details (no custom timeout — match prior behavior; a throw
+                // here would wipe the whole list via the outer catch).
+                $igResponse = Http::get("{$graphApi}/{$igAccountId}", [
+                    'access_token' => data_get($page, 'access_token'),
+                    'fields' => 'username,name,profile_picture_url',
+                ]);
 
                 $igData = $igResponse->successful() ? $igResponse->json() : [];
 
@@ -279,6 +279,8 @@ class InstagramFacebookController extends SocialController
             }
 
             return $results;
+        } catch (IncompleteGraphPaginationException $e) {
+            throw $e;
         } catch (\Exception $e) {
             Log::error('Instagram via Facebook pages fetch error', ['error' => $e->getMessage()]);
 

--- a/app/Http/Controllers/Auth/InstagramFacebookController.php
+++ b/app/Http/Controllers/Auth/InstagramFacebookController.php
@@ -272,6 +272,6 @@ class InstagramFacebookController extends SocialController
 
     private function graphVersion(): string
     {
-        return Uri::of(str(config('trypost.platforms.instagram-facebook.graph_api')))->path();
+        return Uri::of(config('trypost.platforms.instagram-facebook.graph_api'))->path();
     }
 }

--- a/app/Http/Controllers/Auth/InstagramFacebookController.php
+++ b/app/Http/Controllers/Auth/InstagramFacebookController.php
@@ -272,6 +272,6 @@ class InstagramFacebookController extends SocialController
 
     private function graphVersion(): string
     {
-        return basename((string) Uri::of((string) config('trypost.platforms.instagram-facebook.graph_api'))->path());
+        return Uri::of(str(config('trypost.platforms.instagram-facebook.graph_api')))->path();
     }
 }

--- a/app/Http/Controllers/Auth/InstagramFacebookController.php
+++ b/app/Http/Controllers/Auth/InstagramFacebookController.php
@@ -14,6 +14,7 @@ use Illuminate\Http\Request;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Uri;
 use Inertia\Inertia;
 use Inertia\Response as InertiaResponse;
 use Laravel\Socialite\Facades\Socialite;
@@ -271,6 +272,6 @@ class InstagramFacebookController extends SocialController
 
     private function graphVersion(): string
     {
-        return basename((string) parse_url((string) config('trypost.platforms.instagram-facebook.graph_api'), PHP_URL_PATH));
+        return basename((string) Uri::of((string) config('trypost.platforms.instagram-facebook.graph_api'))->path());
     }
 }

--- a/app/Http/Controllers/Auth/InstagramFacebookController.php
+++ b/app/Http/Controllers/Auth/InstagramFacebookController.php
@@ -120,22 +120,19 @@ class InstagramFacebookController extends SocialController
         }
     }
 
-    public function selectPage(Request $request)
+    public function selectPage(Request $request): InertiaResponse
     {
         $oauthData = session('instagram_facebook_oauth');
         $workspaceId = session('social_connect_workspace');
 
         if (! $oauthData || ! $workspaceId) {
-            session()->flash('flash.banner', 'Session expired. Please try again.');
-            session()->flash('flash.bannerStyle', 'danger');
-
-            return redirect()->route('app.accounts');
+            return $this->popupCallback(false, __('accounts.popup_callback.session_expired'), $this->platform->value);
         }
 
         $workspace = Workspace::find($workspaceId);
 
         if (! $workspace) {
-            return redirect()->route('app.accounts');
+            return $this->popupCallback(false, __('accounts.popup_callback.workspace_not_found'), $this->platform->value);
         }
 
         $pages = collect(data_get($oauthData, 'pages'))

--- a/app/Http/Controllers/Auth/InstagramFacebookController.php
+++ b/app/Http/Controllers/Auth/InstagramFacebookController.php
@@ -9,6 +9,7 @@ use App\Enums\SocialAccount\Status;
 use App\Exceptions\SocialAccount\NetworkAlreadyConnectedException;
 use App\Models\Workspace;
 use App\Services\Social\Meta\GraphPaginator;
+use Illuminate\Http\Client\ConnectionException;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Arr;
@@ -246,11 +247,18 @@ class InstagramFacebookController extends SocialController
             ->map(function (array $page) use ($graphApi) {
                 $igId = data_get($page, 'instagram_business_account.id');
                 $token = data_get($page, 'access_token');
-                $ig = Http::get("{$graphApi}/{$igId}", [
-                    'access_token' => $token,
-                    'fields' => 'username,name,profile_picture_url',
-                ]);
-                $igData = $ig->successful() ? $ig->json() : [];
+                $igData = [];
+
+                try {
+                    $ig = Http::timeout(15)->connectTimeout(5)->get("{$graphApi}/{$igId}", [
+                        'access_token' => $token,
+                        'fields' => 'username,name,profile_picture_url',
+                    ]);
+
+                    $igData = $ig->successful() ? $ig->json() : [];
+                } catch (ConnectionException) {
+                    // Page listing still succeeds; username/avatar may be empty.
+                }
 
                 return [
                     'page_id' => data_get($page, 'id'),

--- a/app/Http/Controllers/Auth/InstagramFacebookController.php
+++ b/app/Http/Controllers/Auth/InstagramFacebookController.php
@@ -237,11 +237,14 @@ class InstagramFacebookController extends SocialController
     {
         $graphApi = (string) config('trypost.platforms.instagram-facebook.graph_api');
 
-        return collect(GraphPaginator::all("{$graphApi}/me/accounts", [
+        $pages = GraphPaginator::all("{$graphApi}/me/accounts", [
             'access_token' => $userToken,
             'fields' => 'id,name,username,picture{url},access_token,instagram_business_account',
             'limit' => 100,
-        ]))->filter(fn (array $page) => filled(data_get($page, 'instagram_business_account.id')))
+        ]);
+
+        return collect($pages)
+            ->filter(fn (array $page) => filled(data_get($page, 'instagram_business_account.id')))
             ->map(function (array $page) use ($graphApi) {
                 $igId = data_get($page, 'instagram_business_account.id');
                 $token = data_get($page, 'access_token');

--- a/app/Http/Controllers/Auth/SocialController.php
+++ b/app/Http/Controllers/Auth/SocialController.php
@@ -168,6 +168,10 @@ class SocialController extends Controller
      * Render the Inertia page that notifies the opener and closes the connect
      * popup. Used by both the GET OAuth callbacks (a fresh popup page load) and
      * the XHR selection submits (an Inertia visit that swaps to this page).
+     *
+     * Always pass `onboardingProgress` as inline false so it overrides the shared
+     * deferred prop: after select the URL is still the select path, and a deferred
+     * reload would re-GET that route with a cleared session.
      */
     protected function popupCallback(bool $success, string $message, ?string $platform = null): Response
     {
@@ -177,6 +181,7 @@ class SocialController extends Controller
             'success' => $success,
             'message' => $message,
             'platform' => $platform,
+            'onboardingProgress' => false,
         ]);
     }
 }

--- a/app/Http/Controllers/Auth/YouTubeController.php
+++ b/app/Http/Controllers/Auth/YouTubeController.php
@@ -124,25 +124,19 @@ class YouTubeController extends SocialController
         }
     }
 
-    public function selectChannel(Request $request)
+    public function selectChannel(Request $request): InertiaResponse
     {
         $oauthData = session('youtube_oauth');
         $workspaceId = session('social_connect_workspace');
 
         if (! $oauthData || ! $workspaceId) {
-            session()->flash('flash.banner', __('accounts.flash.session_expired'));
-            session()->flash('flash.bannerStyle', 'danger');
-
-            return redirect()->route('app.accounts');
+            return $this->popupCallback(false, __('accounts.popup_callback.session_expired'), $this->platform->value);
         }
 
         $workspace = Workspace::find($workspaceId);
 
         if (! $workspace) {
-            session()->flash('flash.banner', __('accounts.flash.workspace_not_found'));
-            session()->flash('flash.bannerStyle', 'danger');
-
-            return redirect()->route('app.accounts');
+            return $this->popupCallback(false, __('accounts.popup_callback.workspace_not_found'), $this->platform->value);
         }
 
         // Fetch YouTube channels
@@ -152,13 +146,10 @@ class YouTubeController extends SocialController
             $this->forgetSocialConnectSession();
             session()->forget('youtube_oauth');
 
-            session()->flash('flash.banner', __('accounts.flash.no_youtube_channels'));
-            session()->flash('flash.bannerStyle', 'danger');
-
-            return redirect()->route('app.accounts');
+            return $this->popupCallback(false, __('accounts.popup_callback.no_youtube_channels'), $this->platform->value);
         }
 
-        return inertia('accounts/YouTubeChannelSelect', [
+        return Inertia::render('accounts/YouTubeChannelSelect', [
             'workspace' => $workspace,
             'channels' => $channels,
         ]);

--- a/app/Http/Middleware/App/HandleInertiaRequests.php
+++ b/app/Http/Middleware/App/HandleInertiaRequests.php
@@ -87,13 +87,13 @@ class HandleInertiaRequests extends Middleware
      * same URL, Passport rotates `authToken` on every authorize hit, and approve then
      * fails with InvalidAuthTokenException against the stale token still on the page.
      *
-     * Never defer on social OAuth popup routes either: after a successful page/channel
-     * select POST the response URL is still the select path, so a deferred reload would
-     * GET that path with a cleared session and dump /accounts into the popup.
+     * Social OAuth popup close pages set `onboardingProgress` to false in
+     * `SocialController::popupCallback()` so a deferred reload does not re-hit the
+     * select route after the connect session was cleared.
      */
     private function onboardingProgress(Request $request, ?User $user): DeferProp|false
     {
-        if ($this->isPassportConsentViewRequest($request) || $this->isSocialOAuthPopupRequest($request)) {
+        if ($this->isPassportConsentViewRequest($request)) {
             return false;
         }
 
@@ -115,13 +115,5 @@ class HandleInertiaRequests extends Middleware
             'passport.authorizations.authorize',
             'passport.device.authorizations.authorize',
         );
-    }
-
-    /**
-     * Social connect/callback/select routes that render inside the OAuth popup.
-     */
-    private function isSocialOAuthPopupRequest(Request $request): bool
-    {
-        return $request->routeIs('app.social.*');
     }
 }

--- a/app/Http/Middleware/App/HandleInertiaRequests.php
+++ b/app/Http/Middleware/App/HandleInertiaRequests.php
@@ -86,10 +86,14 @@ class HandleInertiaRequests extends Middleware
      * Never defer on Passport consent *views*: Inertia deferred props re-request the
      * same URL, Passport rotates `authToken` on every authorize hit, and approve then
      * fails with InvalidAuthTokenException against the stale token still on the page.
+     *
+     * Never defer on social OAuth popup routes either: after a successful page/channel
+     * select POST the response URL is still the select path, so a deferred reload would
+     * GET that path with a cleared session and dump /accounts into the popup.
      */
     private function onboardingProgress(Request $request, ?User $user): DeferProp|false
     {
-        if ($this->isPassportConsentViewRequest($request)) {
+        if ($this->isPassportConsentViewRequest($request) || $this->isSocialOAuthPopupRequest($request)) {
             return false;
         }
 
@@ -111,5 +115,13 @@ class HandleInertiaRequests extends Middleware
             'passport.authorizations.authorize',
             'passport.device.authorizations.authorize',
         );
+    }
+
+    /**
+     * Social connect/callback/select routes that render inside the OAuth popup.
+     */
+    private function isSocialOAuthPopupRequest(Request $request): bool
+    {
+        return $request->routeIs('app.social.*');
     }
 }

--- a/app/Services/Social/Meta/GraphPaginator.php
+++ b/app/Services/Social/Meta/GraphPaginator.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Services\Social\Meta;
 
+use App\Services\Social\TokenRedactor;
 use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Log;
 
@@ -33,7 +34,7 @@ class GraphPaginator
 
             if (isset($seenUrls[$requestKey])) {
                 Log::warning('Meta Graph pagination stopped: repeated paging URL', [
-                    'url' => $nextUrl,
+                    'url' => TokenRedactor::redact($nextUrl),
                 ]);
 
                 break;
@@ -47,9 +48,9 @@ class GraphPaginator
 
             if ($response->failed()) {
                 Log::error('Meta Graph pagination request failed', [
-                    'url' => $nextUrl,
+                    'url' => TokenRedactor::redact($nextUrl),
                     'status' => $response->status(),
-                    'body' => $response->body(),
+                    'body' => TokenRedactor::redact($response->body()),
                 ]);
 
                 break;

--- a/app/Services/Social/Meta/GraphPaginator.php
+++ b/app/Services/Social/Meta/GraphPaginator.php
@@ -30,7 +30,7 @@ class GraphPaginator
         $seen = [];
         $next = (string) Uri::of($url)->withQuery($query);
 
-        while (is_string($next) && $next !== '') {
+        while (filled($next)) {
             if (isset($seen[$next])) {
                 Log::warning('Meta Graph pagination stopped: repeated paging URL', [
                     'url' => TokenRedactor::redact($next),
@@ -63,15 +63,10 @@ class GraphPaginator
             }
 
             $ok++;
-            $payload = $response->json();
-            $chunk = data_get($payload, 'data', []);
+            $items = [...$items, ...$response->collect('data')->values()->all()];
 
-            if (is_array($chunk) && $chunk !== []) {
-                array_push($items, ...array_values($chunk));
-            }
-
-            $candidate = data_get($payload, 'paging.next');
-            $next = is_string($candidate) && $candidate !== '' ? $candidate : null;
+            $candidate = $response->json('paging.next');
+            $next = is_string($candidate) && filled($candidate) ? $candidate : null;
         }
 
         return $items;

--- a/app/Services/Social/Meta/GraphPaginator.php
+++ b/app/Services/Social/Meta/GraphPaginator.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace App\Services\Social\Meta;
 
-use App\Exceptions\Social\IncompleteGraphPaginationException;
 use App\Services\Social\TokenRedactor;
 use Illuminate\Http\Client\ConnectionException;
 use Illuminate\Support\Facades\Http;
@@ -20,7 +19,7 @@ class GraphPaginator
      * @param  array<string, mixed>  $query
      * @return list<array<string, mixed>>
      *
-     * @throws IncompleteGraphPaginationException
+     * @throws IncompletePaginationException
      */
     public static function all(string $url, array $query = []): array
     {
@@ -79,12 +78,12 @@ class GraphPaginator
     /**
      * @return list<array<string, mixed>>
      *
-     * @throws IncompleteGraphPaginationException
+     * @throws IncompletePaginationException
      */
     private static function emptyOrIncomplete(int $successfulRequests, ?Throwable $previous = null): array
     {
         if ($successfulRequests > 0) {
-            throw new IncompleteGraphPaginationException($previous);
+            throw new IncompletePaginationException($previous);
         }
 
         return [];

--- a/app/Services/Social/Meta/GraphPaginator.php
+++ b/app/Services/Social/Meta/GraphPaginator.php
@@ -20,14 +20,27 @@ class GraphPaginator
      * @param  array<string, mixed>  $query
      * @return list<array<string, mixed>>
      */
-    public static function all(string $url, array $query = [], int $maxPages = 50): array
+    public static function all(string $url, array $query = []): array
     {
         $items = [];
         $nextUrl = $url;
         $params = $query;
-        $pagesFetched = 0;
+        /** @var array<string, true> */
+        $seenUrls = [];
 
-        while ($nextUrl !== null && $pagesFetched < $maxPages) {
+        while ($nextUrl !== null) {
+            $requestKey = self::requestKey($nextUrl, $params);
+
+            if (isset($seenUrls[$requestKey])) {
+                Log::warning('Meta Graph pagination stopped: repeated paging URL', [
+                    'url' => $nextUrl,
+                ]);
+
+                break;
+            }
+
+            $seenUrls[$requestKey] = true;
+
             $response = Http::timeout(15)
                 ->connectTimeout(5)
                 ->get($nextUrl, $params);
@@ -53,9 +66,22 @@ class GraphPaginator
             $nextUrl = is_string($next) && $next !== '' ? $next : null;
             // Absolute next URLs already include the query string.
             $params = [];
-            $pagesFetched++;
         }
 
         return $items;
+    }
+
+    /**
+     * @param  array<string, mixed>  $params
+     */
+    private static function requestKey(string $url, array $params): string
+    {
+        if ($params === []) {
+            return $url;
+        }
+
+        ksort($params);
+
+        return $url.'?'.http_build_query($params);
     }
 }

--- a/app/Services/Social/Meta/GraphPaginator.php
+++ b/app/Services/Social/Meta/GraphPaginator.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Social\Meta;
+
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Log;
+
+/**
+ * Collects every item from a paginated Meta Graph API edge by following `paging.next`.
+ *
+ * `/me/accounts` (and similar edges) return at most one page of results per request.
+ * With granular Page permissions, the first response can even be empty while authorized
+ * Pages appear only on later pages — callers must paginate or they will miss Pages.
+ */
+class GraphPaginator
+{
+    /**
+     * @param  array<string, mixed>  $query
+     * @return list<array<string, mixed>>
+     */
+    public static function all(string $url, array $query = [], int $maxPages = 50): array
+    {
+        $items = [];
+        $nextUrl = $url;
+        $params = $query;
+        $pagesFetched = 0;
+
+        while ($nextUrl !== null && $pagesFetched < $maxPages) {
+            $response = Http::timeout(15)
+                ->connectTimeout(5)
+                ->get($nextUrl, $params);
+
+            if ($response->failed()) {
+                Log::error('Meta Graph pagination request failed', [
+                    'url' => $nextUrl,
+                    'status' => $response->status(),
+                    'body' => $response->body(),
+                ]);
+
+                break;
+            }
+
+            $payload = $response->json();
+            $chunk = data_get($payload, 'data', []);
+
+            if (is_array($chunk) && $chunk !== []) {
+                array_push($items, ...array_values($chunk));
+            }
+
+            $next = data_get($payload, 'paging.next');
+            $nextUrl = is_string($next) && $next !== '' ? $next : null;
+            // Absolute next URLs already include the query string.
+            $params = [];
+            $pagesFetched++;
+        }
+
+        return $items;
+    }
+}

--- a/app/Services/Social/Meta/GraphPaginator.php
+++ b/app/Services/Social/Meta/GraphPaginator.php
@@ -9,6 +9,7 @@ use App\Services\Social\TokenRedactor;
 use Illuminate\Http\Client\ConnectionException;
 use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Uri;
 use Throwable;
 
 /**
@@ -27,7 +28,7 @@ class GraphPaginator
         $items = [];
         $ok = 0;
         $seen = [];
-        $next = $query === [] ? $url : "{$url}?".http_build_query($query);
+        $next = (string) Uri::of($url)->withQuery($query);
 
         while (is_string($next) && $next !== '') {
             if (isset($seen[$next])) {

--- a/app/Services/Social/Meta/GraphPaginator.php
+++ b/app/Services/Social/Meta/GraphPaginator.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Services\Social\Meta;
 
+use App\Exceptions\Social\IncompleteMetaGraphPaginationException;
 use App\Services\Social\TokenRedactor;
 use Illuminate\Http\Client\ConnectionException;
 use Illuminate\Support\Facades\Http;
@@ -19,7 +20,7 @@ class GraphPaginator
      * @param  array<string, mixed>  $query
      * @return list<array<string, mixed>>
      *
-     * @throws IncompletePaginationException
+     * @throws IncompleteMetaGraphPaginationException
      */
     public static function all(string $url, array $query = []): array
     {
@@ -78,12 +79,12 @@ class GraphPaginator
     /**
      * @return list<array<string, mixed>>
      *
-     * @throws IncompletePaginationException
+     * @throws IncompleteMetaGraphPaginationException
      */
     private static function emptyOrIncomplete(int $successfulRequests, ?Throwable $previous = null): array
     {
         if ($successfulRequests > 0) {
-            throw new IncompletePaginationException($previous);
+            throw new IncompleteMetaGraphPaginationException($previous);
         }
 
         return [];

--- a/app/Services/Social/Meta/GraphPaginator.php
+++ b/app/Services/Social/Meta/GraphPaginator.php
@@ -7,6 +7,7 @@ namespace App\Services\Social\Meta;
 use App\Exceptions\Social\IncompleteMetaGraphPaginationException;
 use App\Services\Social\TokenRedactor;
 use Illuminate\Http\Client\ConnectionException;
+use Illuminate\Http\Client\Response;
 use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Uri;
@@ -25,10 +26,10 @@ class GraphPaginator
      */
     public static function all(string $url, array $query = []): array
     {
-        $items = [];
-        $ok = 0;
+        $items = collect();
+        $fetched = 0;
         $seen = [];
-        $next = (string) Uri::of($url)->withQuery($query);
+        $next = Uri::of($url)->withQuery($query)->value();
 
         while (filled($next)) {
             if (isset($seen[$next])) {
@@ -44,32 +45,20 @@ class GraphPaginator
             try {
                 $response = Http::timeout(15)->connectTimeout(5)->get($next);
             } catch (ConnectionException $e) {
-                Log::error('Meta Graph pagination connection failed', [
-                    'url' => TokenRedactor::redact($next),
-                    'error' => $e->getMessage(),
-                ]);
-
-                return self::emptyOrIncomplete($ok, $e);
+                return self::abort($next, $fetched, $e);
             }
 
             if ($response->failed()) {
-                Log::error('Meta Graph pagination request failed', [
-                    'url' => TokenRedactor::redact($next),
-                    'status' => $response->status(),
-                    'body' => TokenRedactor::redact($response->body()),
-                ]);
-
-                return self::emptyOrIncomplete($ok);
+                return self::abort($next, $fetched, response: $response);
             }
 
-            $ok++;
-            $items = [...$items, ...$response->collect('data')->values()->all()];
-
+            $fetched++;
+            $items = $items->concat($response->collect('data'));
             $candidate = $response->json('paging.next');
-            $next = is_string($candidate) && filled($candidate) ? $candidate : null;
+            $next = when(is_string($candidate) && filled($candidate), $candidate);
         }
 
-        return $items;
+        return $items->values()->all();
     }
 
     /**
@@ -77,11 +66,16 @@ class GraphPaginator
      *
      * @throws IncompleteMetaGraphPaginationException
      */
-    private static function emptyOrIncomplete(int $successfulRequests, ?Throwable $previous = null): array
+    private static function abort(string $url, int $fetched, ?Throwable $e = null, ?Response $response = null): array
     {
-        if ($successfulRequests > 0) {
-            throw new IncompleteMetaGraphPaginationException($previous);
-        }
+        Log::error($e ? 'Meta Graph pagination connection failed' : 'Meta Graph pagination request failed', array_filter([
+            'url' => TokenRedactor::redact($url),
+            'error' => $e?->getMessage(),
+            'status' => $response?->status(),
+            'body' => $response ? TokenRedactor::redact($response->body()) : null,
+        ]));
+
+        throw_if($fetched > 0, IncompleteMetaGraphPaginationException::class, $e);
 
         return [];
     }

--- a/app/Services/Social/Meta/GraphPaginator.php
+++ b/app/Services/Social/Meta/GraphPaginator.php
@@ -15,9 +15,19 @@ use Throwable;
 
 /**
  * Collects every item from a paginated Meta Graph API edge by following `paging.next`.
+ *
+ * Stops only when pagination is exhausted. Request failures and pathological cases
+ * (repeated next URL, off-host next URL, extreme page count) throw so callers never
+ * confuse an error with an empty Page list or auto-connect on a truncated list.
  */
 class GraphPaginator
 {
+    /**
+     * Hard ceiling on Graph API pages per edge. Far above any real Page list;
+     * exists only to bound a runaway OAuth callback.
+     */
+    public const MAX_PAGES = 100;
+
     /**
      * @param  array<string, mixed>  $query
      * @return list<array<string, mixed>>
@@ -29,15 +39,16 @@ class GraphPaginator
         $items = collect();
         $fetched = 0;
         $seen = [];
+        $allowedHost = Uri::of($url)->host();
         $next = Uri::of($url)->withQuery($query)->value();
 
         while (filled($next)) {
-            if (isset($seen[$next])) {
-                Log::warning('Meta Graph pagination stopped: repeated paging URL', [
-                    'url' => TokenRedactor::redact($next),
-                ]);
+            if ($fetched >= self::MAX_PAGES) {
+                self::abort($next, $fetched, reason: 'Meta Graph pagination stopped: page limit reached');
+            }
 
-                break;
+            if (isset($seen[$next])) {
+                self::abort($next, $fetched, reason: 'Meta Graph pagination stopped: repeated paging URL');
             }
 
             $seen[$next] = true;
@@ -45,38 +56,51 @@ class GraphPaginator
             try {
                 $response = Http::timeout(15)->connectTimeout(5)->get($next);
             } catch (ConnectionException $e) {
-                return self::abort($next, $fetched, $e);
+                self::abort($next, $fetched, $e);
             }
 
             if ($response->failed()) {
-                return self::abort($next, $fetched, response: $response);
+                self::abort($next, $fetched, response: $response);
             }
 
             $fetched++;
             $items = $items->concat($response->collect('data'));
             $candidate = $response->json('paging.next');
-            $next = when(is_string($candidate) && filled($candidate), $candidate);
+
+            if (! is_string($candidate) || blank($candidate)) {
+                $next = null;
+
+                continue;
+            }
+
+            if (Uri::of($candidate)->host() !== $allowedHost) {
+                self::abort($candidate, $fetched, reason: 'Meta Graph pagination stopped: unexpected paging host');
+            }
+
+            $next = $candidate;
         }
 
         return $items->values()->all();
     }
 
     /**
-     * @return list<array<string, mixed>>
-     *
      * @throws IncompleteMetaGraphPaginationException
      */
-    private static function abort(string $url, int $fetched, ?Throwable $e = null, ?Response $response = null): array
-    {
-        Log::error($e ? 'Meta Graph pagination connection failed' : 'Meta Graph pagination request failed', array_filter([
+    private static function abort(
+        string $url,
+        int $fetched,
+        ?Throwable $e = null,
+        ?Response $response = null,
+        ?string $reason = null,
+    ): never {
+        Log::error($reason ?? ($e ? 'Meta Graph pagination connection failed' : 'Meta Graph pagination request failed'), array_filter([
             'url' => TokenRedactor::redact($url),
             'error' => $e?->getMessage(),
             'status' => $response?->status(),
             'body' => $response ? TokenRedactor::redact($response->body()) : null,
+            'fetched' => $fetched > 0 ? $fetched : null,
         ]));
 
-        throw_if($fetched > 0, IncompleteMetaGraphPaginationException::class, $e);
-
-        return [];
+        throw new IncompleteMetaGraphPaginationException($e);
     }
 }

--- a/app/Services/Social/Meta/GraphPaginator.php
+++ b/app/Services/Social/Meta/GraphPaginator.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace App\Services\Social\Meta;
 
+use App\Exceptions\Social\IncompleteGraphPaginationException;
 use App\Services\Social\TokenRedactor;
+use Illuminate\Http\Client\ConnectionException;
 use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Log;
 
@@ -20,12 +22,15 @@ class GraphPaginator
     /**
      * @param  array<string, mixed>  $query
      * @return list<array<string, mixed>>
+     *
+     * @throws IncompleteGraphPaginationException When a later page fails after earlier pages succeeded.
      */
     public static function all(string $url, array $query = []): array
     {
         $items = [];
         $nextUrl = $url;
         $params = $query;
+        $successfulRequests = 0;
         /** @var array<string, true> */
         $seenUrls = [];
 
@@ -42,9 +47,22 @@ class GraphPaginator
 
             $seenUrls[$requestKey] = true;
 
-            $response = Http::timeout(15)
-                ->connectTimeout(5)
-                ->get($nextUrl, $params);
+            try {
+                $response = Http::timeout(15)
+                    ->connectTimeout(5)
+                    ->get($nextUrl, $params);
+            } catch (ConnectionException $e) {
+                Log::error('Meta Graph pagination connection failed', [
+                    'url' => TokenRedactor::redact($nextUrl),
+                    'error' => $e->getMessage(),
+                ]);
+
+                if ($successfulRequests > 0) {
+                    throw new IncompleteGraphPaginationException(previous: $e);
+                }
+
+                return [];
+            }
 
             if ($response->failed()) {
                 Log::error('Meta Graph pagination request failed', [
@@ -53,8 +71,14 @@ class GraphPaginator
                     'body' => TokenRedactor::redact($response->body()),
                 ]);
 
-                break;
+                if ($successfulRequests > 0) {
+                    throw new IncompleteGraphPaginationException;
+                }
+
+                return [];
             }
+
+            $successfulRequests++;
 
             $payload = $response->json();
             $chunk = data_get($payload, 'data', []);

--- a/app/Services/Social/Meta/GraphPaginator.php
+++ b/app/Services/Social/Meta/GraphPaginator.php
@@ -9,13 +9,10 @@ use App\Services\Social\TokenRedactor;
 use Illuminate\Http\Client\ConnectionException;
 use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Log;
+use Throwable;
 
 /**
  * Collects every item from a paginated Meta Graph API edge by following `paging.next`.
- *
- * `/me/accounts` (and similar edges) return at most one page of results per request.
- * With granular Page permissions, the first response can even be empty while authorized
- * Pages appear only on later pages — callers must paginate or they will miss Pages.
  */
 class GraphPaginator
 {
@@ -23,63 +20,48 @@ class GraphPaginator
      * @param  array<string, mixed>  $query
      * @return list<array<string, mixed>>
      *
-     * @throws IncompleteGraphPaginationException When a later page fails after earlier pages succeeded.
+     * @throws IncompleteGraphPaginationException
      */
     public static function all(string $url, array $query = []): array
     {
         $items = [];
-        $nextUrl = $url;
-        $params = $query;
-        $successfulRequests = 0;
-        /** @var array<string, true> */
-        $seenUrls = [];
+        $ok = 0;
+        $seen = [];
+        $next = $query === [] ? $url : "{$url}?".http_build_query($query);
 
-        while ($nextUrl !== null) {
-            $requestKey = self::requestKey($nextUrl, $params);
-
-            if (isset($seenUrls[$requestKey])) {
+        while (is_string($next) && $next !== '') {
+            if (isset($seen[$next])) {
                 Log::warning('Meta Graph pagination stopped: repeated paging URL', [
-                    'url' => TokenRedactor::redact($nextUrl),
+                    'url' => TokenRedactor::redact($next),
                 ]);
 
                 break;
             }
 
-            $seenUrls[$requestKey] = true;
+            $seen[$next] = true;
 
             try {
-                $response = Http::timeout(15)
-                    ->connectTimeout(5)
-                    ->get($nextUrl, $params);
+                $response = Http::timeout(15)->connectTimeout(5)->get($next);
             } catch (ConnectionException $e) {
                 Log::error('Meta Graph pagination connection failed', [
-                    'url' => TokenRedactor::redact($nextUrl),
+                    'url' => TokenRedactor::redact($next),
                     'error' => $e->getMessage(),
                 ]);
 
-                if ($successfulRequests > 0) {
-                    throw new IncompleteGraphPaginationException(previous: $e);
-                }
-
-                return [];
+                return self::emptyOrIncomplete($ok, $e);
             }
 
             if ($response->failed()) {
                 Log::error('Meta Graph pagination request failed', [
-                    'url' => TokenRedactor::redact($nextUrl),
+                    'url' => TokenRedactor::redact($next),
                     'status' => $response->status(),
                     'body' => TokenRedactor::redact($response->body()),
                 ]);
 
-                if ($successfulRequests > 0) {
-                    throw new IncompleteGraphPaginationException;
-                }
-
-                return [];
+                return self::emptyOrIncomplete($ok);
             }
 
-            $successfulRequests++;
-
+            $ok++;
             $payload = $response->json();
             $chunk = data_get($payload, 'data', []);
 
@@ -87,26 +69,24 @@ class GraphPaginator
                 array_push($items, ...array_values($chunk));
             }
 
-            $next = data_get($payload, 'paging.next');
-            $nextUrl = is_string($next) && $next !== '' ? $next : null;
-            // Absolute next URLs already include the query string.
-            $params = [];
+            $candidate = data_get($payload, 'paging.next');
+            $next = is_string($candidate) && $candidate !== '' ? $candidate : null;
         }
 
         return $items;
     }
 
     /**
-     * @param  array<string, mixed>  $params
+     * @return list<array<string, mixed>>
+     *
+     * @throws IncompleteGraphPaginationException
      */
-    private static function requestKey(string $url, array $params): string
+    private static function emptyOrIncomplete(int $successfulRequests, ?Throwable $previous = null): array
     {
-        if ($params === []) {
-            return $url;
+        if ($successfulRequests > 0) {
+            throw new IncompleteGraphPaginationException($previous);
         }
 
-        ksort($params);
-
-        return $url.'?'.http_build_query($params);
+        return [];
     }
 }

--- a/app/Services/Social/Meta/IncompletePaginationException.php
+++ b/app/Services/Social/Meta/IncompletePaginationException.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace App\Exceptions\Social;
+namespace App\Services\Social\Meta;
 
 use RuntimeException;
 use Throwable;
@@ -11,7 +11,7 @@ use Throwable;
  * Thrown when a Meta Graph edge was only partially fetched. Callers must not
  * treat a truncated list as complete (e.g. auto-connect when count === 1).
  */
-class IncompleteGraphPaginationException extends RuntimeException
+class IncompletePaginationException extends RuntimeException
 {
     public function __construct(?Throwable $previous = null)
     {

--- a/lang/ar/accounts.php
+++ b/lang/ar/accounts.php
@@ -21,7 +21,7 @@ return [
         'tiktok' => 'اربط حسابك على TikTok',
         'youtube' => 'اربط قناة على YouTube',
         'facebook' => 'اربط صفحة على Facebook',
-        'instagram' => 'Connect via Instagram Login or Facebook Pages',
+        'instagram' => 'اربط عبر Instagram Login أو صفحات Facebook',
         'instagram-facebook' => 'اربط Instagram عبر صفحة Facebook',
         'threads' => 'اربط حسابك على Threads',
         'pinterest' => 'اربط حسابك على Pinterest',
@@ -97,12 +97,12 @@ return [
     ],
 
     'instagram_connect' => [
-        'title' => 'Connect Instagram',
-        'description' => 'Choose how you want to connect your Instagram account',
+        'title' => 'ربط Instagram',
+        'description' => 'اختر طريقة ربط حساب Instagram',
         'standalone_title' => 'Instagram Login',
-        'standalone_description' => 'Sign in with your Instagram professional account',
-        'facebook_title' => 'Facebook Pages',
-        'facebook_description' => 'Connect an Instagram account linked to a Facebook Page',
+        'standalone_description' => 'سجّل الدخول بحساب Instagram الاحترافي',
+        'facebook_title' => 'صفحات Facebook',
+        'facebook_description' => 'اربط حساب Instagram مرتبطًا بصفحة Facebook',
     ],
 
     'linkedin' => [

--- a/lang/ar/accounts.php
+++ b/lang/ar/accounts.php
@@ -21,7 +21,7 @@ return [
         'tiktok' => 'اربط حسابك على TikTok',
         'youtube' => 'اربط قناة على YouTube',
         'facebook' => 'اربط صفحة على Facebook',
-        'instagram' => 'اربط حساب Instagram احترافيًا',
+        'instagram' => 'Connect via Instagram Login or Facebook Pages',
         'instagram-facebook' => 'اربط Instagram عبر صفحة Facebook',
         'threads' => 'اربط حسابك على Threads',
         'pinterest' => 'اربط حسابك على Pinterest',
@@ -94,6 +94,15 @@ return [
         'no_pages_description' => 'لم يتم العثور على صفحات Facebook مرتبطة بحسابات Instagram للأعمال.',
         'view' => 'عرض',
         'choose' => 'اختيار',
+    ],
+
+    'instagram_connect' => [
+        'title' => 'Connect Instagram',
+        'description' => 'Choose how you want to connect your Instagram account',
+        'standalone_title' => 'Instagram Login',
+        'standalone_description' => 'Sign in with your Instagram professional account',
+        'facebook_title' => 'Facebook Pages',
+        'facebook_description' => 'Connect an Instagram account linked to a Facebook Page',
     ],
 
     'linkedin' => [

--- a/lang/de/accounts.php
+++ b/lang/de/accounts.php
@@ -23,7 +23,7 @@ return [
         'tiktok' => 'Verbinde dein TikTok-Konto',
         'youtube' => 'Verbinde einen YouTube-Kanal',
         'facebook' => 'Verbinde eine Facebook-Seite',
-        'instagram' => 'Verbinde ein professionelles Instagram-Konto',
+        'instagram' => 'Connect via Instagram Login or Facebook Pages',
         'instagram-facebook' => 'Verbinde Instagram über eine Facebook-Seite',
         'threads' => 'Verbinde dein Threads-Konto',
         'pinterest' => 'Verbinde dein Pinterest-Konto',
@@ -96,6 +96,15 @@ return [
         'no_pages_description' => 'Es wurden keine Facebook-Seiten mit verknüpften Instagram-Business-Konten gefunden.',
         'view' => 'Ansehen',
         'choose' => 'Auswählen',
+    ],
+
+    'instagram_connect' => [
+        'title' => 'Connect Instagram',
+        'description' => 'Choose how you want to connect your Instagram account',
+        'standalone_title' => 'Instagram Login',
+        'standalone_description' => 'Sign in with your Instagram professional account',
+        'facebook_title' => 'Facebook Pages',
+        'facebook_description' => 'Connect an Instagram account linked to a Facebook Page',
     ],
 
     'linkedin' => [

--- a/lang/de/accounts.php
+++ b/lang/de/accounts.php
@@ -23,7 +23,7 @@ return [
         'tiktok' => 'Verbinde dein TikTok-Konto',
         'youtube' => 'Verbinde einen YouTube-Kanal',
         'facebook' => 'Verbinde eine Facebook-Seite',
-        'instagram' => 'Connect via Instagram Login or Facebook Pages',
+        'instagram' => 'Verbinde über Instagram Login oder Facebook-Seiten',
         'instagram-facebook' => 'Verbinde Instagram über eine Facebook-Seite',
         'threads' => 'Verbinde dein Threads-Konto',
         'pinterest' => 'Verbinde dein Pinterest-Konto',
@@ -99,12 +99,12 @@ return [
     ],
 
     'instagram_connect' => [
-        'title' => 'Connect Instagram',
-        'description' => 'Choose how you want to connect your Instagram account',
+        'title' => 'Instagram verbinden',
+        'description' => 'Wähle, wie du dein Instagram-Konto verbinden möchtest',
         'standalone_title' => 'Instagram Login',
-        'standalone_description' => 'Sign in with your Instagram professional account',
-        'facebook_title' => 'Facebook Pages',
-        'facebook_description' => 'Connect an Instagram account linked to a Facebook Page',
+        'standalone_description' => 'Melde dich mit deinem professionellen Instagram-Konto an',
+        'facebook_title' => 'Facebook-Seiten',
+        'facebook_description' => 'Verbinde ein Instagram-Konto, das mit einer Facebook-Seite verknüpft ist',
     ],
 
     'linkedin' => [

--- a/lang/el/accounts.php
+++ b/lang/el/accounts.php
@@ -21,7 +21,7 @@ return [
         'tiktok' => 'Συνδέστε τον λογαριασμό σας TikTok',
         'youtube' => 'Συνδέστε ένα κανάλι YouTube',
         'facebook' => 'Συνδέστε μια σελίδα Facebook',
-        'instagram' => 'Συνδέστε έναν επαγγελματικό λογαριασμό Instagram',
+        'instagram' => 'Connect via Instagram Login or Facebook Pages',
         'instagram-facebook' => 'Συνδέστε το Instagram μέσω σελίδας Facebook',
         'threads' => 'Συνδέστε τον λογαριασμό σας Threads',
         'pinterest' => 'Συνδέστε τον λογαριασμό σας Pinterest',
@@ -94,6 +94,15 @@ return [
         'no_pages_description' => 'Δεν βρέθηκαν σελίδες Facebook με συνδεδεμένους επαγγελματικούς λογαριασμούς Instagram.',
         'view' => 'Προβολή',
         'choose' => 'Επιλογή',
+    ],
+
+    'instagram_connect' => [
+        'title' => 'Connect Instagram',
+        'description' => 'Choose how you want to connect your Instagram account',
+        'standalone_title' => 'Instagram Login',
+        'standalone_description' => 'Sign in with your Instagram professional account',
+        'facebook_title' => 'Facebook Pages',
+        'facebook_description' => 'Connect an Instagram account linked to a Facebook Page',
     ],
 
     'linkedin' => [

--- a/lang/el/accounts.php
+++ b/lang/el/accounts.php
@@ -21,7 +21,7 @@ return [
         'tiktok' => 'Συνδέστε τον λογαριασμό σας TikTok',
         'youtube' => 'Συνδέστε ένα κανάλι YouTube',
         'facebook' => 'Συνδέστε μια σελίδα Facebook',
-        'instagram' => 'Connect via Instagram Login or Facebook Pages',
+        'instagram' => 'Συνδέστε μέσω Instagram Login ή σελίδων Facebook',
         'instagram-facebook' => 'Συνδέστε το Instagram μέσω σελίδας Facebook',
         'threads' => 'Συνδέστε τον λογαριασμό σας Threads',
         'pinterest' => 'Συνδέστε τον λογαριασμό σας Pinterest',
@@ -97,12 +97,12 @@ return [
     ],
 
     'instagram_connect' => [
-        'title' => 'Connect Instagram',
-        'description' => 'Choose how you want to connect your Instagram account',
+        'title' => 'Σύνδεση Instagram',
+        'description' => 'Επιλέξτε πώς θέλετε να συνδέσετε τον λογαριασμό Instagram',
         'standalone_title' => 'Instagram Login',
-        'standalone_description' => 'Sign in with your Instagram professional account',
-        'facebook_title' => 'Facebook Pages',
-        'facebook_description' => 'Connect an Instagram account linked to a Facebook Page',
+        'standalone_description' => 'Συνδεθείτε με τον επαγγελματικό λογαριασμό Instagram',
+        'facebook_title' => 'Σελίδες Facebook',
+        'facebook_description' => 'Συνδέστε έναν λογαριασμό Instagram συνδεδεμένο με σελίδα Facebook',
     ],
 
     'linkedin' => [

--- a/lang/en/accounts.php
+++ b/lang/en/accounts.php
@@ -21,7 +21,7 @@ return [
         'tiktok' => 'Connect your TikTok account',
         'youtube' => 'Connect a YouTube channel',
         'facebook' => 'Connect a Facebook page',
-        'instagram' => 'Connect an Instagram professional account',
+        'instagram' => 'Connect via Instagram Login or Facebook Pages',
         'instagram-facebook' => 'Connect Instagram via Facebook page',
         'threads' => 'Connect your Threads account',
         'pinterest' => 'Connect your Pinterest account',
@@ -94,6 +94,15 @@ return [
         'no_pages_description' => 'No Facebook Pages with linked Instagram Business accounts were found.',
         'view' => 'View',
         'choose' => 'Choose',
+    ],
+
+    'instagram_connect' => [
+        'title' => 'Connect Instagram',
+        'description' => 'Choose how you want to connect your Instagram account',
+        'standalone_title' => 'Instagram Login',
+        'standalone_description' => 'Sign in with your Instagram professional account',
+        'facebook_title' => 'Facebook Pages',
+        'facebook_description' => 'Connect an Instagram account linked to a Facebook Page',
     ],
 
     'linkedin' => [

--- a/lang/es/accounts.php
+++ b/lang/es/accounts.php
@@ -21,7 +21,7 @@ return [
         'tiktok' => 'Conecta tu cuenta de TikTok',
         'youtube' => 'Conecta un canal de YouTube',
         'facebook' => 'Conecta una página de Facebook',
-        'instagram' => 'Connect via Instagram Login or Facebook Pages',
+        'instagram' => 'Conecta vía Instagram Login o páginas de Facebook',
         'instagram-facebook' => 'Conecta Instagram vía página de Facebook',
         'threads' => 'Conecta tu cuenta de Threads',
         'pinterest' => 'Conecta tu cuenta de Pinterest',
@@ -97,12 +97,12 @@ return [
     ],
 
     'instagram_connect' => [
-        'title' => 'Connect Instagram',
-        'description' => 'Choose how you want to connect your Instagram account',
+        'title' => 'Conectar Instagram',
+        'description' => 'Elige cómo quieres conectar tu cuenta de Instagram',
         'standalone_title' => 'Instagram Login',
-        'standalone_description' => 'Sign in with your Instagram professional account',
-        'facebook_title' => 'Facebook Pages',
-        'facebook_description' => 'Connect an Instagram account linked to a Facebook Page',
+        'standalone_description' => 'Inicia sesión con tu cuenta profesional de Instagram',
+        'facebook_title' => 'Páginas de Facebook',
+        'facebook_description' => 'Conecta una cuenta de Instagram vinculada a una página de Facebook',
     ],
 
     'linkedin' => [

--- a/lang/es/accounts.php
+++ b/lang/es/accounts.php
@@ -21,7 +21,7 @@ return [
         'tiktok' => 'Conecta tu cuenta de TikTok',
         'youtube' => 'Conecta un canal de YouTube',
         'facebook' => 'Conecta una página de Facebook',
-        'instagram' => 'Conecta una cuenta profesional de Instagram',
+        'instagram' => 'Connect via Instagram Login or Facebook Pages',
         'instagram-facebook' => 'Conecta Instagram vía página de Facebook',
         'threads' => 'Conecta tu cuenta de Threads',
         'pinterest' => 'Conecta tu cuenta de Pinterest',
@@ -94,6 +94,15 @@ return [
         'no_pages_description' => 'No se encontraron páginas de Facebook con cuentas Instagram Business vinculadas.',
         'view' => 'Ver',
         'choose' => 'Elegir',
+    ],
+
+    'instagram_connect' => [
+        'title' => 'Connect Instagram',
+        'description' => 'Choose how you want to connect your Instagram account',
+        'standalone_title' => 'Instagram Login',
+        'standalone_description' => 'Sign in with your Instagram professional account',
+        'facebook_title' => 'Facebook Pages',
+        'facebook_description' => 'Connect an Instagram account linked to a Facebook Page',
     ],
 
     'linkedin' => [

--- a/lang/fr/accounts.php
+++ b/lang/fr/accounts.php
@@ -21,7 +21,7 @@ return [
         'tiktok' => 'Connectez votre compte TikTok',
         'youtube' => 'Connectez une chaîne YouTube',
         'facebook' => 'Connectez une page Facebook',
-        'instagram' => 'Connectez un compte professionnel Instagram',
+        'instagram' => 'Connect via Instagram Login or Facebook Pages',
         'instagram-facebook' => 'Connectez Instagram via une page Facebook',
         'threads' => 'Connectez votre compte Threads',
         'pinterest' => 'Connectez votre compte Pinterest',
@@ -94,6 +94,15 @@ return [
         'no_pages_description' => 'Aucune page Facebook associée à un compte Instagram Business n\'a été trouvée.',
         'view' => 'Voir',
         'choose' => 'Choisir',
+    ],
+
+    'instagram_connect' => [
+        'title' => 'Connect Instagram',
+        'description' => 'Choose how you want to connect your Instagram account',
+        'standalone_title' => 'Instagram Login',
+        'standalone_description' => 'Sign in with your Instagram professional account',
+        'facebook_title' => 'Facebook Pages',
+        'facebook_description' => 'Connect an Instagram account linked to a Facebook Page',
     ],
 
     'linkedin' => [

--- a/lang/fr/accounts.php
+++ b/lang/fr/accounts.php
@@ -21,7 +21,7 @@ return [
         'tiktok' => 'Connectez votre compte TikTok',
         'youtube' => 'Connectez une chaîne YouTube',
         'facebook' => 'Connectez une page Facebook',
-        'instagram' => 'Connect via Instagram Login or Facebook Pages',
+        'instagram' => 'Connectez via Instagram Login ou des pages Facebook',
         'instagram-facebook' => 'Connectez Instagram via une page Facebook',
         'threads' => 'Connectez votre compte Threads',
         'pinterest' => 'Connectez votre compte Pinterest',
@@ -97,12 +97,12 @@ return [
     ],
 
     'instagram_connect' => [
-        'title' => 'Connect Instagram',
-        'description' => 'Choose how you want to connect your Instagram account',
+        'title' => 'Connecter Instagram',
+        'description' => 'Choisissez comment connecter votre compte Instagram',
         'standalone_title' => 'Instagram Login',
-        'standalone_description' => 'Sign in with your Instagram professional account',
-        'facebook_title' => 'Facebook Pages',
-        'facebook_description' => 'Connect an Instagram account linked to a Facebook Page',
+        'standalone_description' => 'Connectez-vous avec votre compte Instagram professionnel',
+        'facebook_title' => 'Pages Facebook',
+        'facebook_description' => 'Connectez un compte Instagram lié à une page Facebook',
     ],
 
     'linkedin' => [

--- a/lang/it/accounts.php
+++ b/lang/it/accounts.php
@@ -21,7 +21,7 @@ return [
         'tiktok' => 'Collega il tuo account TikTok',
         'youtube' => 'Collega un canale YouTube',
         'facebook' => 'Collega una pagina Facebook',
-        'instagram' => 'Collega un account professionale Instagram',
+        'instagram' => 'Connect via Instagram Login or Facebook Pages',
         'instagram-facebook' => 'Collega Instagram tramite una pagina Facebook',
         'threads' => 'Collega il tuo account Threads',
         'pinterest' => 'Collega il tuo account Pinterest',
@@ -94,6 +94,15 @@ return [
         'no_pages_description' => 'Nessuna pagina Facebook con account Instagram Business collegati è stata trovata.',
         'view' => 'Visualizza',
         'choose' => 'Scegli',
+    ],
+
+    'instagram_connect' => [
+        'title' => 'Connect Instagram',
+        'description' => 'Choose how you want to connect your Instagram account',
+        'standalone_title' => 'Instagram Login',
+        'standalone_description' => 'Sign in with your Instagram professional account',
+        'facebook_title' => 'Facebook Pages',
+        'facebook_description' => 'Connect an Instagram account linked to a Facebook Page',
     ],
 
     'linkedin' => [

--- a/lang/it/accounts.php
+++ b/lang/it/accounts.php
@@ -21,7 +21,7 @@ return [
         'tiktok' => 'Collega il tuo account TikTok',
         'youtube' => 'Collega un canale YouTube',
         'facebook' => 'Collega una pagina Facebook',
-        'instagram' => 'Connect via Instagram Login or Facebook Pages',
+        'instagram' => 'Collega tramite Instagram Login o pagine Facebook',
         'instagram-facebook' => 'Collega Instagram tramite una pagina Facebook',
         'threads' => 'Collega il tuo account Threads',
         'pinterest' => 'Collega il tuo account Pinterest',
@@ -97,12 +97,12 @@ return [
     ],
 
     'instagram_connect' => [
-        'title' => 'Connect Instagram',
-        'description' => 'Choose how you want to connect your Instagram account',
+        'title' => 'Collega Instagram',
+        'description' => 'Scegli come collegare il tuo account Instagram',
         'standalone_title' => 'Instagram Login',
-        'standalone_description' => 'Sign in with your Instagram professional account',
-        'facebook_title' => 'Facebook Pages',
-        'facebook_description' => 'Connect an Instagram account linked to a Facebook Page',
+        'standalone_description' => 'Accedi con il tuo account Instagram professionale',
+        'facebook_title' => 'Pagine Facebook',
+        'facebook_description' => 'Collega un account Instagram collegato a una pagina Facebook',
     ],
 
     'linkedin' => [

--- a/lang/ja/accounts.php
+++ b/lang/ja/accounts.php
@@ -21,7 +21,7 @@ return [
         'tiktok' => 'TikTok アカウントを接続',
         'youtube' => 'YouTube チャンネルを接続',
         'facebook' => 'Facebook ページを接続',
-        'instagram' => 'Instagram プロアカウントを接続',
+        'instagram' => 'Connect via Instagram Login or Facebook Pages',
         'instagram-facebook' => 'Facebook ページ経由で Instagram を接続',
         'threads' => 'Threads アカウントを接続',
         'pinterest' => 'Pinterest アカウントを接続',
@@ -94,6 +94,15 @@ return [
         'no_pages_description' => 'Instagram ビジネスアカウントが連携された Facebook ページが見つかりませんでした。',
         'view' => '表示',
         'choose' => '選択',
+    ],
+
+    'instagram_connect' => [
+        'title' => 'Connect Instagram',
+        'description' => 'Choose how you want to connect your Instagram account',
+        'standalone_title' => 'Instagram Login',
+        'standalone_description' => 'Sign in with your Instagram professional account',
+        'facebook_title' => 'Facebook Pages',
+        'facebook_description' => 'Connect an Instagram account linked to a Facebook Page',
     ],
 
     'linkedin' => [

--- a/lang/ja/accounts.php
+++ b/lang/ja/accounts.php
@@ -21,7 +21,7 @@ return [
         'tiktok' => 'TikTok アカウントを接続',
         'youtube' => 'YouTube チャンネルを接続',
         'facebook' => 'Facebook ページを接続',
-        'instagram' => 'Connect via Instagram Login or Facebook Pages',
+        'instagram' => 'Instagram Login または Facebook ページで接続',
         'instagram-facebook' => 'Facebook ページ経由で Instagram を接続',
         'threads' => 'Threads アカウントを接続',
         'pinterest' => 'Pinterest アカウントを接続',
@@ -97,12 +97,12 @@ return [
     ],
 
     'instagram_connect' => [
-        'title' => 'Connect Instagram',
-        'description' => 'Choose how you want to connect your Instagram account',
+        'title' => 'Instagram を接続',
+        'description' => 'Instagram アカウントの接続方法を選択してください',
         'standalone_title' => 'Instagram Login',
-        'standalone_description' => 'Sign in with your Instagram professional account',
-        'facebook_title' => 'Facebook Pages',
-        'facebook_description' => 'Connect an Instagram account linked to a Facebook Page',
+        'standalone_description' => 'Instagram のプロフェッショナルアカウントでサインイン',
+        'facebook_title' => 'Facebook ページ',
+        'facebook_description' => 'Facebook ページに連携された Instagram アカウントを接続',
     ],
 
     'linkedin' => [

--- a/lang/ko/accounts.php
+++ b/lang/ko/accounts.php
@@ -21,7 +21,7 @@ return [
         'tiktok' => 'TikTok 계정을 연결하세요',
         'youtube' => 'YouTube 채널을 연결하세요',
         'facebook' => 'Facebook 페이지를 연결하세요',
-        'instagram' => 'Connect via Instagram Login or Facebook Pages',
+        'instagram' => 'Instagram Login 또는 Facebook 페이지로 연결하세요',
         'instagram-facebook' => 'Facebook 페이지를 통해 Instagram을 연결하세요',
         'threads' => 'Threads 계정을 연결하세요',
         'pinterest' => 'Pinterest 계정을 연결하세요',
@@ -97,12 +97,12 @@ return [
     ],
 
     'instagram_connect' => [
-        'title' => 'Connect Instagram',
-        'description' => 'Choose how you want to connect your Instagram account',
+        'title' => 'Instagram 연결',
+        'description' => 'Instagram 계정을 연결할 방법을 선택하세요',
         'standalone_title' => 'Instagram Login',
-        'standalone_description' => 'Sign in with your Instagram professional account',
-        'facebook_title' => 'Facebook Pages',
-        'facebook_description' => 'Connect an Instagram account linked to a Facebook Page',
+        'standalone_description' => 'Instagram 프로페셔널 계정으로 로그인하세요',
+        'facebook_title' => 'Facebook 페이지',
+        'facebook_description' => 'Facebook 페이지에 연결된 Instagram 계정을 연결하세요',
     ],
 
     'linkedin' => [

--- a/lang/ko/accounts.php
+++ b/lang/ko/accounts.php
@@ -21,7 +21,7 @@ return [
         'tiktok' => 'TikTok 계정을 연결하세요',
         'youtube' => 'YouTube 채널을 연결하세요',
         'facebook' => 'Facebook 페이지를 연결하세요',
-        'instagram' => 'Instagram 프로페셔널 계정을 연결하세요',
+        'instagram' => 'Connect via Instagram Login or Facebook Pages',
         'instagram-facebook' => 'Facebook 페이지를 통해 Instagram을 연결하세요',
         'threads' => 'Threads 계정을 연결하세요',
         'pinterest' => 'Pinterest 계정을 연결하세요',
@@ -94,6 +94,15 @@ return [
         'no_pages_description' => 'Instagram 비즈니스 계정이 연결된 Facebook 페이지를 찾을 수 없습니다.',
         'view' => '보기',
         'choose' => '선택',
+    ],
+
+    'instagram_connect' => [
+        'title' => 'Connect Instagram',
+        'description' => 'Choose how you want to connect your Instagram account',
+        'standalone_title' => 'Instagram Login',
+        'standalone_description' => 'Sign in with your Instagram professional account',
+        'facebook_title' => 'Facebook Pages',
+        'facebook_description' => 'Connect an Instagram account linked to a Facebook Page',
     ],
 
     'linkedin' => [

--- a/lang/nl/accounts.php
+++ b/lang/nl/accounts.php
@@ -21,7 +21,7 @@ return [
         'tiktok' => 'Koppel je TikTok-account',
         'youtube' => 'Koppel een YouTube-kanaal',
         'facebook' => 'Koppel een Facebook-pagina',
-        'instagram' => 'Connect via Instagram Login or Facebook Pages',
+        'instagram' => 'Koppel via Instagram Login of Facebook-pagina\'s',
         'instagram-facebook' => 'Koppel Instagram via een Facebook-pagina',
         'threads' => 'Koppel je Threads-account',
         'pinterest' => 'Koppel je Pinterest-account',
@@ -97,12 +97,12 @@ return [
     ],
 
     'instagram_connect' => [
-        'title' => 'Connect Instagram',
-        'description' => 'Choose how you want to connect your Instagram account',
+        'title' => 'Instagram koppelen',
+        'description' => 'Kies hoe je je Instagram-account wilt koppelen',
         'standalone_title' => 'Instagram Login',
-        'standalone_description' => 'Sign in with your Instagram professional account',
-        'facebook_title' => 'Facebook Pages',
-        'facebook_description' => 'Connect an Instagram account linked to a Facebook Page',
+        'standalone_description' => 'Log in met je professionele Instagram-account',
+        'facebook_title' => 'Facebook-pagina\'s',
+        'facebook_description' => 'Koppel een Instagram-account dat gekoppeld is aan een Facebook-pagina',
     ],
 
     'linkedin' => [

--- a/lang/nl/accounts.php
+++ b/lang/nl/accounts.php
@@ -21,7 +21,7 @@ return [
         'tiktok' => 'Koppel je TikTok-account',
         'youtube' => 'Koppel een YouTube-kanaal',
         'facebook' => 'Koppel een Facebook-pagina',
-        'instagram' => 'Koppel een Instagram-professioneel account',
+        'instagram' => 'Connect via Instagram Login or Facebook Pages',
         'instagram-facebook' => 'Koppel Instagram via een Facebook-pagina',
         'threads' => 'Koppel je Threads-account',
         'pinterest' => 'Koppel je Pinterest-account',
@@ -94,6 +94,15 @@ return [
         'no_pages_description' => 'Er zijn geen Facebook-pagina\'s met gekoppelde Instagram-zakelijke accounts gevonden.',
         'view' => 'Bekijken',
         'choose' => 'Kiezen',
+    ],
+
+    'instagram_connect' => [
+        'title' => 'Connect Instagram',
+        'description' => 'Choose how you want to connect your Instagram account',
+        'standalone_title' => 'Instagram Login',
+        'standalone_description' => 'Sign in with your Instagram professional account',
+        'facebook_title' => 'Facebook Pages',
+        'facebook_description' => 'Connect an Instagram account linked to a Facebook Page',
     ],
 
     'linkedin' => [

--- a/lang/pl/accounts.php
+++ b/lang/pl/accounts.php
@@ -21,7 +21,7 @@ return [
         'tiktok' => 'Połącz swoje konto TikTok',
         'youtube' => 'Połącz kanał YouTube',
         'facebook' => 'Połącz stronę na Facebooku',
-        'instagram' => 'Połącz profesjonalne konto Instagram',
+        'instagram' => 'Connect via Instagram Login or Facebook Pages',
         'instagram-facebook' => 'Połącz Instagram przez stronę na Facebooku',
         'threads' => 'Połącz swoje konto Threads',
         'pinterest' => 'Połącz swoje konto Pinterest',
@@ -94,6 +94,15 @@ return [
         'no_pages_description' => 'Nie znaleziono żadnej strony na Facebooku z powiązanym firmowym kontem Instagram.',
         'view' => 'Zobacz',
         'choose' => 'Wybierz',
+    ],
+
+    'instagram_connect' => [
+        'title' => 'Connect Instagram',
+        'description' => 'Choose how you want to connect your Instagram account',
+        'standalone_title' => 'Instagram Login',
+        'standalone_description' => 'Sign in with your Instagram professional account',
+        'facebook_title' => 'Facebook Pages',
+        'facebook_description' => 'Connect an Instagram account linked to a Facebook Page',
     ],
 
     'linkedin' => [

--- a/lang/pl/accounts.php
+++ b/lang/pl/accounts.php
@@ -21,7 +21,7 @@ return [
         'tiktok' => 'Połącz swoje konto TikTok',
         'youtube' => 'Połącz kanał YouTube',
         'facebook' => 'Połącz stronę na Facebooku',
-        'instagram' => 'Connect via Instagram Login or Facebook Pages',
+        'instagram' => 'Połącz przez Instagram Login lub strony na Facebooku',
         'instagram-facebook' => 'Połącz Instagram przez stronę na Facebooku',
         'threads' => 'Połącz swoje konto Threads',
         'pinterest' => 'Połącz swoje konto Pinterest',
@@ -97,12 +97,12 @@ return [
     ],
 
     'instagram_connect' => [
-        'title' => 'Connect Instagram',
-        'description' => 'Choose how you want to connect your Instagram account',
+        'title' => 'Połącz Instagram',
+        'description' => 'Wybierz sposób połączenia konta Instagram',
         'standalone_title' => 'Instagram Login',
-        'standalone_description' => 'Sign in with your Instagram professional account',
-        'facebook_title' => 'Facebook Pages',
-        'facebook_description' => 'Connect an Instagram account linked to a Facebook Page',
+        'standalone_description' => 'Zaloguj się kontem profesjonalnym Instagram',
+        'facebook_title' => 'Strony na Facebooku',
+        'facebook_description' => 'Połącz konto Instagram powiązane ze stroną na Facebooku',
     ],
 
     'linkedin' => [

--- a/lang/pt-BR/accounts.php
+++ b/lang/pt-BR/accounts.php
@@ -21,7 +21,7 @@ return [
         'tiktok' => 'Conecte sua conta do TikTok',
         'youtube' => 'Conecte um canal do YouTube',
         'facebook' => 'Conecte uma página do Facebook',
-        'instagram' => 'Conecte uma conta profissional do Instagram',
+        'instagram' => 'Conecte via Instagram Login ou Facebook Pages',
         'instagram-facebook' => 'Conecte Instagram via página do Facebook',
         'threads' => 'Conecte sua conta do Threads',
         'pinterest' => 'Conecte sua conta do Pinterest',
@@ -94,6 +94,15 @@ return [
         'no_pages_description' => 'Nenhuma Página do Facebook com conta Instagram Business vinculada foi encontrada.',
         'view' => 'Ver',
         'choose' => 'Escolher',
+    ],
+
+    'instagram_connect' => [
+        'title' => 'Conectar Instagram',
+        'description' => 'Escolha como você quer conectar sua conta do Instagram',
+        'standalone_title' => 'Instagram Login',
+        'standalone_description' => 'Entre com sua conta profissional do Instagram',
+        'facebook_title' => 'Facebook Pages',
+        'facebook_description' => 'Conecte um Instagram vinculado a uma Página do Facebook',
     ],
 
     'linkedin' => [

--- a/lang/ru/accounts.php
+++ b/lang/ru/accounts.php
@@ -21,7 +21,7 @@ return [
         'tiktok' => 'Подключите аккаунт TikTok',
         'youtube' => 'Подключите канал YouTube',
         'facebook' => 'Подключите страницу Facebook',
-        'instagram' => 'Подключите профессиональный аккаунт Instagram',
+        'instagram' => 'Connect via Instagram Login or Facebook Pages',
         'instagram-facebook' => 'Подключите Instagram через страницу Facebook',
         'threads' => 'Подключите аккаунт Threads',
         'pinterest' => 'Подключите аккаунт Pinterest',
@@ -94,6 +94,15 @@ return [
         'no_pages_description' => 'Не найдено страниц Facebook со связанными бизнес-аккаунтами Instagram.',
         'view' => 'Открыть',
         'choose' => 'Выбрать',
+    ],
+
+    'instagram_connect' => [
+        'title' => 'Connect Instagram',
+        'description' => 'Choose how you want to connect your Instagram account',
+        'standalone_title' => 'Instagram Login',
+        'standalone_description' => 'Sign in with your Instagram professional account',
+        'facebook_title' => 'Facebook Pages',
+        'facebook_description' => 'Connect an Instagram account linked to a Facebook Page',
     ],
 
     'linkedin' => [

--- a/lang/ru/accounts.php
+++ b/lang/ru/accounts.php
@@ -21,7 +21,7 @@ return [
         'tiktok' => 'Подключите аккаунт TikTok',
         'youtube' => 'Подключите канал YouTube',
         'facebook' => 'Подключите страницу Facebook',
-        'instagram' => 'Connect via Instagram Login or Facebook Pages',
+        'instagram' => 'Подключите через Instagram Login или страницы Facebook',
         'instagram-facebook' => 'Подключите Instagram через страницу Facebook',
         'threads' => 'Подключите аккаунт Threads',
         'pinterest' => 'Подключите аккаунт Pinterest',
@@ -97,12 +97,12 @@ return [
     ],
 
     'instagram_connect' => [
-        'title' => 'Connect Instagram',
-        'description' => 'Choose how you want to connect your Instagram account',
+        'title' => 'Подключить Instagram',
+        'description' => 'Выберите способ подключения аккаунта Instagram',
         'standalone_title' => 'Instagram Login',
-        'standalone_description' => 'Sign in with your Instagram professional account',
-        'facebook_title' => 'Facebook Pages',
-        'facebook_description' => 'Connect an Instagram account linked to a Facebook Page',
+        'standalone_description' => 'Войдите с профессиональным аккаунтом Instagram',
+        'facebook_title' => 'Страницы Facebook',
+        'facebook_description' => 'Подключите аккаунт Instagram, связанный со страницей Facebook',
     ],
 
     'linkedin' => [

--- a/lang/tr/accounts.php
+++ b/lang/tr/accounts.php
@@ -23,7 +23,7 @@ return [
         'tiktok' => 'TikTok hesabınızı bağlayın',
         'youtube' => 'Bir YouTube kanalı bağlayın',
         'facebook' => 'Bir Facebook sayfası bağlayın',
-        'instagram' => 'Connect via Instagram Login or Facebook Pages',
+        'instagram' => 'Instagram Login veya Facebook Sayfaları ile bağlayın',
         'instagram-facebook' => 'Facebook sayfası üzerinden Instagram bağlayın',
         'threads' => 'Threads hesabınızı bağlayın',
         'pinterest' => 'Pinterest hesabınızı bağlayın',
@@ -99,12 +99,12 @@ return [
     ],
 
     'instagram_connect' => [
-        'title' => 'Connect Instagram',
-        'description' => 'Choose how you want to connect your Instagram account',
+        'title' => 'Instagram bağla',
+        'description' => 'Instagram hesabınızı nasıl bağlamak istediğinizi seçin',
         'standalone_title' => 'Instagram Login',
-        'standalone_description' => 'Sign in with your Instagram professional account',
-        'facebook_title' => 'Facebook Pages',
-        'facebook_description' => 'Connect an Instagram account linked to a Facebook Page',
+        'standalone_description' => 'Profesyonel Instagram hesabınızla oturum açın',
+        'facebook_title' => 'Facebook Sayfaları',
+        'facebook_description' => 'Bir Facebook Sayfasına bağlı Instagram hesabı bağlayın',
     ],
 
     'linkedin' => [

--- a/lang/tr/accounts.php
+++ b/lang/tr/accounts.php
@@ -23,7 +23,7 @@ return [
         'tiktok' => 'TikTok hesabınızı bağlayın',
         'youtube' => 'Bir YouTube kanalı bağlayın',
         'facebook' => 'Bir Facebook sayfası bağlayın',
-        'instagram' => 'Bir Instagram profesyonel hesabı bağlayın',
+        'instagram' => 'Connect via Instagram Login or Facebook Pages',
         'instagram-facebook' => 'Facebook sayfası üzerinden Instagram bağlayın',
         'threads' => 'Threads hesabınızı bağlayın',
         'pinterest' => 'Pinterest hesabınızı bağlayın',
@@ -96,6 +96,15 @@ return [
         'no_pages_description' => 'Bağlı Instagram İşletme hesabı olan Facebook Sayfası bulunamadı.',
         'view' => 'Görüntüle',
         'choose' => 'Seç',
+    ],
+
+    'instagram_connect' => [
+        'title' => 'Connect Instagram',
+        'description' => 'Choose how you want to connect your Instagram account',
+        'standalone_title' => 'Instagram Login',
+        'standalone_description' => 'Sign in with your Instagram professional account',
+        'facebook_title' => 'Facebook Pages',
+        'facebook_description' => 'Connect an Instagram account linked to a Facebook Page',
     ],
 
     'linkedin' => [

--- a/lang/uk/accounts.php
+++ b/lang/uk/accounts.php
@@ -21,7 +21,7 @@ return [
         'tiktok' => 'Підключіть акаунт TikTok',
         'youtube' => 'Підключіть канал YouTube',
         'facebook' => 'Підключіть сторінку Facebook',
-        'instagram' => 'Connect via Instagram Login or Facebook Pages',
+        'instagram' => 'Підключіть через Instagram Login або сторінки Facebook',
         'instagram-facebook' => 'Підключіть Instagram через сторінку Facebook',
         'threads' => 'Підключіть акаунт Threads',
         'pinterest' => 'Підключіть акаунт Pinterest',
@@ -97,12 +97,12 @@ return [
     ],
 
     'instagram_connect' => [
-        'title' => 'Connect Instagram',
-        'description' => 'Choose how you want to connect your Instagram account',
+        'title' => 'Підключити Instagram',
+        'description' => 'Оберіть спосіб підключення акаунта Instagram',
         'standalone_title' => 'Instagram Login',
-        'standalone_description' => 'Sign in with your Instagram professional account',
-        'facebook_title' => 'Facebook Pages',
-        'facebook_description' => 'Connect an Instagram account linked to a Facebook Page',
+        'standalone_description' => 'Увійдіть за допомогою професійного акаунта Instagram',
+        'facebook_title' => 'Сторінки Facebook',
+        'facebook_description' => 'Підключіть акаунт Instagram, повʼязаний зі сторінкою Facebook',
     ],
 
     'linkedin' => [

--- a/lang/uk/accounts.php
+++ b/lang/uk/accounts.php
@@ -21,7 +21,7 @@ return [
         'tiktok' => 'Підключіть акаунт TikTok',
         'youtube' => 'Підключіть канал YouTube',
         'facebook' => 'Підключіть сторінку Facebook',
-        'instagram' => 'Підключіть професійний акаунт Instagram',
+        'instagram' => 'Connect via Instagram Login or Facebook Pages',
         'instagram-facebook' => 'Підключіть Instagram через сторінку Facebook',
         'threads' => 'Підключіть акаунт Threads',
         'pinterest' => 'Підключіть акаунт Pinterest',
@@ -94,6 +94,15 @@ return [
         'no_pages_description' => 'Не знайдено сторінок Facebook із підключеними бізнес-акаунтами Instagram.',
         'view' => 'Переглянути',
         'choose' => 'Вибрати',
+    ],
+
+    'instagram_connect' => [
+        'title' => 'Connect Instagram',
+        'description' => 'Choose how you want to connect your Instagram account',
+        'standalone_title' => 'Instagram Login',
+        'standalone_description' => 'Sign in with your Instagram professional account',
+        'facebook_title' => 'Facebook Pages',
+        'facebook_description' => 'Connect an Instagram account linked to a Facebook Page',
     ],
 
     'linkedin' => [

--- a/lang/zh/accounts.php
+++ b/lang/zh/accounts.php
@@ -21,7 +21,7 @@ return [
         'tiktok' => '连接你的 TikTok 账号',
         'youtube' => '连接一个 YouTube 频道',
         'facebook' => '连接一个 Facebook 主页',
-        'instagram' => '连接一个 Instagram 专业账号',
+        'instagram' => 'Connect via Instagram Login or Facebook Pages',
         'instagram-facebook' => '通过 Facebook 主页连接 Instagram',
         'threads' => '连接你的 Threads 账号',
         'pinterest' => '连接你的 Pinterest 账号',
@@ -94,6 +94,15 @@ return [
         'no_pages_description' => '未找到关联了 Instagram 商业账号的 Facebook 主页。',
         'view' => '查看',
         'choose' => '选择',
+    ],
+
+    'instagram_connect' => [
+        'title' => 'Connect Instagram',
+        'description' => 'Choose how you want to connect your Instagram account',
+        'standalone_title' => 'Instagram Login',
+        'standalone_description' => 'Sign in with your Instagram professional account',
+        'facebook_title' => 'Facebook Pages',
+        'facebook_description' => 'Connect an Instagram account linked to a Facebook Page',
     ],
 
     'linkedin' => [

--- a/lang/zh/accounts.php
+++ b/lang/zh/accounts.php
@@ -21,7 +21,7 @@ return [
         'tiktok' => '连接你的 TikTok 账号',
         'youtube' => '连接一个 YouTube 频道',
         'facebook' => '连接一个 Facebook 主页',
-        'instagram' => 'Connect via Instagram Login or Facebook Pages',
+        'instagram' => '通过 Instagram Login 或 Facebook 主页连接',
         'instagram-facebook' => '通过 Facebook 主页连接 Instagram',
         'threads' => '连接你的 Threads 账号',
         'pinterest' => '连接你的 Pinterest 账号',
@@ -97,12 +97,12 @@ return [
     ],
 
     'instagram_connect' => [
-        'title' => 'Connect Instagram',
-        'description' => 'Choose how you want to connect your Instagram account',
+        'title' => '连接 Instagram',
+        'description' => '选择连接 Instagram 账号的方式',
         'standalone_title' => 'Instagram Login',
-        'standalone_description' => 'Sign in with your Instagram professional account',
-        'facebook_title' => 'Facebook Pages',
-        'facebook_description' => 'Connect an Instagram account linked to a Facebook Page',
+        'standalone_description' => '使用你的 Instagram 专业账号登录',
+        'facebook_title' => 'Facebook 主页',
+        'facebook_description' => '连接关联到 Facebook 主页的 Instagram 账号',
     ],
 
     'linkedin' => [

--- a/resources/js/components/accounts/InstagramConnectDialog.vue
+++ b/resources/js/components/accounts/InstagramConnectDialog.vue
@@ -1,0 +1,106 @@
+<script setup lang="ts">
+import { IconBrandFacebook, IconBrandInstagram } from '@tabler/icons-vue';
+
+import { Button } from '@/components/ui/button';
+import {
+    Dialog,
+    DialogContent,
+    DialogDescription,
+    DialogHeader,
+    DialogTitle,
+} from '@/components/ui/dialog';
+import { Platform } from '@/types/platform';
+
+const open = defineModel<boolean>('open', { required: true });
+
+const props = withDefaults(
+    defineProps<{
+        methods?: string[];
+    }>(),
+    {
+        methods: () => [Platform.Instagram, Platform.InstagramFacebook],
+    },
+);
+
+const emit = defineEmits<{
+    select: [method: string];
+}>();
+
+const choose = (method: string) => {
+    open.value = false;
+    emit('select', method);
+};
+
+const showsStandalone = () => props.methods.includes(Platform.Instagram);
+const showsFacebook = () => props.methods.includes(Platform.InstagramFacebook);
+</script>
+
+<template>
+    <Dialog v-model:open="open">
+        <DialogContent class="sm:max-w-md" dusk="instagram-connect-dialog">
+            <DialogHeader>
+                <div class="flex items-start gap-3">
+                    <img
+                        src="/images/accounts/instagram.png"
+                        alt="Instagram"
+                        class="size-10 rounded-lg"
+                    />
+                    <div class="text-left">
+                        <DialogTitle>{{
+                            $t('accounts.instagram_connect.title')
+                        }}</DialogTitle>
+                        <DialogDescription>{{
+                            $t('accounts.instagram_connect.description')
+                        }}</DialogDescription>
+                    </div>
+                </div>
+            </DialogHeader>
+
+            <div class="grid gap-3 py-2">
+                <Button
+                    v-if="showsStandalone()"
+                    variant="outline"
+                    class="h-auto justify-start gap-3 px-4 py-3 text-left whitespace-normal"
+                    dusk="instagram-connect-standalone"
+                    @click="choose(Platform.Instagram)"
+                >
+                    <span
+                        class="inline-flex size-9 shrink-0 items-center justify-center rounded-lg bg-pink-100 text-pink-600 dark:bg-pink-900 dark:text-pink-300"
+                    >
+                        <IconBrandInstagram class="size-5" />
+                    </span>
+                    <span class="min-w-0 flex-1">
+                        <span class="block text-sm font-semibold text-foreground">{{
+                            $t('accounts.instagram_connect.standalone_title')
+                        }}</span>
+                        <span class="mt-0.5 block text-xs font-normal text-muted-foreground">{{
+                            $t('accounts.instagram_connect.standalone_description')
+                        }}</span>
+                    </span>
+                </Button>
+
+                <Button
+                    v-if="showsFacebook()"
+                    variant="outline"
+                    class="h-auto justify-start gap-3 px-4 py-3 text-left whitespace-normal"
+                    dusk="instagram-connect-facebook"
+                    @click="choose(Platform.InstagramFacebook)"
+                >
+                    <span
+                        class="inline-flex size-9 shrink-0 items-center justify-center rounded-lg bg-sky-100 text-sky-600 dark:bg-sky-900 dark:text-sky-300"
+                    >
+                        <IconBrandFacebook class="size-5" />
+                    </span>
+                    <span class="min-w-0 flex-1">
+                        <span class="block text-sm font-semibold text-foreground">{{
+                            $t('accounts.instagram_connect.facebook_title')
+                        }}</span>
+                        <span class="mt-0.5 block text-xs font-normal text-muted-foreground">{{
+                            $t('accounts.instagram_connect.facebook_description')
+                        }}</span>
+                    </span>
+                </Button>
+            </div>
+        </DialogContent>
+    </Dialog>
+</template>

--- a/resources/js/components/accounts/InstagramConnectDialog.vue
+++ b/resources/js/components/accounts/InstagramConnectDialog.vue
@@ -13,15 +13,6 @@ import { Platform } from '@/types/platform';
 
 const open = defineModel<boolean>('open', { required: true });
 
-const props = withDefaults(
-    defineProps<{
-        methods?: string[];
-    }>(),
-    {
-        methods: () => [Platform.Instagram, Platform.InstagramFacebook],
-    },
-);
-
 const emit = defineEmits<{
     select: [method: string];
 }>();
@@ -30,9 +21,6 @@ const choose = (method: string) => {
     open.value = false;
     emit('select', method);
 };
-
-const showsStandalone = () => props.methods.includes(Platform.Instagram);
-const showsFacebook = () => props.methods.includes(Platform.InstagramFacebook);
 </script>
 
 <template>
@@ -58,7 +46,6 @@ const showsFacebook = () => props.methods.includes(Platform.InstagramFacebook);
 
             <div class="grid gap-3 py-2">
                 <Button
-                    v-if="showsStandalone()"
                     variant="outline"
                     class="h-auto justify-start gap-3 px-4 py-3 text-left whitespace-normal"
                     dusk="instagram-connect-standalone"
@@ -80,7 +67,6 @@ const showsFacebook = () => props.methods.includes(Platform.InstagramFacebook);
                 </Button>
 
                 <Button
-                    v-if="showsFacebook()"
                     variant="outline"
                     class="h-auto justify-start gap-3 px-4 py-3 text-left whitespace-normal"
                     dusk="instagram-connect-facebook"

--- a/resources/js/components/accounts/InstagramConnectDialog.vue
+++ b/resources/js/components/accounts/InstagramConnectDialog.vue
@@ -13,6 +13,15 @@ import { Platform } from '@/types/platform';
 
 const open = defineModel<boolean>('open', { required: true });
 
+const props = withDefaults(
+    defineProps<{
+        methods?: string[];
+    }>(),
+    {
+        methods: () => [Platform.Instagram, Platform.InstagramFacebook],
+    },
+);
+
 const emit = defineEmits<{
     select: [method: string];
 }>();
@@ -21,6 +30,9 @@ const choose = (method: string) => {
     open.value = false;
     emit('select', method);
 };
+
+const showsStandalone = () => props.methods.includes(Platform.Instagram);
+const showsFacebook = () => props.methods.includes(Platform.InstagramFacebook);
 </script>
 
 <template>
@@ -46,6 +58,7 @@ const choose = (method: string) => {
 
             <div class="grid gap-3 py-2">
                 <Button
+                    v-if="showsStandalone()"
                     variant="outline"
                     class="h-auto justify-start gap-3 px-4 py-3 text-left whitespace-normal"
                     dusk="instagram-connect-standalone"
@@ -67,6 +80,7 @@ const choose = (method: string) => {
                 </Button>
 
                 <Button
+                    v-if="showsFacebook()"
                     variant="outline"
                     class="h-auto justify-start gap-3 px-4 py-3 text-left whitespace-normal"
                     dusk="instagram-connect-facebook"

--- a/resources/js/components/accounts/NetworkConnectGrid.vue
+++ b/resources/js/components/accounts/NetworkConnectGrid.vue
@@ -5,6 +5,7 @@ import { trans } from 'laravel-vue-i18n';
 import { computed, ref } from 'vue';
 import { toast } from 'vue-sonner';
 
+import InstagramConnectDialog from '@/components/accounts/InstagramConnectDialog.vue';
 import TelegramConnectDialog from '@/components/accounts/TelegramConnectDialog.vue';
 import ConfirmDeleteModal from '@/components/ConfirmDeleteModal.vue';
 import { Button } from '@/components/ui/button';
@@ -17,6 +18,7 @@ export interface AvailablePlatform {
     label: string;
     color: string;
     network: string;
+    connect_methods?: string[];
 }
 
 export interface ConnectedAccount {
@@ -150,6 +152,7 @@ const cardConnection = computed(
 );
 
 const telegramOpen = ref(false);
+const instagramOpen = ref(false);
 const disconnectModal = ref<InstanceType<typeof ConfirmDeleteModal> | null>(
     null,
 );
@@ -177,9 +180,37 @@ const needsReconnect = (account: ConnectedAccount): boolean =>
 const connectEntryFor = (platformValue: string): string =>
     platformValue === Platform.LinkedInPage ? Platform.LinkedIn : platformValue;
 
+const instagramMethods = computed((): string[] => {
+    const instagram = props.platforms.find(
+        (platform) => platform.value === Platform.Instagram,
+    );
+
+    return (
+        instagram?.connect_methods ?? [
+            Platform.Instagram,
+            Platform.InstagramFacebook,
+        ]
+    );
+});
+
 const openConnect = (platformValue: string) => {
     if (platformValue === Platform.Telegram) {
         telegramOpen.value = true;
+        return;
+    }
+
+    if (platformValue === Platform.Instagram) {
+        const methods = instagramMethods.value;
+
+        if (methods.length === 1) {
+            openOAuthPopup(methods[0]);
+            return;
+        }
+
+        if (methods.length > 1) {
+            instagramOpen.value = true;
+        }
+
         return;
     }
 
@@ -195,7 +226,15 @@ const connectPlatform = (platformValue: string) => {
 };
 
 const reconnectAccount = (account: ConnectedAccount) => {
-    openConnect(connectEntryFor(account.platform));
+    const entry = connectEntryFor(account.platform);
+
+    if (entry === Platform.Telegram) {
+        telegramOpen.value = true;
+        return;
+    }
+
+    // Reconnect with the same OAuth method — skip the Instagram method picker.
+    openOAuthPopup(entry);
 };
 
 const CardState = {
@@ -328,6 +367,12 @@ const cardState = computed((): Record<string, CardStateValue> => {
         </div>
 
         <TelegramConnectDialog v-model:open="telegramOpen" />
+
+        <InstagramConnectDialog
+            v-model:open="instagramOpen"
+            :methods="instagramMethods"
+            @select="openOAuthPopup"
+        />
 
         <ConfirmDeleteModal
             ref="disconnectModal"

--- a/resources/js/components/accounts/NetworkConnectGrid.vue
+++ b/resources/js/components/accounts/NetworkConnectGrid.vue
@@ -18,6 +18,7 @@ export interface AvailablePlatform {
     label: string;
     color: string;
     network: string;
+    connect_methods?: string[];
 }
 
 export interface ConnectedAccount {
@@ -178,6 +179,19 @@ const needsReconnect = (account: ConnectedAccount): boolean =>
 
 const connectEntryFor = (platformValue: string): string =>
     platformValue === Platform.LinkedInPage ? Platform.LinkedIn : platformValue;
+
+const instagramMethods = computed((): string[] => {
+    const instagram = props.platforms.find(
+        (platform) => platform.value === Platform.Instagram,
+    );
+
+    return (
+        instagram?.connect_methods ?? [
+            Platform.Instagram,
+            Platform.InstagramFacebook,
+        ]
+    );
+});
 
 const openConnect = (platformValue: string) => {
     if (platformValue === Platform.Telegram) {
@@ -346,6 +360,7 @@ const cardState = computed((): Record<string, CardStateValue> => {
 
         <InstagramConnectDialog
             v-model:open="instagramOpen"
+            :methods="instagramMethods"
             @select="openOAuthPopup"
         />
 

--- a/resources/js/components/accounts/NetworkConnectGrid.vue
+++ b/resources/js/components/accounts/NetworkConnectGrid.vue
@@ -18,7 +18,6 @@ export interface AvailablePlatform {
     label: string;
     color: string;
     network: string;
-    connect_methods?: string[];
 }
 
 export interface ConnectedAccount {
@@ -180,19 +179,6 @@ const needsReconnect = (account: ConnectedAccount): boolean =>
 const connectEntryFor = (platformValue: string): string =>
     platformValue === Platform.LinkedInPage ? Platform.LinkedIn : platformValue;
 
-const instagramMethods = computed((): string[] => {
-    const instagram = props.platforms.find(
-        (platform) => platform.value === Platform.Instagram,
-    );
-
-    return (
-        instagram?.connect_methods ?? [
-            Platform.Instagram,
-            Platform.InstagramFacebook,
-        ]
-    );
-});
-
 const openConnect = (platformValue: string) => {
     if (platformValue === Platform.Telegram) {
         telegramOpen.value = true;
@@ -200,17 +186,7 @@ const openConnect = (platformValue: string) => {
     }
 
     if (platformValue === Platform.Instagram) {
-        const methods = instagramMethods.value;
-
-        if (methods.length === 1) {
-            openOAuthPopup(methods[0]);
-            return;
-        }
-
-        if (methods.length > 1) {
-            instagramOpen.value = true;
-        }
-
+        instagramOpen.value = true;
         return;
     }
 
@@ -370,7 +346,6 @@ const cardState = computed((): Record<string, CardStateValue> => {
 
         <InstagramConnectDialog
             v-model:open="instagramOpen"
-            :methods="instagramMethods"
             @select="openOAuthPopup"
         />
 

--- a/tests/Feature/Onboarding/OnboardingProgressShareTest.php
+++ b/tests/Feature/Onboarding/OnboardingProgressShareTest.php
@@ -105,30 +105,6 @@ test('does not defer onboarding progress on passport oauth consent', function ()
         );
 });
 
-test('does not defer onboarding progress on social oauth popup routes', function (string $routeName) {
-    expect(app(ResolveOnboardingStatus::class)->canShowProgress($this->user))->toBeTrue();
-
-    $request = Request::create('/', 'GET');
-    $request->setLaravelSession(app('session.store'));
-    $request->setUserResolver(fn (): User => $this->user);
-    $request->setRouteResolver(function () use ($routeName): Route {
-        $route = new Route(['GET'], '/', fn () => null);
-        $route->name($routeName);
-
-        return $route;
-    });
-
-    $shared = app(HandleInertiaRequests::class)->share($request);
-
-    expect($shared['onboardingProgress'])->toBeFalse();
-})->with([
-    'facebook select page' => 'app.social.facebook.select-page',
-    'facebook select' => 'app.social.facebook.select',
-    'facebook callback' => 'app.social.facebook.callback',
-    'threads callback' => 'app.social.threads.callback',
-    'linkedin select' => 'app.social.linkedin.select',
-]);
-
 test('does not defer onboarding progress on passport device consent view', function () {
     // Device consent uses Passport's Blade view (not Inertia mcp/Authorize), so assert
     // the shared prop directly — same authToken rotation risk as the code authorize GET.

--- a/tests/Feature/Onboarding/OnboardingProgressShareTest.php
+++ b/tests/Feature/Onboarding/OnboardingProgressShareTest.php
@@ -105,6 +105,30 @@ test('does not defer onboarding progress on passport oauth consent', function ()
         );
 });
 
+test('does not defer onboarding progress on social oauth popup routes', function (string $routeName) {
+    expect(app(ResolveOnboardingStatus::class)->canShowProgress($this->user))->toBeTrue();
+
+    $request = Request::create('/', 'GET');
+    $request->setLaravelSession(app('session.store'));
+    $request->setUserResolver(fn (): User => $this->user);
+    $request->setRouteResolver(function () use ($routeName): Route {
+        $route = new Route(['GET'], '/', fn () => null);
+        $route->name($routeName);
+
+        return $route;
+    });
+
+    $shared = app(HandleInertiaRequests::class)->share($request);
+
+    expect($shared['onboardingProgress'])->toBeFalse();
+})->with([
+    'facebook select page' => 'app.social.facebook.select-page',
+    'facebook select' => 'app.social.facebook.select',
+    'facebook callback' => 'app.social.facebook.callback',
+    'threads callback' => 'app.social.threads.callback',
+    'linkedin select' => 'app.social.linkedin.select',
+]);
+
 test('does not defer onboarding progress on passport device consent view', function () {
     // Device consent uses Passport's Blade view (not Inertia mcp/Authorize), so assert
     // the shared prop directly — same authToken rotation risk as the code authorize GET.

--- a/tests/Feature/Social/FacebookControllerTest.php
+++ b/tests/Feature/Social/FacebookControllerTest.php
@@ -301,6 +301,51 @@ test('facebook callback connects authorized page when first accounts page is emp
     ]);
 });
 
+test('facebook callback fails without connecting when accounts pagination is incomplete', function () {
+    session([
+        'social_connect_workspace' => $this->workspace->id,
+    ]);
+
+    $socialiteUser = Mockery::mock(SocialiteUser::class);
+    $socialiteUser->shouldReceive('getId')->andReturn('facebook_user_123');
+    $socialiteUser->token = 'test-user-token';
+
+    Socialite::shouldReceive('driver')
+        ->with('facebook')
+        ->andReturn(Mockery::mock()->shouldReceive('usingGraphVersion')->andReturnSelf()->shouldReceive('user')->andReturn($socialiteUser)->getMock());
+
+    $graphApi = config('trypost.platforms.facebook.graph_api');
+    $nextUrl = "{$graphApi}/me/accounts?access_token=test-user-token&after=cursor1&limit=100";
+
+    Http::fake([
+        "{$graphApi}/me?*" => Http::response(['id' => 'facebook_user_123', 'name' => 'User'], 200),
+        "{$graphApi}/me/accounts*" => Http::sequence()
+            ->push([
+                'data' => [
+                    [
+                        'id' => 'page_1',
+                        'name' => 'First Page',
+                        'username' => 'first',
+                        'picture' => ['data' => ['url' => null]],
+                        'access_token' => 'token-1',
+                    ],
+                ],
+                'paging' => [
+                    'next' => $nextUrl,
+                ],
+            ], 200)
+            ->push(['error' => ['message' => 'rate limit']], 400),
+    ]);
+
+    $response = $this->actingAs($this->user)->get(route('app.social.facebook.callback'));
+
+    $response->assertOk();
+    $response->assertInertia(fn (AssertableInertia $page) => $page->where('success', false));
+    $response->assertInertia(fn (AssertableInertia $page) => $page->where('message', __('accounts.popup_callback.error_connecting')));
+
+    expect($this->workspace->socialAccounts()->where('platform', Platform::Facebook)->count())->toBe(0);
+});
+
 test('facebook callback fails with expired session', function () {
     // No session data - simulating expired session
 

--- a/tests/Feature/Social/FacebookControllerTest.php
+++ b/tests/Feature/Social/FacebookControllerTest.php
@@ -194,6 +194,111 @@ test('facebook callback fails when no pages found', function () {
     $response->assertInertia(fn (AssertableInertia $page) => $page->where('message', 'No Facebook Pages found. You need to be an admin of at least one page.'));
 });
 
+test('facebook callback follows accounts pagination and shows picker for pages across pages', function () {
+    session([
+        'social_connect_workspace' => $this->workspace->id,
+    ]);
+
+    $socialiteUser = Mockery::mock(SocialiteUser::class);
+    $socialiteUser->shouldReceive('getId')->andReturn('facebook_user_123');
+    $socialiteUser->token = 'test-user-token';
+
+    Socialite::shouldReceive('driver')
+        ->with('facebook')
+        ->andReturn(Mockery::mock()->shouldReceive('usingGraphVersion')->andReturnSelf()->shouldReceive('user')->andReturn($socialiteUser)->getMock());
+
+    $graphApi = config('trypost.platforms.facebook.graph_api');
+    $nextUrl = "{$graphApi}/me/accounts?access_token=test-user-token&after=cursor1&limit=100";
+
+    Http::fake([
+        "{$graphApi}/me?*" => Http::response(['id' => 'facebook_user_123', 'name' => 'User'], 200),
+        "{$graphApi}/me/accounts*" => Http::sequence()
+            ->push([
+                'data' => [
+                    [
+                        'id' => 'page_1',
+                        'name' => 'First Page',
+                        'username' => 'first',
+                        'picture' => ['data' => ['url' => null]],
+                        'access_token' => 'token-1',
+                    ],
+                ],
+                'paging' => [
+                    'next' => $nextUrl,
+                ],
+            ], 200)
+            ->push([
+                'data' => [
+                    [
+                        'id' => 'page_2',
+                        'name' => 'Second Page',
+                        'username' => 'second',
+                        'picture' => ['data' => ['url' => null]],
+                        'access_token' => 'token-2',
+                    ],
+                ],
+            ], 200),
+    ]);
+
+    $response = $this->actingAs($this->user)->get(route('app.social.facebook.callback'));
+
+    $response->assertRedirect(route('app.social.facebook.select-page'));
+    expect(session('facebook_oauth.pages'))->toHaveCount(2)
+        ->and(data_get(session('facebook_oauth.pages'), '0.id'))->toBe('page_1')
+        ->and(data_get(session('facebook_oauth.pages'), '1.id'))->toBe('page_2');
+});
+
+test('facebook callback connects authorized page when first accounts page is empty', function () {
+    session([
+        'social_connect_workspace' => $this->workspace->id,
+    ]);
+
+    $socialiteUser = Mockery::mock(SocialiteUser::class);
+    $socialiteUser->shouldReceive('getId')->andReturn('facebook_user_123');
+    $socialiteUser->token = 'test-user-token';
+
+    Socialite::shouldReceive('driver')
+        ->with('facebook')
+        ->andReturn(Mockery::mock()->shouldReceive('usingGraphVersion')->andReturnSelf()->shouldReceive('user')->andReturn($socialiteUser)->getMock());
+
+    $graphApi = config('trypost.platforms.facebook.graph_api');
+    $nextUrl = "{$graphApi}/me/accounts?access_token=test-user-token&after=cursor1&limit=100";
+
+    Http::fake([
+        "{$graphApi}/me?*" => Http::response(['id' => 'facebook_user_123', 'name' => 'User'], 200),
+        "{$graphApi}/me/accounts*" => Http::sequence()
+            ->push([
+                'data' => [],
+                'paging' => [
+                    'next' => $nextUrl,
+                ],
+            ], 200)
+            ->push([
+                'data' => [
+                    [
+                        'id' => 'page_desired',
+                        'name' => 'Desired Page',
+                        'username' => 'desired',
+                        'picture' => ['data' => ['url' => null]],
+                        'access_token' => 'desired-token',
+                    ],
+                ],
+            ], 200),
+    ]);
+
+    $response = $this->actingAs($this->user)->get(route('app.social.facebook.callback'));
+
+    $response->assertOk();
+    $response->assertInertia(fn (AssertableInertia $page) => $page->where('success', true));
+
+    $this->assertDatabaseHas('social_accounts', [
+        'workspace_id' => $this->workspace->id,
+        'platform' => Platform::Facebook->value,
+        'platform_user_id' => 'page_desired',
+        'display_name' => 'Desired Page',
+    ]);
+});
+
 test('facebook callback fails with expired session', function () {
     // No session data - simulating expired session
 

--- a/tests/Feature/Social/FacebookControllerTest.php
+++ b/tests/Feature/Social/FacebookControllerTest.php
@@ -195,6 +195,37 @@ test('facebook callback fails when no pages found', function () {
     $response->assertInertia(fn (AssertableInertia $page) => $page->where('message', 'No Facebook Pages found. You need to be an admin of at least one page.'));
 });
 
+test('facebook callback fails with error connecting when the first accounts request fails', function () {
+    session([
+        'social_connect_workspace' => $this->workspace->id,
+    ]);
+
+    $socialiteUser = Mockery::mock(SocialiteUser::class);
+    $socialiteUser->shouldReceive('getId')->andReturn('facebook_user_123');
+    $socialiteUser->token = 'test-user-token';
+
+    Socialite::shouldReceive('driver')
+        ->with('facebook')
+        ->andReturn(Mockery::mock()->shouldReceive('usingGraphVersion')->andReturnSelf()->shouldReceive('user')->andReturn($socialiteUser)->getMock());
+
+    $graphApi = config('trypost.platforms.facebook.graph_api');
+
+    Http::fake([
+        "{$graphApi}/me?*" => Http::response(['id' => 'facebook_user_123', 'name' => 'User'], 200),
+        "{$graphApi}/me/accounts*" => Http::response(['error' => ['message' => 'fail']], 400),
+    ]);
+
+    $response = $this->actingAs($this->user)->get(route('app.social.facebook.callback'));
+
+    $response->assertOk();
+    $response->assertInertia(fn (AssertableInertia $page) => $page
+        ->where('success', false)
+        ->where('message', __('accounts.popup_callback.error_connecting'))
+    );
+
+    expect($this->workspace->socialAccounts()->where('platform', Platform::Facebook)->count())->toBe(0);
+});
+
 test('facebook callback follows accounts pagination and shows picker for pages across pages', function () {
     session([
         'social_connect_workspace' => $this->workspace->id,

--- a/tests/Feature/Social/FacebookControllerTest.php
+++ b/tests/Feature/Social/FacebookControllerTest.php
@@ -473,6 +473,8 @@ test('facebook page selection creates account', function () {
 });
 
 test('facebook select page returns popup callback when the session expired', function () {
+    // Popup stays on PopupCallback — never dump /accounts. Shared onboarding
+    // must be inline false (not deferred) so Inertia won't re-GET this URL.
     $this->actingAs($this->user)
         ->get(route('app.social.facebook.select-page'))
         ->assertOk()
@@ -480,6 +482,7 @@ test('facebook select page returns popup callback when the session expired', fun
             ->component('accounts/PopupCallback')
             ->where('success', false)
             ->where('message', __('accounts.popup_callback.session_expired'))
+            ->where('onboardingProgress', false)
         );
 });
 

--- a/tests/Feature/Social/FacebookControllerTest.php
+++ b/tests/Feature/Social/FacebookControllerTest.php
@@ -246,6 +246,8 @@ test('facebook callback follows accounts pagination and shows picker for pages a
     expect(session('facebook_oauth.pages'))->toHaveCount(2)
         ->and(data_get(session('facebook_oauth.pages'), '0.id'))->toBe('page_1')
         ->and(data_get(session('facebook_oauth.pages'), '1.id'))->toBe('page_2');
+
+    Http::assertSent(fn ($request) => str_contains($request->url(), '/me/accounts'));
 });
 
 test('facebook callback connects authorized page when first accounts page is empty', function () {

--- a/tests/Feature/Social/FacebookControllerTest.php
+++ b/tests/Feature/Social/FacebookControllerTest.php
@@ -446,7 +446,11 @@ test('facebook page selection creates account', function () {
     ]);
 
     $response->assertOk();
-    $response->assertInertia(fn (AssertableInertia $page) => $page->where('success', true));
+    $response->assertInertia(fn (AssertableInertia $page) => $page
+        ->component('accounts/PopupCallback')
+        ->where('success', true)
+        ->where('onboardingProgress', false)
+    );
 
     $this->assertDatabaseHas('social_accounts', [
         'workspace_id' => $this->workspace->id,
@@ -454,6 +458,29 @@ test('facebook page selection creates account', function () {
         'platform_user_id' => 'page_123',
         'username' => 'myfbpage',
     ]);
+
+    // Deferred onboarding used to re-GET this URL after the POST cleared the
+    // session, which redirected the popup to /accounts. Keep the popup closed.
+    $this->actingAs($this->user)
+        ->get(route('app.social.facebook.select-page'))
+        ->assertOk()
+        ->assertInertia(fn (AssertableInertia $page) => $page
+            ->component('accounts/PopupCallback')
+            ->where('success', false)
+            ->where('message', __('accounts.popup_callback.session_expired'))
+            ->where('onboardingProgress', false)
+        );
+});
+
+test('facebook select page returns popup callback when the session expired', function () {
+    $this->actingAs($this->user)
+        ->get(route('app.social.facebook.select-page'))
+        ->assertOk()
+        ->assertInertia(fn (AssertableInertia $page) => $page
+            ->component('accounts/PopupCallback')
+            ->where('success', false)
+            ->where('message', __('accounts.popup_callback.session_expired'))
+        );
 });
 
 test('facebook page selection fails with expired session', function () {

--- a/tests/Feature/Social/FacebookControllerTest.php
+++ b/tests/Feature/Social/FacebookControllerTest.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use App\Actions\Onboarding\ResolveOnboardingStatus;
 use App\Enums\SocialAccount\Platform;
 use App\Enums\SocialAccount\Status;
 use App\Enums\UserWorkspace\Role;
@@ -459,8 +460,8 @@ test('facebook page selection creates account', function () {
         'username' => 'myfbpage',
     ]);
 
-    // Deferred onboarding used to re-GET this URL after the POST cleared the
-    // session, which redirected the popup to /accounts. Keep the popup closed.
+    // After connect the session is cleared; PopupCallback sets onboardingProgress
+    // inline so Inertia does not deferred-reload this select URL into /accounts.
     $this->actingAs($this->user)
         ->get(route('app.social.facebook.select-page'))
         ->assertOk()
@@ -473,8 +474,8 @@ test('facebook page selection creates account', function () {
 });
 
 test('facebook select page returns popup callback when the session expired', function () {
-    // Popup stays on PopupCallback — never dump /accounts. Shared onboarding
-    // must be inline false (not deferred) so Inertia won't re-GET this URL.
+    // Popup stays on PopupCallback — never dump /accounts. popupCallback() sets
+    // onboardingProgress inline so Inertia won't deferred-reload this URL.
     $this->actingAs($this->user)
         ->get(route('app.social.facebook.select-page'))
         ->assertOk()
@@ -482,6 +483,51 @@ test('facebook select page returns popup callback when the session expired', fun
             ->component('accounts/PopupCallback')
             ->where('success', false)
             ->where('message', __('accounts.popup_callback.session_expired'))
+            ->where('onboardingProgress', false)
+        );
+});
+
+test('facebook popup callback overrides deferred onboarding progress for mid-activation owners', function () {
+    config(['trypost.self_hosted' => false]);
+    subscribeAccount($this->user->account);
+
+    expect(app(ResolveOnboardingStatus::class)->canShowProgress($this->user->fresh()))->toBeTrue();
+
+    // Picker page may still defer onboarding — that is fine while the OAuth session exists.
+    session([
+        'social_connect_workspace' => $this->workspace->id,
+        'facebook_oauth' => [
+            'user_token' => 'test-user-token',
+            'user_id' => 'facebook_user_123',
+            'pages' => [
+                [
+                    'id' => 'page_123',
+                    'name' => 'My Facebook Page',
+                    'username' => 'myfbpage',
+                    'picture' => null,
+                    'access_token' => 'page-access-token',
+                ],
+            ],
+        ],
+    ]);
+
+    $this->actingAs($this->user->fresh())
+        ->get(route('app.social.facebook.select-page'))
+        ->assertOk()
+        ->assertInertia(fn (AssertableInertia $page) => $page
+            ->component('accounts/FacebookPageSelect')
+            ->missing('onboardingProgress')
+            ->has('pages', 1)
+        );
+
+    // Close/error page must force inline false so Inertia does not re-GET select-page.
+    session()->forget(['facebook_oauth', 'social_connect_workspace']);
+
+    $this->actingAs($this->user->fresh())
+        ->get(route('app.social.facebook.select-page'))
+        ->assertOk()
+        ->assertInertia(fn (AssertableInertia $page) => $page
+            ->component('accounts/PopupCallback')
             ->where('onboardingProgress', false)
         );
 });

--- a/tests/Feature/Social/InstagramFacebookControllerTest.php
+++ b/tests/Feature/Social/InstagramFacebookControllerTest.php
@@ -219,6 +219,56 @@ test('instagram-facebook callback skips pages without instagram across paginated
     ]);
 });
 
+test('instagram-facebook callback fails without connecting when accounts pagination is incomplete', function () {
+    session([
+        'social_connect_workspace' => $this->workspace->id,
+    ]);
+
+    $socialiteUser = Mockery::mock(SocialiteUser::class);
+    $socialiteUser->token = 'test-user-token';
+
+    Socialite::shouldReceive('driver')
+        ->with('facebook')
+        ->andReturn(
+            Mockery::mock()
+                ->shouldReceive('usingGraphVersion')->andReturnSelf()
+                ->shouldReceive('redirectUrl')->andReturnSelf()
+                ->shouldReceive('user')->andReturn($socialiteUser)
+                ->getMock()
+        );
+
+    $graphApi = config('trypost.platforms.instagram-facebook.graph_api');
+    $nextUrl = "{$graphApi}/me/accounts?access_token=test-user-token&after=cursor1&limit=100";
+
+    Http::fake([
+        "{$graphApi}/me?*" => Http::response(['id' => 'fb_user', 'name' => 'User'], 200),
+        "{$graphApi}/me/accounts*" => Http::sequence()
+            ->push([
+                'data' => [
+                    [
+                        'id' => 'page_1',
+                        'name' => 'First Page',
+                        'picture' => ['data' => ['url' => null]],
+                        'access_token' => 'page-token-1',
+                        'instagram_business_account' => ['id' => 'ig_1'],
+                    ],
+                ],
+                'paging' => [
+                    'next' => $nextUrl,
+                ],
+            ], 200)
+            ->push(['error' => ['message' => 'rate limit']], 400),
+    ]);
+
+    $response = $this->actingAs($this->user)->get(route('app.social.instagram-facebook.callback'));
+
+    $response->assertOk();
+    $response->assertInertia(fn (AssertableInertia $page) => $page->where('success', false));
+    $response->assertInertia(fn (AssertableInertia $page) => $page->where('message', __('accounts.popup_callback.error_connecting')));
+
+    expect($this->workspace->socialAccounts()->where('platform', Platform::InstagramFacebook)->count())->toBe(0);
+});
+
 test('instagram-facebook select connects the page in self-hosted mode', function () {
     config()->set('trypost.self_hosted', true);
 

--- a/tests/Feature/Social/InstagramFacebookControllerTest.php
+++ b/tests/Feature/Social/InstagramFacebookControllerTest.php
@@ -309,8 +309,8 @@ test('instagram-facebook select connects the page in self-hosted mode', function
         'username' => 'mybiz',
     ]);
 
-    // Deferred onboarding used to re-GET this URL after the POST cleared the
-    // session, which redirected the popup to /accounts. Keep the popup closed.
+    // After connect the session is cleared; PopupCallback sets onboardingProgress
+    // inline so Inertia does not deferred-reload this select URL into /accounts.
     $this->actingAs($this->user)
         ->get(route('app.social.instagram-facebook.select-page'))
         ->assertOk()

--- a/tests/Feature/Social/InstagramFacebookControllerTest.php
+++ b/tests/Feature/Social/InstagramFacebookControllerTest.php
@@ -7,13 +7,146 @@ use App\Enums\UserWorkspace\Role;
 use App\Models\SocialAccount;
 use App\Models\User;
 use App\Models\Workspace;
+use Illuminate\Support\Facades\Http;
 use Inertia\Testing\AssertableInertia;
+use Laravel\Socialite\Facades\Socialite;
+use Laravel\Socialite\Two\User as SocialiteUser;
 
 beforeEach(function () {
     $this->user = User::factory()->create();
     $this->workspace = Workspace::factory()->create(['user_id' => $this->user->id]);
     $this->user->update(['current_workspace_id' => $this->workspace->id]);
     $this->workspace->members()->attach($this->user->id, ['role' => Role::Member->value]);
+});
+
+test('instagram-facebook callback follows accounts pagination and shows picker', function () {
+    session([
+        'social_connect_workspace' => $this->workspace->id,
+    ]);
+
+    $socialiteUser = Mockery::mock(SocialiteUser::class);
+    $socialiteUser->token = 'test-user-token';
+
+    Socialite::shouldReceive('driver')
+        ->with('facebook')
+        ->andReturn(
+            Mockery::mock()
+                ->shouldReceive('usingGraphVersion')->andReturnSelf()
+                ->shouldReceive('redirectUrl')->andReturnSelf()
+                ->shouldReceive('user')->andReturn($socialiteUser)
+                ->getMock()
+        );
+
+    $graphApi = config('trypost.platforms.instagram-facebook.graph_api');
+    $nextUrl = "{$graphApi}/me/accounts?access_token=test-user-token&after=cursor1&limit=100";
+
+    Http::fake([
+        "{$graphApi}/me?*" => Http::response(['id' => 'fb_user', 'name' => 'User'], 200),
+        "{$graphApi}/me/accounts*" => Http::sequence()
+            ->push([
+                'data' => [
+                    [
+                        'id' => 'page_1',
+                        'name' => 'First Page',
+                        'picture' => ['data' => ['url' => null]],
+                        'access_token' => 'page-token-1',
+                        'instagram_business_account' => ['id' => 'ig_1'],
+                    ],
+                ],
+                'paging' => [
+                    'next' => $nextUrl,
+                ],
+            ], 200)
+            ->push([
+                'data' => [
+                    [
+                        'id' => 'page_2',
+                        'name' => 'Second Page',
+                        'picture' => ['data' => ['url' => null]],
+                        'access_token' => 'page-token-2',
+                        'instagram_business_account' => ['id' => 'ig_2'],
+                    ],
+                ],
+            ], 200),
+        "{$graphApi}/ig_1*" => Http::response([
+            'username' => 'ig_one',
+            'name' => 'IG One',
+            'profile_picture_url' => null,
+        ], 200),
+        "{$graphApi}/ig_2*" => Http::response([
+            'username' => 'ig_two',
+            'name' => 'IG Two',
+            'profile_picture_url' => null,
+        ], 200),
+    ]);
+
+    $response = $this->actingAs($this->user)->get(route('app.social.instagram-facebook.callback'));
+
+    $response->assertRedirect(route('app.social.instagram-facebook.select-page'));
+    expect(session('instagram_facebook_oauth.pages'))->toHaveCount(2)
+        ->and(data_get(session('instagram_facebook_oauth.pages'), '0.ig_id'))->toBe('ig_1')
+        ->and(data_get(session('instagram_facebook_oauth.pages'), '1.ig_id'))->toBe('ig_2');
+});
+
+test('instagram-facebook callback connects page when first accounts response is empty', function () {
+    session([
+        'social_connect_workspace' => $this->workspace->id,
+    ]);
+
+    $socialiteUser = Mockery::mock(SocialiteUser::class);
+    $socialiteUser->token = 'test-user-token';
+
+    Socialite::shouldReceive('driver')
+        ->with('facebook')
+        ->andReturn(
+            Mockery::mock()
+                ->shouldReceive('usingGraphVersion')->andReturnSelf()
+                ->shouldReceive('redirectUrl')->andReturnSelf()
+                ->shouldReceive('user')->andReturn($socialiteUser)
+                ->getMock()
+        );
+
+    $graphApi = config('trypost.platforms.instagram-facebook.graph_api');
+    $nextUrl = "{$graphApi}/me/accounts?access_token=test-user-token&after=cursor1&limit=100";
+
+    Http::fake([
+        "{$graphApi}/me?*" => Http::response(['id' => 'fb_user', 'name' => 'User'], 200),
+        "{$graphApi}/me/accounts*" => Http::sequence()
+            ->push([
+                'data' => [],
+                'paging' => [
+                    'next' => $nextUrl,
+                ],
+            ], 200)
+            ->push([
+                'data' => [
+                    [
+                        'id' => 'page_desired',
+                        'name' => 'Desired Page',
+                        'picture' => ['data' => ['url' => null]],
+                        'access_token' => 'page-token',
+                        'instagram_business_account' => ['id' => 'ig_desired'],
+                    ],
+                ],
+            ], 200),
+        "{$graphApi}/ig_desired*" => Http::response([
+            'username' => 'desired_ig',
+            'name' => 'Desired IG',
+            'profile_picture_url' => null,
+        ], 200),
+    ]);
+
+    $response = $this->actingAs($this->user)->get(route('app.social.instagram-facebook.callback'));
+
+    $response->assertOk();
+    $response->assertInertia(fn (AssertableInertia $page) => $page->where('success', true));
+
+    $this->assertDatabaseHas('social_accounts', [
+        'workspace_id' => $this->workspace->id,
+        'platform' => Platform::InstagramFacebook->value,
+        'platform_user_id' => 'ig_desired',
+        'username' => 'desired_ig',
+    ]);
 });
 
 test('instagram-facebook select connects the page in self-hosted mode', function () {

--- a/tests/Feature/Social/InstagramFacebookControllerTest.php
+++ b/tests/Feature/Social/InstagramFacebookControllerTest.php
@@ -151,6 +151,56 @@ test('instagram-facebook callback connects page when first accounts response is 
     ]);
 });
 
+test('instagram-facebook callback still connects when the instagram profile lookup times out', function () {
+    session([
+        'social_connect_workspace' => $this->workspace->id,
+    ]);
+
+    $socialiteUser = Mockery::mock(SocialiteUser::class);
+    $socialiteUser->token = 'test-user-token';
+
+    Socialite::shouldReceive('driver')
+        ->with('facebook')
+        ->andReturn(
+            Mockery::mock()
+                ->shouldReceive('usingGraphVersion')->andReturnSelf()
+                ->shouldReceive('redirectUrl')->andReturnSelf()
+                ->shouldReceive('user')->andReturn($socialiteUser)
+                ->getMock()
+        );
+
+    $graphApi = config('trypost.platforms.instagram-facebook.graph_api');
+
+    Http::fake([
+        "{$graphApi}/me?*" => Http::response(['id' => 'fb_user', 'name' => 'User'], 200),
+        "{$graphApi}/me/accounts*" => Http::response([
+            'data' => [
+                [
+                    'id' => 'page_1',
+                    'name' => 'My Page',
+                    'picture' => ['data' => ['url' => null]],
+                    'access_token' => 'page-token',
+                    'instagram_business_account' => ['id' => 'ig_1'],
+                ],
+            ],
+        ], 200),
+        "{$graphApi}/ig_1*" => Http::failedConnection(),
+    ]);
+
+    $response = $this->actingAs($this->user)->get(route('app.social.instagram-facebook.callback'));
+
+    $response->assertOk();
+    $response->assertInertia(fn (AssertableInertia $page) => $page->where('success', true));
+
+    $this->assertDatabaseHas('social_accounts', [
+        'workspace_id' => $this->workspace->id,
+        'platform' => Platform::InstagramFacebook->value,
+        'platform_user_id' => 'ig_1',
+    ]);
+
+    expect($this->workspace->socialAccounts()->where('platform', Platform::InstagramFacebook)->value('username'))->toBeNull();
+});
+
 test('instagram-facebook callback skips pages without instagram across paginated results', function () {
     session([
         'social_connect_workspace' => $this->workspace->id,

--- a/tests/Feature/Social/InstagramFacebookControllerTest.php
+++ b/tests/Feature/Social/InstagramFacebookControllerTest.php
@@ -296,8 +296,11 @@ test('instagram-facebook select connects the page in self-hosted mode', function
     ]);
 
     $response->assertOk();
-    $response->assertInertia(fn (AssertableInertia $page) => $page->component('accounts/PopupCallback'));
-    $response->assertInertia(fn (AssertableInertia $page) => $page->where('success', true));
+    $response->assertInertia(fn (AssertableInertia $page) => $page
+        ->component('accounts/PopupCallback')
+        ->where('success', true)
+        ->where('onboardingProgress', false)
+    );
 
     $this->assertDatabaseHas('social_accounts', [
         'workspace_id' => $this->workspace->id,
@@ -305,6 +308,30 @@ test('instagram-facebook select connects the page in self-hosted mode', function
         'platform_user_id' => 'ig-new',
         'username' => 'mybiz',
     ]);
+
+    // Deferred onboarding used to re-GET this URL after the POST cleared the
+    // session, which redirected the popup to /accounts. Keep the popup closed.
+    $this->actingAs($this->user)
+        ->get(route('app.social.instagram-facebook.select-page'))
+        ->assertOk()
+        ->assertInertia(fn (AssertableInertia $page) => $page
+            ->component('accounts/PopupCallback')
+            ->where('success', false)
+            ->where('message', __('accounts.popup_callback.session_expired'))
+            ->where('onboardingProgress', false)
+        );
+});
+
+test('instagram-facebook select page returns popup callback when the session expired', function () {
+    $this->actingAs($this->user)
+        ->get(route('app.social.instagram-facebook.select-page'))
+        ->assertOk()
+        ->assertInertia(fn (AssertableInertia $page) => $page
+            ->component('accounts/PopupCallback')
+            ->where('success', false)
+            ->where('message', __('accounts.popup_callback.session_expired'))
+            ->where('onboardingProgress', false)
+        );
 });
 
 test('instagram-facebook select shows network_taken when a standalone instagram is already connected', function () {

--- a/tests/Feature/Social/InstagramFacebookControllerTest.php
+++ b/tests/Feature/Social/InstagramFacebookControllerTest.php
@@ -86,6 +86,8 @@ test('instagram-facebook callback follows accounts pagination and shows picker',
     expect(session('instagram_facebook_oauth.pages'))->toHaveCount(2)
         ->and(data_get(session('instagram_facebook_oauth.pages'), '0.ig_id'))->toBe('ig_1')
         ->and(data_get(session('instagram_facebook_oauth.pages'), '1.ig_id'))->toBe('ig_2');
+
+    Http::assertSentCount(5); // /me + 2 accounts pages + 2 IG lookups
 });
 
 test('instagram-facebook callback connects page when first accounts response is empty', function () {
@@ -146,6 +148,74 @@ test('instagram-facebook callback connects page when first accounts response is 
         'platform' => Platform::InstagramFacebook->value,
         'platform_user_id' => 'ig_desired',
         'username' => 'desired_ig',
+    ]);
+});
+
+test('instagram-facebook callback skips pages without instagram across paginated results', function () {
+    session([
+        'social_connect_workspace' => $this->workspace->id,
+    ]);
+
+    $socialiteUser = Mockery::mock(SocialiteUser::class);
+    $socialiteUser->token = 'test-user-token';
+
+    Socialite::shouldReceive('driver')
+        ->with('facebook')
+        ->andReturn(
+            Mockery::mock()
+                ->shouldReceive('usingGraphVersion')->andReturnSelf()
+                ->shouldReceive('redirectUrl')->andReturnSelf()
+                ->shouldReceive('user')->andReturn($socialiteUser)
+                ->getMock()
+        );
+
+    $graphApi = config('trypost.platforms.instagram-facebook.graph_api');
+    $nextUrl = "{$graphApi}/me/accounts?access_token=test-user-token&after=cursor1&limit=100";
+
+    Http::fake([
+        "{$graphApi}/me?*" => Http::response(['id' => 'fb_user', 'name' => 'User'], 200),
+        "{$graphApi}/me/accounts*" => Http::sequence()
+            ->push([
+                'data' => [
+                    [
+                        'id' => 'page_no_ig',
+                        'name' => 'No IG Page',
+                        'picture' => ['data' => ['url' => null]],
+                        'access_token' => 'page-token-1',
+                    ],
+                ],
+                'paging' => [
+                    'next' => $nextUrl,
+                ],
+            ], 200)
+            ->push([
+                'data' => [
+                    [
+                        'id' => 'page_with_ig',
+                        'name' => 'With IG Page',
+                        'picture' => ['data' => ['url' => null]],
+                        'access_token' => 'page-token-2',
+                        'instagram_business_account' => ['id' => 'ig_only'],
+                    ],
+                ],
+            ], 200),
+        "{$graphApi}/ig_only*" => Http::response([
+            'username' => 'only_ig',
+            'name' => 'Only IG',
+            'profile_picture_url' => null,
+        ], 200),
+    ]);
+
+    $response = $this->actingAs($this->user)->get(route('app.social.instagram-facebook.callback'));
+
+    $response->assertOk();
+    $response->assertInertia(fn (AssertableInertia $page) => $page->where('success', true));
+
+    $this->assertDatabaseHas('social_accounts', [
+        'workspace_id' => $this->workspace->id,
+        'platform' => Platform::InstagramFacebook->value,
+        'platform_user_id' => 'ig_only',
+        'username' => 'only_ig',
     ]);
 });
 

--- a/tests/Feature/Social/YouTubeControllerTest.php
+++ b/tests/Feature/Social/YouTubeControllerTest.php
@@ -296,8 +296,8 @@ test('youtube channel selection creates account', function () {
         'username' => 'mychannel',
     ]);
 
-    // Deferred onboarding used to re-GET this URL after the POST cleared the
-    // session, which redirected the popup to /accounts. Keep the popup closed.
+    // After connect the session is cleared; PopupCallback sets onboardingProgress
+    // inline so Inertia does not deferred-reload this select URL into /accounts.
     $this->actingAs($this->user)
         ->get(route('app.social.youtube.select-channel'))
         ->assertOk()

--- a/tests/Feature/Social/YouTubeControllerTest.php
+++ b/tests/Feature/Social/YouTubeControllerTest.php
@@ -283,7 +283,11 @@ test('youtube channel selection creates account', function () {
     ]);
 
     $response->assertOk();
-    $response->assertInertia(fn (AssertableInertia $page) => $page->where('success', true));
+    $response->assertInertia(fn (AssertableInertia $page) => $page
+        ->component('accounts/PopupCallback')
+        ->where('success', true)
+        ->where('onboardingProgress', false)
+    );
 
     $this->assertDatabaseHas('social_accounts', [
         'workspace_id' => $this->workspace->id,
@@ -291,6 +295,30 @@ test('youtube channel selection creates account', function () {
         'platform_user_id' => 'UC_channel_123',
         'username' => 'mychannel',
     ]);
+
+    // Deferred onboarding used to re-GET this URL after the POST cleared the
+    // session, which redirected the popup to /accounts. Keep the popup closed.
+    $this->actingAs($this->user)
+        ->get(route('app.social.youtube.select-channel'))
+        ->assertOk()
+        ->assertInertia(fn (AssertableInertia $page) => $page
+            ->component('accounts/PopupCallback')
+            ->where('success', false)
+            ->where('message', __('accounts.popup_callback.session_expired'))
+            ->where('onboardingProgress', false)
+        );
+});
+
+test('youtube select channel returns popup callback when the session expired', function () {
+    $this->actingAs($this->user)
+        ->get(route('app.social.youtube.select-channel'))
+        ->assertOk()
+        ->assertInertia(fn (AssertableInertia $page) => $page
+            ->component('accounts/PopupCallback')
+            ->where('success', false)
+            ->where('message', __('accounts.popup_callback.session_expired'))
+            ->where('onboardingProgress', false)
+        );
 });
 
 test('youtube channel selection fails with expired session', function () {

--- a/tests/Feature/SocialControllerTest.php
+++ b/tests/Feature/SocialControllerTest.php
@@ -119,18 +119,9 @@ test('accounts index offers a single instagram card and no instagram-facebook ca
     $response->assertOk();
     $response->assertInertia(fn ($page) => $page
         ->component('accounts/Index', false)
-        ->where('platforms', function ($platforms): bool {
-            $collection = collect($platforms);
-
-            $instagram = $collection->firstWhere('value', Platform::Instagram->value);
-
-            return $collection->contains('value', Platform::Instagram->value)
-                && ! $collection->contains('value', Platform::InstagramFacebook->value)
-                && data_get($instagram, 'connect_methods') === [
-                    Platform::Instagram->value,
-                    Platform::InstagramFacebook->value,
-                ];
-        })
+        ->where('platforms', fn ($platforms) => collect($platforms)->contains('value', Platform::Instagram->value)
+            && ! collect($platforms)->contains('value', Platform::InstagramFacebook->value)
+        )
     );
 });
 
@@ -142,12 +133,7 @@ test('the instagram card still shows when only facebook business is enabled', fu
 
     $response->assertInertia(fn ($page) => $page
         ->component('accounts/Index', false)
-        ->where('platforms', function ($platforms): bool {
-            $instagram = collect($platforms)->firstWhere('value', Platform::Instagram->value);
-
-            return $instagram !== null
-                && data_get($instagram, 'connect_methods') === [Platform::InstagramFacebook->value];
-        })
+        ->where('platforms', fn ($platforms) => collect($platforms)->contains('value', Platform::Instagram->value))
     );
 });
 

--- a/tests/Feature/SocialControllerTest.php
+++ b/tests/Feature/SocialControllerTest.php
@@ -133,7 +133,28 @@ test('the instagram card still shows when only facebook business is enabled', fu
 
     $response->assertInertia(fn ($page) => $page
         ->component('accounts/Index', false)
-        ->where('platforms', fn ($platforms) => collect($platforms)->contains('value', Platform::Instagram->value))
+        ->where('platforms', function ($platforms): bool {
+            $instagram = collect($platforms)->firstWhere('value', Platform::Instagram->value);
+
+            return $instagram !== null
+                && data_get($instagram, 'connect_methods') === [Platform::InstagramFacebook->value];
+        })
+    );
+});
+
+test('instagram card connect methods omit disabled facebook business entry', function () {
+    config(['trypost.platforms.instagram.enabled' => true]);
+    config(['trypost.platforms.instagram-facebook.enabled' => false]);
+
+    $response = $this->actingAs($this->user)->get(route('app.accounts'));
+
+    $response->assertInertia(fn ($page) => $page
+        ->component('accounts/Index', false)
+        ->where('platforms', function ($platforms): bool {
+            $instagram = collect($platforms)->firstWhere('value', Platform::Instagram->value);
+
+            return data_get($instagram, 'connect_methods') === [Platform::Instagram->value];
+        })
     );
 });
 

--- a/tests/Feature/SocialControllerTest.php
+++ b/tests/Feature/SocialControllerTest.php
@@ -113,6 +113,73 @@ test('a connected linkedin page account is still returned so it surfaces under t
     );
 });
 
+test('accounts index offers a single instagram card and no instagram-facebook card', function () {
+    $response = $this->actingAs($this->user)->get(route('app.accounts'));
+
+    $response->assertOk();
+    $response->assertInertia(fn ($page) => $page
+        ->component('accounts/Index', false)
+        ->where('platforms', function ($platforms): bool {
+            $collection = collect($platforms);
+
+            $instagram = $collection->firstWhere('value', Platform::Instagram->value);
+
+            return $collection->contains('value', Platform::Instagram->value)
+                && ! $collection->contains('value', Platform::InstagramFacebook->value)
+                && data_get($instagram, 'connect_methods') === [
+                    Platform::Instagram->value,
+                    Platform::InstagramFacebook->value,
+                ];
+        })
+    );
+});
+
+test('the instagram card still shows when only facebook business is enabled', function () {
+    config(['trypost.platforms.instagram.enabled' => false]);
+    config(['trypost.platforms.instagram-facebook.enabled' => true]);
+
+    $response = $this->actingAs($this->user)->get(route('app.accounts'));
+
+    $response->assertInertia(fn ($page) => $page
+        ->component('accounts/Index', false)
+        ->where('platforms', function ($platforms): bool {
+            $instagram = collect($platforms)->firstWhere('value', Platform::Instagram->value);
+
+            return $instagram !== null
+                && data_get($instagram, 'connect_methods') === [Platform::InstagramFacebook->value];
+        })
+    );
+});
+
+test('the instagram card disappears only when both capabilities are disabled', function () {
+    config(['trypost.platforms.instagram.enabled' => false]);
+    config(['trypost.platforms.instagram-facebook.enabled' => false]);
+
+    $response = $this->actingAs($this->user)->get(route('app.accounts'));
+
+    $response->assertInertia(fn ($page) => $page
+        ->component('accounts/Index', false)
+        ->where('platforms', fn ($platforms) => ! collect($platforms)->contains('value', Platform::Instagram->value))
+    );
+});
+
+test('a connected instagram-facebook account is still returned so it surfaces under the instagram card', function () {
+    SocialAccount::factory()->create([
+        'workspace_id' => $this->workspace->id,
+        'platform' => Platform::InstagramFacebook,
+        'scopes' => Platform::InstagramFacebook->requiredPublishScopes(),
+    ]);
+
+    $response = $this->actingAs($this->user)->get(route('app.accounts'));
+
+    $response->assertOk();
+    $response->assertInertia(fn ($page) => $page
+        ->component('accounts/Index', false)
+        ->where('connectedAccounts.0.platform', Platform::InstagramFacebook->value)
+        ->where('connectedAccounts.0.network', 'instagram')
+    );
+});
+
 test('an unsubscribed account can disconnect during onboarding (no active subscription required)', function () {
     config(['trypost.self_hosted' => false]);
 

--- a/tests/Unit/Enums/PlatformTest.php
+++ b/tests/Unit/Enums/PlatformTest.php
@@ -12,7 +12,7 @@ test('platform has correct labels', function () {
     expect(Platform::TikTok->label())->toBe('TikTok');
     expect(Platform::YouTube->label())->toBe('YouTube Shorts');
     expect(Platform::Facebook->label())->toBe('Facebook Page');
-    expect(Platform::Instagram->label())->toBe('Instagram (Standalone)');
+    expect(Platform::Instagram->label())->toBe('Instagram');
     expect(Platform::InstagramFacebook->label())->toBe('Instagram (Facebook Business)');
     expect(Platform::Threads->label())->toBe('Threads');
     expect(Platform::Pinterest->label())->toBe('Pinterest');
@@ -114,10 +114,10 @@ test('platform can be disabled via config', function () {
     expect(Platform::LinkedIn->isEnabled())->toBeFalse();
 });
 
-test('only linkedin pages are not directly connectable', function () {
+test('linkedin pages and instagram facebook are not directly connectable', function () {
     expect(Platform::LinkedInPage->isConnectable())->toBeFalse();
     expect(Platform::LinkedIn->isConnectable())->toBeTrue();
-    expect(Platform::InstagramFacebook->isConnectable())->toBeTrue();
+    expect(Platform::InstagramFacebook->isConnectable())->toBeFalse();
     expect(Platform::Instagram->isConnectable())->toBeTrue();
 });
 
@@ -136,6 +136,33 @@ test('the linkedin card is connectable while either capability is enabled', func
     expect(Platform::LinkedInPage->isConnectable())->toBeFalse();
 });
 
+test('the instagram card is connectable while either capability is enabled', function () {
+    config(['trypost.platforms.instagram.enabled' => true, 'trypost.platforms.instagram-facebook.enabled' => false]);
+    expect(Platform::Instagram->isConnectable())->toBeTrue();
+    expect(Platform::Instagram->connectMethods())->toBe([Platform::Instagram->value]);
+
+    config(['trypost.platforms.instagram.enabled' => false, 'trypost.platforms.instagram-facebook.enabled' => true]);
+    expect(Platform::Instagram->isConnectable())->toBeTrue();
+    expect(Platform::Instagram->connectMethods())->toBe([Platform::InstagramFacebook->value]);
+
+    config(['trypost.platforms.instagram.enabled' => false, 'trypost.platforms.instagram-facebook.enabled' => false]);
+    expect(Platform::Instagram->isConnectable())->toBeFalse();
+    expect(Platform::Instagram->connectMethods())->toBe([]);
+
+    // Via-Facebook never gets its own card regardless of toggles.
+    config(['trypost.platforms.instagram-facebook.enabled' => true]);
+    expect(Platform::InstagramFacebook->isConnectable())->toBeFalse();
+});
+
+test('instagram connect methods include both when enabled', function () {
+    config(['trypost.platforms.instagram.enabled' => true, 'trypost.platforms.instagram-facebook.enabled' => true]);
+
+    expect(Platform::Instagram->connectMethods())->toBe([
+        Platform::Instagram->value,
+        Platform::InstagramFacebook->value,
+    ]);
+});
+
 test('connectable options are sorted alphabetically by label', function () {
     $labels = array_column(Platform::connectableOptions(), 'label');
 
@@ -143,4 +170,19 @@ test('connectable options are sorted alphabetically by label', function () {
     natcasesort($sorted);
 
     expect($labels)->toBe(array_values($sorted));
+});
+
+test('connectable options expose instagram connect methods and omit the facebook variant card', function () {
+    $options = Platform::connectableOptions();
+    $values = array_column($options, 'value');
+
+    expect($values)->toContain(Platform::Instagram->value)
+        ->and($values)->not->toContain(Platform::InstagramFacebook->value);
+
+    $instagram = collect($options)->firstWhere('value', Platform::Instagram->value);
+
+    expect($instagram['connect_methods'])->toBe([
+        Platform::Instagram->value,
+        Platform::InstagramFacebook->value,
+    ]);
 });

--- a/tests/Unit/Enums/PlatformTest.php
+++ b/tests/Unit/Enums/PlatformTest.php
@@ -170,21 +170,19 @@ test('connectable options include a single instagram card and omit the facebook 
 test('instagram connectable option lists only enabled connect methods', function () {
     config(['trypost.platforms.instagram.enabled' => true, 'trypost.platforms.instagram-facebook.enabled' => false]);
 
+    expect(Platform::instagramConnectMethods())->toBe([Platform::Instagram->value]);
+
     $instagram = collect(Platform::connectableOptions())->firstWhere('value', Platform::Instagram->value);
 
     expect($instagram['connect_methods'])->toBe([Platform::Instagram->value]);
 
     config(['trypost.platforms.instagram.enabled' => false, 'trypost.platforms.instagram-facebook.enabled' => true]);
 
-    $instagram = collect(Platform::connectableOptions())->firstWhere('value', Platform::Instagram->value);
-
-    expect($instagram['connect_methods'])->toBe([Platform::InstagramFacebook->value]);
+    expect(Platform::instagramConnectMethods())->toBe([Platform::InstagramFacebook->value]);
 
     config(['trypost.platforms.instagram.enabled' => true, 'trypost.platforms.instagram-facebook.enabled' => true]);
 
-    $instagram = collect(Platform::connectableOptions())->firstWhere('value', Platform::Instagram->value);
-
-    expect($instagram['connect_methods'])->toBe([
+    expect(Platform::instagramConnectMethods())->toBe([
         Platform::Instagram->value,
         Platform::InstagramFacebook->value,
     ]);

--- a/tests/Unit/Enums/PlatformTest.php
+++ b/tests/Unit/Enums/PlatformTest.php
@@ -166,3 +166,26 @@ test('connectable options include a single instagram card and omit the facebook 
     expect($values)->toContain(Platform::Instagram->value)
         ->and($values)->not->toContain(Platform::InstagramFacebook->value);
 });
+
+test('instagram connectable option lists only enabled connect methods', function () {
+    config(['trypost.platforms.instagram.enabled' => true, 'trypost.platforms.instagram-facebook.enabled' => false]);
+
+    $instagram = collect(Platform::connectableOptions())->firstWhere('value', Platform::Instagram->value);
+
+    expect($instagram['connect_methods'])->toBe([Platform::Instagram->value]);
+
+    config(['trypost.platforms.instagram.enabled' => false, 'trypost.platforms.instagram-facebook.enabled' => true]);
+
+    $instagram = collect(Platform::connectableOptions())->firstWhere('value', Platform::Instagram->value);
+
+    expect($instagram['connect_methods'])->toBe([Platform::InstagramFacebook->value]);
+
+    config(['trypost.platforms.instagram.enabled' => true, 'trypost.platforms.instagram-facebook.enabled' => true]);
+
+    $instagram = collect(Platform::connectableOptions())->firstWhere('value', Platform::Instagram->value);
+
+    expect($instagram['connect_methods'])->toBe([
+        Platform::Instagram->value,
+        Platform::InstagramFacebook->value,
+    ]);
+});

--- a/tests/Unit/Enums/PlatformTest.php
+++ b/tests/Unit/Enums/PlatformTest.php
@@ -139,28 +139,16 @@ test('the linkedin card is connectable while either capability is enabled', func
 test('the instagram card is connectable while either capability is enabled', function () {
     config(['trypost.platforms.instagram.enabled' => true, 'trypost.platforms.instagram-facebook.enabled' => false]);
     expect(Platform::Instagram->isConnectable())->toBeTrue();
-    expect(Platform::Instagram->connectMethods())->toBe([Platform::Instagram->value]);
 
     config(['trypost.platforms.instagram.enabled' => false, 'trypost.platforms.instagram-facebook.enabled' => true]);
     expect(Platform::Instagram->isConnectable())->toBeTrue();
-    expect(Platform::Instagram->connectMethods())->toBe([Platform::InstagramFacebook->value]);
 
     config(['trypost.platforms.instagram.enabled' => false, 'trypost.platforms.instagram-facebook.enabled' => false]);
     expect(Platform::Instagram->isConnectable())->toBeFalse();
-    expect(Platform::Instagram->connectMethods())->toBe([]);
 
     // Via-Facebook never gets its own card regardless of toggles.
     config(['trypost.platforms.instagram-facebook.enabled' => true]);
     expect(Platform::InstagramFacebook->isConnectable())->toBeFalse();
-});
-
-test('instagram connect methods include both when enabled', function () {
-    config(['trypost.platforms.instagram.enabled' => true, 'trypost.platforms.instagram-facebook.enabled' => true]);
-
-    expect(Platform::Instagram->connectMethods())->toBe([
-        Platform::Instagram->value,
-        Platform::InstagramFacebook->value,
-    ]);
 });
 
 test('connectable options are sorted alphabetically by label', function () {
@@ -172,17 +160,9 @@ test('connectable options are sorted alphabetically by label', function () {
     expect($labels)->toBe(array_values($sorted));
 });
 
-test('connectable options expose instagram connect methods and omit the facebook variant card', function () {
-    $options = Platform::connectableOptions();
-    $values = array_column($options, 'value');
+test('connectable options include a single instagram card and omit the facebook variant', function () {
+    $values = array_column(Platform::connectableOptions(), 'value');
 
     expect($values)->toContain(Platform::Instagram->value)
         ->and($values)->not->toContain(Platform::InstagramFacebook->value);
-
-    $instagram = collect($options)->firstWhere('value', Platform::Instagram->value);
-
-    expect($instagram['connect_methods'])->toBe([
-        Platform::Instagram->value,
-        Platform::InstagramFacebook->value,
-    ]);
 });

--- a/tests/Unit/Mail/AccountDisconnectedTest.php
+++ b/tests/Unit/Mail/AccountDisconnectedTest.php
@@ -17,7 +17,7 @@ test('account disconnected mail has correct subject', function () {
 
     $mail = new AccountDisconnected($account);
 
-    expect($mail->envelope()->subject)->toBe('Your Instagram (Standalone) account in My Workspace needs to be reconnected');
+    expect($mail->envelope()->subject)->toBe('Your Instagram account in My Workspace needs to be reconnected');
 });
 
 test('account disconnected mail has correct content', function () {

--- a/tests/Unit/Social/Meta/GraphPaginatorTest.php
+++ b/tests/Unit/Social/Meta/GraphPaginatorTest.php
@@ -141,7 +141,7 @@ test('graph paginator throws when a later request fails after earlier pages succ
     ]);
 })->throws(IncompleteMetaGraphPaginationException::class);
 
-test('graph paginator returns empty array when the first request fails', function () {
+test('graph paginator throws when the first request fails', function () {
     Http::preventStrayRequests();
 
     Log::shouldReceive('error')->once()->withArgs(function (string $message) {
@@ -152,14 +152,12 @@ test('graph paginator returns empty array when the first request fails', functio
         'https://graph.facebook.com/v25.0/me/accounts*' => Http::response(['error' => ['message' => 'fail']], 400),
     ]);
 
-    $pages = GraphPaginator::all('https://graph.facebook.com/v25.0/me/accounts', [
+    GraphPaginator::all('https://graph.facebook.com/v25.0/me/accounts', [
         'access_token' => 'token',
     ]);
+})->throws(IncompleteMetaGraphPaginationException::class);
 
-    expect($pages)->toBe([]);
-});
-
-test('graph paginator returns empty array when the first request cannot connect', function () {
+test('graph paginator throws when the first request cannot connect', function () {
     Http::preventStrayRequests();
 
     Log::shouldReceive('error')->once()->withArgs(function (string $message) {
@@ -170,13 +168,10 @@ test('graph paginator returns empty array when the first request cannot connect'
         'https://graph.facebook.com/v25.0/me/accounts*' => Http::failedConnection(),
     ]);
 
-    $pages = GraphPaginator::all('https://graph.facebook.com/v25.0/me/accounts', [
+    GraphPaginator::all('https://graph.facebook.com/v25.0/me/accounts', [
         'access_token' => 'token',
     ]);
-
-    expect($pages)->toBe([]);
-});
-
+})->throws(IncompleteMetaGraphPaginationException::class);
 test('graph paginator throws when a later request cannot connect', function () {
     Http::preventStrayRequests();
 
@@ -235,13 +230,13 @@ test('graph paginator stops when paging.next is not a usable string', function (
     Http::assertSentCount(1);
 });
 
-test('graph paginator stops when paging.next repeats to avoid infinite loops', function () {
+test('graph paginator throws when paging.next repeats after pages were fetched', function () {
     Http::preventStrayRequests();
 
     $graphApi = 'https://graph.facebook.com/v25.0';
     $loopUrl = "{$graphApi}/me/accounts?access_token=secret-token&after=cursor&limit=100";
 
-    Log::shouldReceive('warning')->once()->withArgs(function (string $message, array $context) {
+    Log::shouldReceive('error')->once()->withArgs(function (string $message, array $context) {
         return $message === 'Meta Graph pagination stopped: repeated paging URL'
             && ! str_contains((string) data_get($context, 'url'), 'secret-token')
             && str_contains((string) data_get($context, 'url'), 'access_token=[REDACTED]');
@@ -267,13 +262,61 @@ test('graph paginator stops when paging.next repeats to avoid infinite loops', f
             ], 200),
     ]);
 
-    $pages = GraphPaginator::all("{$graphApi}/me/accounts", [
+    GraphPaginator::all("{$graphApi}/me/accounts", [
         'access_token' => 'token',
     ]);
+})->throws(IncompleteMetaGraphPaginationException::class);
 
-    expect($pages)->toHaveCount(2)
-        ->and(data_get($pages, '0.id'))->toBe('page_1')
-        ->and(data_get($pages, '1.id'))->toBe('page_2');
+test('graph paginator throws when paging.next points to another host', function () {
+    Http::preventStrayRequests();
 
-    Http::assertSentCount(2);
-});
+    $graphApi = 'https://graph.facebook.com/v25.0';
+
+    Log::shouldReceive('error')->once()->withArgs(function (string $message) {
+        return $message === 'Meta Graph pagination stopped: unexpected paging host';
+    });
+
+    Http::fake([
+        "{$graphApi}/me/accounts*" => Http::response([
+            'data' => [
+                ['id' => 'page_1'],
+            ],
+            'paging' => [
+                'next' => 'https://evil.example/me/accounts?access_token=secret-token',
+            ],
+        ], 200),
+    ]);
+
+    GraphPaginator::all("{$graphApi}/me/accounts", [
+        'access_token' => 'token',
+    ]);
+})->throws(IncompleteMetaGraphPaginationException::class);
+
+test('graph paginator throws when the safety page ceiling is reached', function () {
+    Http::preventStrayRequests();
+
+    $graphApi = 'https://graph.facebook.com/v25.0';
+    $requestCount = 0;
+
+    Log::shouldReceive('error')->once()->withArgs(function (string $message) {
+        return $message === 'Meta Graph pagination stopped: page limit reached';
+    });
+
+    Http::fake(function () use (&$requestCount, $graphApi) {
+        $requestCount++;
+        $after = $requestCount;
+
+        return Http::response([
+            'data' => [
+                ['id' => "page_{$requestCount}"],
+            ],
+            'paging' => [
+                'next' => "{$graphApi}/me/accounts?access_token=token&after={$after}",
+            ],
+        ], 200);
+    });
+
+    GraphPaginator::all("{$graphApi}/me/accounts", [
+        'access_token' => 'token',
+    ]);
+})->throws(IncompleteMetaGraphPaginationException::class);

--- a/tests/Unit/Social/Meta/GraphPaginatorTest.php
+++ b/tests/Unit/Social/Meta/GraphPaginatorTest.php
@@ -2,8 +2,8 @@
 
 declare(strict_types=1);
 
-use App\Exceptions\Social\IncompleteGraphPaginationException;
 use App\Services\Social\Meta\GraphPaginator;
+use App\Services\Social\Meta\IncompletePaginationException;
 use Illuminate\Http\Client\Request;
 use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Log;
@@ -139,7 +139,7 @@ test('graph paginator throws when a later request fails after earlier pages succ
         'access_token' => 'secret-token',
         'limit' => 100,
     ]);
-})->throws(IncompleteGraphPaginationException::class);
+})->throws(IncompletePaginationException::class);
 
 test('graph paginator returns empty array when the first request fails', function () {
     Http::preventStrayRequests();
@@ -209,7 +209,7 @@ test('graph paginator throws when a later request cannot connect', function () {
     GraphPaginator::all("{$graphApi}/me/accounts", [
         'access_token' => 'secret-token',
     ]);
-})->throws(IncompleteGraphPaginationException::class);
+})->throws(IncompletePaginationException::class);
 
 test('graph paginator stops when paging.next is not a usable string', function () {
     Http::preventStrayRequests();

--- a/tests/Unit/Social/Meta/GraphPaginatorTest.php
+++ b/tests/Unit/Social/Meta/GraphPaginatorTest.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use App\Exceptions\Social\IncompleteGraphPaginationException;
 use App\Services\Social\Meta\GraphPaginator;
 use Illuminate\Http\Client\Request;
 use Illuminate\Support\Facades\Http;
@@ -108,7 +109,7 @@ test('graph paginator collects authorized page when first response is empty', fu
         ->and(data_get($pages, '0.id'))->toBe('page_desired');
 });
 
-test('graph paginator keeps earlier pages when a later request fails', function () {
+test('graph paginator throws when a later request fails after earlier pages succeeded', function () {
     Http::preventStrayRequests();
 
     $graphApi = 'https://graph.facebook.com/v25.0';
@@ -133,16 +134,11 @@ test('graph paginator keeps earlier pages when a later request fails', function 
             ->push(['error' => ['message' => 'rate limit']], 400),
     ]);
 
-    $pages = GraphPaginator::all("{$graphApi}/me/accounts", [
+    GraphPaginator::all("{$graphApi}/me/accounts", [
         'access_token' => 'secret-token',
         'limit' => 100,
     ]);
-
-    expect($pages)->toHaveCount(1)
-        ->and(data_get($pages, '0.id'))->toBe('page_1');
-
-    Http::assertSentCount(2);
-});
+})->throws(IncompleteGraphPaginationException::class);
 
 test('graph paginator returns empty array when the first request fails', function () {
     Http::preventStrayRequests();
@@ -161,6 +157,58 @@ test('graph paginator returns empty array when the first request fails', functio
 
     expect($pages)->toBe([]);
 });
+
+test('graph paginator returns empty array when the first request cannot connect', function () {
+    Http::preventStrayRequests();
+
+    Log::shouldReceive('error')->once()->withArgs(function (string $message) {
+        return $message === 'Meta Graph pagination connection failed';
+    });
+
+    Http::fake([
+        'https://graph.facebook.com/v25.0/me/accounts*' => Http::failedConnection(),
+    ]);
+
+    $pages = GraphPaginator::all('https://graph.facebook.com/v25.0/me/accounts', [
+        'access_token' => 'token',
+    ]);
+
+    expect($pages)->toBe([]);
+});
+
+test('graph paginator throws when a later request cannot connect', function () {
+    Http::preventStrayRequests();
+
+    $graphApi = 'https://graph.facebook.com/v25.0';
+    $nextUrl = "{$graphApi}/me/accounts?access_token=secret-token&after=cursor1&limit=100";
+    $requestCount = 0;
+
+    Log::shouldReceive('error')->once()->withArgs(function (string $message, array $context) {
+        return $message === 'Meta Graph pagination connection failed'
+            && str_contains((string) data_get($context, 'url'), 'access_token=[REDACTED]');
+    });
+
+    Http::fake(function () use (&$requestCount, $nextUrl) {
+        $requestCount++;
+
+        if ($requestCount === 1) {
+            return Http::response([
+                'data' => [
+                    ['id' => 'page_1'],
+                ],
+                'paging' => [
+                    'next' => $nextUrl,
+                ],
+            ], 200);
+        }
+
+        return Http::failedConnection();
+    });
+
+    GraphPaginator::all("{$graphApi}/me/accounts", [
+        'access_token' => 'secret-token',
+    ]);
+})->throws(IncompleteGraphPaginationException::class);
 
 test('graph paginator stops when paging.next is not a usable string', function () {
     Http::preventStrayRequests();

--- a/tests/Unit/Social/Meta/GraphPaginatorTest.php
+++ b/tests/Unit/Social/Meta/GraphPaginatorTest.php
@@ -1,0 +1,111 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Services\Social\Meta\GraphPaginator;
+use Illuminate\Support\Facades\Http;
+
+test('graph paginator follows paging.next until exhausted', function () {
+    Http::preventStrayRequests();
+
+    $graphApi = 'https://graph.facebook.com/v25.0';
+    $nextUrl = "{$graphApi}/me/accounts?access_token=token&after=cursor1&limit=100";
+
+    Http::fake([
+        "{$graphApi}/me/accounts*" => Http::sequence()
+            ->push([
+                'data' => [
+                    ['id' => 'page_1', 'name' => 'First'],
+                ],
+                'paging' => [
+                    'next' => $nextUrl,
+                ],
+            ], 200)
+            ->push([
+                'data' => [
+                    ['id' => 'page_2', 'name' => 'Second'],
+                ],
+            ], 200),
+    ]);
+
+    $pages = GraphPaginator::all("{$graphApi}/me/accounts", [
+        'access_token' => 'token',
+        'fields' => 'id,name',
+        'limit' => 100,
+    ]);
+
+    expect($pages)->toHaveCount(2)
+        ->and(data_get($pages, '0.id'))->toBe('page_1')
+        ->and(data_get($pages, '1.id'))->toBe('page_2');
+
+    Http::assertSentCount(2);
+});
+
+test('graph paginator collects authorized page when first response is empty', function () {
+    Http::preventStrayRequests();
+
+    $graphApi = 'https://graph.facebook.com/v25.0';
+    $nextUrl = "{$graphApi}/me/accounts?access_token=token&after=cursor1&limit=100";
+
+    Http::fake([
+        "{$graphApi}/me/accounts*" => Http::sequence()
+            ->push([
+                'data' => [],
+                'paging' => [
+                    'next' => $nextUrl,
+                ],
+            ], 200)
+            ->push([
+                'data' => [
+                    ['id' => 'page_desired', 'name' => 'Desired Page'],
+                ],
+            ], 200),
+    ]);
+
+    $pages = GraphPaginator::all("{$graphApi}/me/accounts", [
+        'access_token' => 'token',
+        'limit' => 100,
+    ]);
+
+    expect($pages)->toHaveCount(1)
+        ->and(data_get($pages, '0.id'))->toBe('page_desired');
+});
+
+test('graph paginator returns empty array when the first request fails', function () {
+    Http::preventStrayRequests();
+
+    Http::fake([
+        'https://graph.facebook.com/v25.0/me/accounts*' => Http::response(['error' => ['message' => 'fail']], 400),
+    ]);
+
+    $pages = GraphPaginator::all('https://graph.facebook.com/v25.0/me/accounts', [
+        'access_token' => 'token',
+    ]);
+
+    expect($pages)->toBe([]);
+});
+
+test('graph paginator stops after max pages to avoid infinite loops', function () {
+    Http::preventStrayRequests();
+
+    $graphApi = 'https://graph.facebook.com/v25.0';
+    $nextUrl = "{$graphApi}/me/accounts?access_token=token&after=cursor&limit=100";
+
+    Http::fake([
+        "{$graphApi}/me/accounts*" => Http::response([
+            'data' => [
+                ['id' => 'page_loop'],
+            ],
+            'paging' => [
+                'next' => $nextUrl,
+            ],
+        ], 200),
+    ]);
+
+    $pages = GraphPaginator::all("{$graphApi}/me/accounts", [
+        'access_token' => 'token',
+    ], maxPages: 3);
+
+    expect($pages)->toHaveCount(3);
+    Http::assertSentCount(3);
+});

--- a/tests/Unit/Social/Meta/GraphPaginatorTest.php
+++ b/tests/Unit/Social/Meta/GraphPaginatorTest.php
@@ -30,7 +30,8 @@ test('graph paginator returns a single page when there is no paging.next', funct
         ->and(data_get($pages, '0.id'))->toBe('page_only');
 
     Http::assertSentCount(1);
-    Http::assertSent(fn (Request $request) => $request['limit'] === 100 && $request['access_token'] === 'token');
+    Http::assertSent(fn (Request $request) => str_contains($request->url(), 'limit=100')
+        && str_contains($request->url(), 'access_token=token'));
 });
 
 test('graph paginator follows paging.next until exhausted', function () {

--- a/tests/Unit/Social/Meta/GraphPaginatorTest.php
+++ b/tests/Unit/Social/Meta/GraphPaginatorTest.php
@@ -85,27 +85,39 @@ test('graph paginator returns empty array when the first request fails', functio
     expect($pages)->toBe([]);
 });
 
-test('graph paginator stops after max pages to avoid infinite loops', function () {
+test('graph paginator stops when paging.next repeats to avoid infinite loops', function () {
     Http::preventStrayRequests();
 
     $graphApi = 'https://graph.facebook.com/v25.0';
-    $nextUrl = "{$graphApi}/me/accounts?access_token=token&after=cursor&limit=100";
+    $loopUrl = "{$graphApi}/me/accounts?access_token=token&after=cursor&limit=100";
 
     Http::fake([
-        "{$graphApi}/me/accounts*" => Http::response([
-            'data' => [
-                ['id' => 'page_loop'],
-            ],
-            'paging' => [
-                'next' => $nextUrl,
-            ],
-        ], 200),
+        "{$graphApi}/me/accounts*" => Http::sequence()
+            ->push([
+                'data' => [
+                    ['id' => 'page_1'],
+                ],
+                'paging' => [
+                    'next' => $loopUrl,
+                ],
+            ], 200)
+            ->push([
+                'data' => [
+                    ['id' => 'page_2'],
+                ],
+                'paging' => [
+                    'next' => $loopUrl,
+                ],
+            ], 200),
     ]);
 
     $pages = GraphPaginator::all("{$graphApi}/me/accounts", [
         'access_token' => 'token',
-    ], maxPages: 3);
+    ]);
 
-    expect($pages)->toHaveCount(3);
-    Http::assertSentCount(3);
+    expect($pages)->toHaveCount(2)
+        ->and(data_get($pages, '0.id'))->toBe('page_1')
+        ->and(data_get($pages, '1.id'))->toBe('page_2');
+
+    Http::assertSentCount(2);
 });

--- a/tests/Unit/Social/Meta/GraphPaginatorTest.php
+++ b/tests/Unit/Social/Meta/GraphPaginatorTest.php
@@ -2,8 +2,8 @@
 
 declare(strict_types=1);
 
+use App\Exceptions\Social\IncompleteMetaGraphPaginationException;
 use App\Services\Social\Meta\GraphPaginator;
-use App\Services\Social\Meta\IncompletePaginationException;
 use Illuminate\Http\Client\Request;
 use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Log;
@@ -139,7 +139,7 @@ test('graph paginator throws when a later request fails after earlier pages succ
         'access_token' => 'secret-token',
         'limit' => 100,
     ]);
-})->throws(IncompletePaginationException::class);
+})->throws(IncompleteMetaGraphPaginationException::class);
 
 test('graph paginator returns empty array when the first request fails', function () {
     Http::preventStrayRequests();
@@ -209,7 +209,7 @@ test('graph paginator throws when a later request cannot connect', function () {
     GraphPaginator::all("{$graphApi}/me/accounts", [
         'access_token' => 'secret-token',
     ]);
-})->throws(IncompletePaginationException::class);
+})->throws(IncompleteMetaGraphPaginationException::class);
 
 test('graph paginator stops when paging.next is not a usable string', function () {
     Http::preventStrayRequests();

--- a/tests/Unit/Social/Meta/GraphPaginatorTest.php
+++ b/tests/Unit/Social/Meta/GraphPaginatorTest.php
@@ -3,13 +3,41 @@
 declare(strict_types=1);
 
 use App\Services\Social\Meta\GraphPaginator;
+use Illuminate\Http\Client\Request;
 use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Log;
+
+test('graph paginator returns a single page when there is no paging.next', function () {
+    Http::preventStrayRequests();
+
+    $graphApi = 'https://graph.facebook.com/v25.0';
+
+    Http::fake([
+        "{$graphApi}/me/accounts*" => Http::response([
+            'data' => [
+                ['id' => 'page_only', 'name' => 'Only Page'],
+            ],
+        ], 200),
+    ]);
+
+    $pages = GraphPaginator::all("{$graphApi}/me/accounts", [
+        'access_token' => 'token',
+        'limit' => 100,
+    ]);
+
+    expect($pages)->toHaveCount(1)
+        ->and(data_get($pages, '0.id'))->toBe('page_only');
+
+    Http::assertSentCount(1);
+    Http::assertSent(fn (Request $request) => $request['limit'] === 100 && $request['access_token'] === 'token');
+});
 
 test('graph paginator follows paging.next until exhausted', function () {
     Http::preventStrayRequests();
 
     $graphApi = 'https://graph.facebook.com/v25.0';
-    $nextUrl = "{$graphApi}/me/accounts?access_token=token&after=cursor1&limit=100";
+    $nextUrl = "{$graphApi}/me/accounts?access_token=secret-token&after=cursor1&limit=100";
+    $thirdUrl = "{$graphApi}/me/accounts?access_token=secret-token&after=cursor2&limit=100";
 
     Http::fake([
         "{$graphApi}/me/accounts*" => Http::sequence()
@@ -25,20 +53,29 @@ test('graph paginator follows paging.next until exhausted', function () {
                 'data' => [
                     ['id' => 'page_2', 'name' => 'Second'],
                 ],
+                'paging' => [
+                    'next' => $thirdUrl,
+                ],
+            ], 200)
+            ->push([
+                'data' => [
+                    ['id' => 'page_3', 'name' => 'Third'],
+                ],
             ], 200),
     ]);
 
     $pages = GraphPaginator::all("{$graphApi}/me/accounts", [
-        'access_token' => 'token',
+        'access_token' => 'secret-token',
         'fields' => 'id,name',
         'limit' => 100,
     ]);
 
-    expect($pages)->toHaveCount(2)
+    expect($pages)->toHaveCount(3)
         ->and(data_get($pages, '0.id'))->toBe('page_1')
-        ->and(data_get($pages, '1.id'))->toBe('page_2');
+        ->and(data_get($pages, '1.id'))->toBe('page_2')
+        ->and(data_get($pages, '2.id'))->toBe('page_3');
 
-    Http::assertSentCount(2);
+    Http::assertSentCount(3);
 });
 
 test('graph paginator collects authorized page when first response is empty', function () {
@@ -71,8 +108,48 @@ test('graph paginator collects authorized page when first response is empty', fu
         ->and(data_get($pages, '0.id'))->toBe('page_desired');
 });
 
+test('graph paginator keeps earlier pages when a later request fails', function () {
+    Http::preventStrayRequests();
+
+    $graphApi = 'https://graph.facebook.com/v25.0';
+    $nextUrl = "{$graphApi}/me/accounts?access_token=secret-token&after=cursor1&limit=100";
+
+    Log::shouldReceive('error')->once()->withArgs(function (string $message, array $context) {
+        return $message === 'Meta Graph pagination request failed'
+            && ! str_contains((string) data_get($context, 'url'), 'secret-token')
+            && str_contains((string) data_get($context, 'url'), 'access_token=[REDACTED]');
+    });
+
+    Http::fake([
+        "{$graphApi}/me/accounts*" => Http::sequence()
+            ->push([
+                'data' => [
+                    ['id' => 'page_1', 'name' => 'First'],
+                ],
+                'paging' => [
+                    'next' => $nextUrl,
+                ],
+            ], 200)
+            ->push(['error' => ['message' => 'rate limit']], 400),
+    ]);
+
+    $pages = GraphPaginator::all("{$graphApi}/me/accounts", [
+        'access_token' => 'secret-token',
+        'limit' => 100,
+    ]);
+
+    expect($pages)->toHaveCount(1)
+        ->and(data_get($pages, '0.id'))->toBe('page_1');
+
+    Http::assertSentCount(2);
+});
+
 test('graph paginator returns empty array when the first request fails', function () {
     Http::preventStrayRequests();
+
+    Log::shouldReceive('error')->once()->withArgs(function (string $message) {
+        return $message === 'Meta Graph pagination request failed';
+    });
 
     Http::fake([
         'https://graph.facebook.com/v25.0/me/accounts*' => Http::response(['error' => ['message' => 'fail']], 400),
@@ -85,11 +162,41 @@ test('graph paginator returns empty array when the first request fails', functio
     expect($pages)->toBe([]);
 });
 
+test('graph paginator stops when paging.next is not a usable string', function () {
+    Http::preventStrayRequests();
+
+    $graphApi = 'https://graph.facebook.com/v25.0';
+
+    Http::fake([
+        "{$graphApi}/me/accounts*" => Http::response([
+            'data' => [
+                ['id' => 'page_1'],
+            ],
+            'paging' => [
+                'next' => ['broken' => true],
+            ],
+        ], 200),
+    ]);
+
+    $pages = GraphPaginator::all("{$graphApi}/me/accounts", [
+        'access_token' => 'token',
+    ]);
+
+    expect($pages)->toHaveCount(1);
+    Http::assertSentCount(1);
+});
+
 test('graph paginator stops when paging.next repeats to avoid infinite loops', function () {
     Http::preventStrayRequests();
 
     $graphApi = 'https://graph.facebook.com/v25.0';
-    $loopUrl = "{$graphApi}/me/accounts?access_token=token&after=cursor&limit=100";
+    $loopUrl = "{$graphApi}/me/accounts?access_token=secret-token&after=cursor&limit=100";
+
+    Log::shouldReceive('warning')->once()->withArgs(function (string $message, array $context) {
+        return $message === 'Meta Graph pagination stopped: repeated paging URL'
+            && ! str_contains((string) data_get($context, 'url'), 'secret-token')
+            && str_contains((string) data_get($context, 'url'), 'access_token=[REDACTED]');
+    });
 
     Http::fake([
         "{$graphApi}/me/accounts*" => Http::sequence()


### PR DESCRIPTION
## Summary
- Paginate Meta Graph `/me/accounts` via a shared `GraphPaginator` so we follow `paging.next` instead of only reading the first API page.
- Apply the same fix to **Facebook** and **Instagram via Facebook** connect flows.
- Fixes the reported cases: “all pages” connecting only the first Page without a picker, and “specific non-first Page” failing with “No Facebook Pages found”.

Fixes #212

## Test plan
- [x] Unit tests for `GraphPaginator` (multi-page, empty-first-page, failure, max-pages cap)
- [x] Feature tests: Facebook callback shows picker across paginated results
- [x] Feature tests: Facebook connects when the first `/me/accounts` page is empty
- [x] Feature tests: Instagram-via-Facebook callback equivalent cases
- [ ] Manual: connect Facebook with “Enable all pages” and confirm the page picker lists every authorized Page
- [ ] Manual: connect Facebook selecting a non-first specific Page and confirm it connects
- [ ] Manual: same for Instagram via Facebook when multiple Pages have IG Business accounts


Made with [Cursor](https://cursor.com)