### PR TITLE
fix: eager-load workspace.account in SocialAccountObserver to prevent lazy loading crash

### DIFF
--- a/app/Jobs/VerifyUpcomingPostConnections.php
+++ b/app/Jobs/VerifyUpcomingPostConnections.php
@@ -335,9 +335,9 @@ class VerifyUpcomingPostConnections implements ShouldBeUnique, ShouldQueue
             // socialAccount.workspace is eager-loaded even though this job
             // never reads it directly — SocialAccountObserver::notifyOnboarding()
             // (fired by the ->update() calls below via markAsTokenExpired())
-            // accesses $account->workspace, and lazy loading is disabled
-            // app-wide. Dropping this eager load throws LazyLoadingViolationException
-            // the moment a second account in the same run gets updated (see #255).
+            // reads $account->workspace. The observer self-heals with
+            // loadMissing() (see #255), but without this eager load every
+            // account in the batch triggers its own extra query there.
             ->with(['socialAccount.workspace', 'post'])
             ->get();
     }

--- a/app/Observers/SocialAccountObserver.php
+++ b/app/Observers/SocialAccountObserver.php
@@ -76,6 +76,8 @@ class SocialAccountObserver
      */
     private function notifyOnboarding(SocialAccount $socialAccount): void
     {
+        $socialAccount->loadMissing('workspace.account');
+
         $account = $socialAccount->workspace?->account;
 
         if (! $account?->isOnboardingOpen()) {

--- a/tests/Feature/Observers/SocialAccountObserverTest.php
+++ b/tests/Feature/Observers/SocialAccountObserverTest.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use App\Enums\SocialAccount\Status;
 use App\Jobs\PostHog\SyncAccountUsage;
 use App\Models\Account;
 use App\Models\SocialAccount;
@@ -64,3 +65,18 @@ test('does not dispatch when PostHog is disabled', function () {
 
     Bus::assertNotDispatched(SyncAccountUsage::class);
 });
+
+test('updating status on multiple batch-hydrated social accounts does not throw a lazy loading violation', function () {
+    $accounts = SocialAccount::factory()->count(2)->create([
+        'workspace_id' => $this->workspace->id,
+        'status' => Status::Connected,
+    ]);
+
+    $batch = SocialAccount::query()
+        ->whereIn('id', $accounts->pluck('id'))
+        ->get();
+
+    foreach ($batch as $socialAccount) {
+        $socialAccount->update(['status' => Status::Disconnected]);
+    }
+})->throwsNoExceptions();


### PR DESCRIPTION
## Summary
- `SocialAccountObserver::notifyOnboarding()` read `$socialAccount->workspace?->account` without eager-loading `workspace`, which lazy-load-strict mode rejects once `Builder::hydrate()` batches 2+ distinct `SocialAccount` rows in the same query (only then does it flip `preventsLazyLoading` on the models).
- Fixed at the source: `notifyOnboarding()` now calls `$socialAccount->loadMissing('workspace.account')` before touching the relation, so no caller needs to remember to eager-load it.
- Added a regression test that hydrates 2 `SocialAccount` rows in one query and updates each — reproduces `LazyLoadingViolationException` before the fix, passes after.

Closes #255

## Test plan
- [x] `php artisan test --compact tests/Feature/Observers/SocialAccountObserverTest.php` — 5 passed
- [x] `php artisan test --compact --parallel --filter="Observers|VerifyUpcomingPostConnections"` — 48 passed
- [x] `vendor/bin/pint --dirty --format agent` — clean