### PR TITLE
fix: guard ContentTypeMatchesPlatform against non-uuid social_account_id

### DIFF
--- a/app/Rules/ContentTypeMatchesPlatform.php
+++ b/app/Rules/ContentTypeMatchesPlatform.php
@@ -40,7 +40,7 @@ class ContentTypeMatchesPlatform implements DataAwareRule, ValidationRule
         $parentKey = Str::beforeLast($attribute, '.');
         $accountId = data_get($this->data, $parentKey.'.social_account_id');
 
-        if (! $accountId) {
+        if (! $accountId || ! Str::isUuid((string) $accountId)) {
             return;
         }
 

--- a/tests/Unit/Rules/ContentTypeMatchesPlatformTest.php
+++ b/tests/Unit/Rules/ContentTypeMatchesPlatformTest.php
@@ -67,6 +67,14 @@ test('skips validation when social_account_id is missing', function () {
     expect(runMatchesPlatformRule(ContentType::XPost->value, null))->toBe([]);
 });
 
+test('skips validation without querying the database when social_account_id is not a uuid', function () {
+    // Regression: a non-uuid social_account_id (e.g. an MCP client sending a
+    // placeholder string) must not reach SocialAccount::find(), which throws
+    // a QueryException on Postgres for invalid uuid input instead of
+    // returning no rows.
+    expect(runMatchesPlatformRule(ContentType::XPost->value, 'threads-account'))->toBe([]);
+});
+
 test('skips validation when content_type is not a known enum value', function () {
     $workspace = Workspace::factory()->create();
     $linkedin = SocialAccount::factory()->create([


### PR DESCRIPTION
## Summary
- `App\Rules\ContentTypeMatchesPlatform` fetched the sibling `social_account_id` and passed it straight to `SocialAccount::find()` without checking it was a valid UUID.
- On Postgres, an invalid uuid literal (e.g. `"threads-account"`, sent by an MCP client) throws `QueryException: 22P02 invalid input syntax for type uuid` instead of failing validation normally — reported via Nightwatch from `POST /mcp/trypost`.
- Now guards with `Str::isUuid()` before querying; a non-uuid value is left for the sibling `uuid` rule on `platforms.*.social_account_id` to report.

## Test plan
- [x] `php artisan test --compact --filter=ContentTypeMatchesPlatformTest` (6 passed, new regression test reproduces the crash against local Postgres without the fix)
- [x] `php artisan test --compact --filter=PostToolTest` (32 passed)
- [x] `vendor/bin/pint --dirty --format agent`