### PR TITLE
fix: stop reporting client-error OAuth exceptions to Nightwatch

### DIFF
--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -11,6 +11,7 @@ use Illuminate\Foundation\Configuration\Exceptions;
 use Illuminate\Foundation\Configuration\Middleware;
 use Illuminate\Http\Middleware\AddLinkHeadersForPreloadedAssets;
 use Illuminate\Http\Request;
+use League\OAuth2\Server\Exception\OAuthServerException;
 use Symfony\Component\HttpKernel\Exception\TooManyRequestsHttpException;
 
 return Application::configure(basePath: dirname(__DIR__))
@@ -44,6 +45,10 @@ return Application::configure(basePath: dirname(__DIR__))
         ]);
     })
     ->withExceptions(function (Exceptions $exceptions): void {
+        $exceptions->dontReportWhen(function (Throwable $e) {
+            return $e instanceof OAuthServerException && $e->getHttpStatusCode() < 500;
+        });
+
         $exceptions->renderable(function (TooManyRequestsHttpException $e, Request $request) {
             if ($request->expectsJson()) {
                 $retryAfter = $e->getHeaders()['Retry-After'] ?? null;

--- a/tests/Feature/Passport/OAuthServerExceptionReportingTest.php
+++ b/tests/Feature/Passport/OAuthServerExceptionReportingTest.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Contracts\Debug\ExceptionHandler;
+use League\OAuth2\Server\Exception\OAuthServerException;
+
+test('client-error oauth exceptions are not reported', function () {
+    $handler = app(ExceptionHandler::class);
+
+    expect($handler->shouldReport(OAuthServerException::accessDenied()))->toBeFalse()
+        ->and($handler->shouldReport(OAuthServerException::invalidGrant()))->toBeFalse()
+        ->and($handler->shouldReport(OAuthServerException::invalidRequest('grant_type')))->toBeFalse();
+});
+
+test('server-error oauth exceptions are still reported', function () {
+    $handler = app(ExceptionHandler::class);
+
+    expect($handler->shouldReport(OAuthServerException::serverError('unexpected failure')))->toBeTrue();
+});
+
+test('unrelated exceptions are unaffected', function () {
+    $handler = app(ExceptionHandler::class);
+
+    expect($handler->shouldReport(new RuntimeException('boom')))->toBeTrue();
+});


### PR DESCRIPTION
## Summary
- Passport's `TokenGuard` explicitly calls `report()` on every failed bearer-token check (`League\OAuth2\Server\Exception\OAuthServerException`), including plain 401s from invalid/expired/missing tokens. This was flooding Nightwatch with alerts for bot/scanner traffic hitting the public MCP endpoint, and applies equally to the public REST API.
- Added `dontReportWhen` in `bootstrap/app.php` to ignore `OAuthServerException` with `getHttpStatusCode() < 500` — i.e. client errors (401/400/etc.), consistent with how Laravel already treats `AuthenticationException`/`AuthorizationException`/`ValidationException` by default. Genuine `server_error` (500) responses are still reported.

## Test plan
- [x] `tests/Feature/Passport/OAuthServerExceptionReportingTest.php` — asserts client-error variants (`accessDenied`, `invalidGrant`, `invalidRequest`) are not reported, `serverError` (500) is still reported, and unrelated exceptions are unaffected.
- [x] `vendor/bin/pint --dirty --format agent`
- [x] `php artisan test --compact --filter=Passport` and `tests/Feature/Mcp` (179 tests passing)