### PR TITLE
fix: LinkedIn company page post URL missing the post ID

### DIFF
--- a/app/Console/Commands/BackfillLinkedInPagePostUrls.php
+++ b/app/Console/Commands/BackfillLinkedInPagePostUrls.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use App\Enums\PostPlatform\Status;
+use App\Enums\SocialAccount\Platform;
+use App\Models\PostPlatform;
+use Illuminate\Console\Command;
+
+/**
+ * One-time repair for LinkedIn Page posts published before the fix for
+ * https://github.com/trypostit/trypost/issues/271 — LinkedInPagePublisher::postUrl()
+ * built "company/{username}/posts/" without appending the post ID, so those rows
+ * had that broken, unusable URL persisted to platform_url.
+ */
+class BackfillLinkedInPagePostUrls extends Command
+{
+    protected $signature = 'social:backfill-linkedin-page-post-urls {--dry-run : Preview affected rows without writing changes}';
+
+    protected $description = 'Recompute platform_url for LinkedIn Page posts published with the pre-fix company/{username}/posts/ URL (issue #271)';
+
+    public function handle(): void
+    {
+        $dryRun = (bool) $this->option('dry-run');
+        $count = 0;
+
+        PostPlatform::query()
+            ->where('platform', Platform::LinkedInPage)
+            ->where('status', Status::Published)
+            ->whereNotNull('platform_post_id')
+            ->where('platform_url', 'like', 'https://www.linkedin.com/company/%/posts/')
+            ->each(function (PostPlatform $postPlatform) use ($dryRun, &$count) {
+                $correctedUrl = "https://www.linkedin.com/feed/update/{$postPlatform->platform_post_id}";
+
+                $this->line("{$postPlatform->id}: {$postPlatform->platform_url} -> {$correctedUrl}");
+
+                if (! $dryRun) {
+                    $postPlatform->update(['platform_url' => $correctedUrl]);
+                }
+
+                $count++;
+            });
+
+        $verb = $dryRun ? 'Would fix' : 'Fixed';
+        $this->info("{$verb} {$count} LinkedIn Page post URL(s).");
+    }
+}

--- a/app/Services/Social/AbstractLinkedInPublisher.php
+++ b/app/Services/Social/AbstractLinkedInPublisher.php
@@ -47,8 +47,10 @@ abstract class AbstractLinkedInPublisher
     abstract protected function authorUrn(): string;
 
     /**
-     * Public URL of the created post. Defaults to the member feed update;
-     * company pages override it.
+     * Public URL of the created post. Per LinkedIn's Posts API docs, the
+     * feed/update permalink applies to any published post regardless of
+     * whether the author is a member or an organization, so subclasses
+     * (member vs. company page) share this implementation.
      */
     protected function postUrl(?string $postId): ?string
     {

--- a/app/Services/Social/LinkedInPagePublisher.php
+++ b/app/Services/Social/LinkedInPagePublisher.php
@@ -31,15 +31,4 @@ class LinkedInPagePublisher extends AbstractLinkedInPublisher
 
         return "urn:li:organization:{$organizationId}";
     }
-
-    protected function postUrl(?string $postId): ?string
-    {
-        if (! $postId) {
-            return null;
-        }
-
-        return $this->account->username
-            ? "https://www.linkedin.com/company/{$this->account->username}/posts/"
-            : "https://www.linkedin.com/feed/update/{$postId}";
-    }
 }

--- a/tests/Feature/Commands/BackfillLinkedInPagePostUrlsTest.php
+++ b/tests/Feature/Commands/BackfillLinkedInPagePostUrlsTest.php
@@ -1,0 +1,103 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Enums\PostPlatform\Status;
+use App\Enums\SocialAccount\Platform;
+use App\Models\Post;
+use App\Models\PostPlatform;
+use App\Models\SocialAccount;
+use App\Models\User;
+use App\Models\Workspace;
+
+beforeEach(function () {
+    $this->user = User::factory()->create();
+    $this->workspace = Workspace::factory()->create(['user_id' => $this->user->id]);
+    $this->socialAccount = SocialAccount::factory()->linkedinPage()->create([
+        'workspace_id' => $this->workspace->id,
+        'username' => 'testcompany',
+    ]);
+    $this->post = Post::factory()->create([
+        'workspace_id' => $this->workspace->id,
+        'user_id' => $this->user->id,
+    ]);
+});
+
+test('it corrects broken linkedin page post urls', function () {
+    $broken = PostPlatform::factory()->published()->create([
+        'post_id' => $this->post->id,
+        'social_account_id' => $this->socialAccount->id,
+        'platform' => Platform::LinkedInPage,
+        'platform_post_id' => 'urn:li:share:1234567890',
+        'platform_url' => 'https://www.linkedin.com/company/testcompany/posts/',
+    ]);
+
+    $this->artisan('social:backfill-linkedin-page-post-urls')->assertSuccessful();
+
+    $broken->refresh();
+    expect($broken->platform_url)->toBe('https://www.linkedin.com/feed/update/urn:li:share:1234567890');
+});
+
+test('it leaves already-correct linkedin page urls untouched', function () {
+    $correct = PostPlatform::factory()->published()->create([
+        'post_id' => $this->post->id,
+        'social_account_id' => $this->socialAccount->id,
+        'platform' => Platform::LinkedInPage,
+        'platform_post_id' => 'urn:li:share:1234567890',
+        'platform_url' => 'https://www.linkedin.com/feed/update/urn:li:share:1234567890',
+    ]);
+
+    $this->artisan('social:backfill-linkedin-page-post-urls')->assertSuccessful();
+
+    $correct->refresh();
+    expect($correct->platform_url)->toBe('https://www.linkedin.com/feed/update/urn:li:share:1234567890');
+});
+
+test('it does not touch other platforms with a similarly shaped url', function () {
+    $other = PostPlatform::factory()->published()->create([
+        'post_id' => $this->post->id,
+        'social_account_id' => SocialAccount::factory()->create([
+            'workspace_id' => $this->workspace->id,
+            'platform' => Platform::LinkedIn,
+        ]),
+        'platform' => Platform::LinkedIn,
+        'platform_post_id' => 'urn:li:share:9999999999',
+        'platform_url' => 'https://www.linkedin.com/company/testcompany/posts/',
+    ]);
+
+    $this->artisan('social:backfill-linkedin-page-post-urls')->assertSuccessful();
+
+    $other->refresh();
+    expect($other->platform_url)->toBe('https://www.linkedin.com/company/testcompany/posts/');
+});
+
+test('dry run previews without writing changes', function () {
+    $broken = PostPlatform::factory()->published()->create([
+        'post_id' => $this->post->id,
+        'social_account_id' => $this->socialAccount->id,
+        'platform' => Platform::LinkedInPage,
+        'platform_post_id' => 'urn:li:share:1234567890',
+        'platform_url' => 'https://www.linkedin.com/company/testcompany/posts/',
+    ]);
+
+    $this->artisan('social:backfill-linkedin-page-post-urls', ['--dry-run' => true])->assertSuccessful();
+
+    $broken->refresh();
+    expect($broken->platform_url)->toBe('https://www.linkedin.com/company/testcompany/posts/');
+});
+
+test('it ignores linkedin page rows that are not published', function () {
+    $failed = PostPlatform::factory()->create([
+        'post_id' => $this->post->id,
+        'social_account_id' => $this->socialAccount->id,
+        'platform' => Platform::LinkedInPage,
+        'status' => Status::Failed,
+        'platform_post_id' => 'urn:li:share:1234567890',
+        'platform_url' => 'https://www.linkedin.com/company/testcompany/posts/',
+    ]);
+
+    $this->artisan('social:backfill-linkedin-page-post-urls')->assertSuccessful();
+
+    $failed->refresh();
+    expect($failed->platform_url)->toBe('https://www.linkedin.com/company/testcompany/posts/');
+});

--- a/tests/Feature/Services/Social/LinkedInPagePublisherTest.php
+++ b/tests/Feature/Services/Social/LinkedInPagePublisherTest.php
@@ -203,20 +203,8 @@ test('linkedin page publisher handles empty content', function () {
     });
 });
 
-test('linkedin page publisher builds feed url with post id when username present', function () {
-    Http::fake([
-        config('trypost.platforms.linkedin-page.api').'/rest/posts' => Http::response(null, 201, [
-            'x-restli-id' => 'urn:li:share:1234567890',
-        ]),
-    ]);
-
-    $result = $this->publisher->publish($this->postPlatform);
-
-    expect($result['url'])->toBe('https://www.linkedin.com/feed/update/urn:li:share:1234567890');
-});
-
-test('linkedin page publisher builds feed url when username missing', function () {
-    $this->socialAccount->update(['username' => null]);
+test('linkedin page publisher builds feed url from the post id regardless of username', function (?string $username) {
+    $this->socialAccount->update(['username' => $username]);
 
     Http::fake([
         config('trypost.platforms.linkedin-page.api').'/rest/posts' => Http::response(null, 201, [
@@ -227,6 +215,19 @@ test('linkedin page publisher builds feed url when username missing', function (
     $result = $this->publisher->publish($this->postPlatform);
 
     expect($result['url'])->toBe('https://www.linkedin.com/feed/update/urn:li:share:1234567890');
+})->with([
+    'username present' => ['testcompany'],
+    'username missing' => [null],
+]);
+
+test('linkedin page publisher returns a null url when the response has no post id', function () {
+    Http::fake([
+        config('trypost.platforms.linkedin-page.api').'/rest/posts' => Http::response(null, 201),
+    ]);
+
+    $result = $this->publisher->publish($this->postPlatform);
+
+    expect($result['url'])->toBeNull();
 });
 
 test('linkedin page publisher can publish post with image using organization urn', function () {
@@ -271,6 +272,7 @@ test('linkedin page publisher can publish post with image using organization urn
     $result = $this->publisher->publish($this->postPlatform);
 
     expect($result['id'])->toBe('urn:li:share:9999999999');
+    expect($result['url'])->toBe('https://www.linkedin.com/feed/update/urn:li:share:9999999999');
 
     Http::assertSent(fn ($request) => str_contains($request->url(), '/rest/images'));
 
@@ -319,6 +321,7 @@ test('linkedin page publisher publishes a multi-image carousel with image ids un
     $result = $this->publisher->publish($this->postPlatform);
 
     expect($result['id'])->toBe('urn:li:share:orgcarousel');
+    expect($result['url'])->toBe('https://www.linkedin.com/feed/update/urn:li:share:orgcarousel');
 
     // Org carousel must author as the organization and send image URNs under `id` (not `media`).
     Http::assertSent(function ($request) {

--- a/tests/Feature/Services/Social/LinkedInPagePublisherTest.php
+++ b/tests/Feature/Services/Social/LinkedInPagePublisherTest.php
@@ -57,7 +57,7 @@ test('linkedin page publisher can publish text-only post', function () {
     expect($result)->toHaveKey('id');
     expect($result)->toHaveKey('url');
     expect($result['id'])->toBe('urn:li:share:1234567890');
-    expect($result['url'])->toContain('linkedin.com/company/testcompany/posts/');
+    expect($result['url'])->toBe('https://www.linkedin.com/feed/update/urn:li:share:1234567890');
 
     Http::assertSent(function ($request) {
         return str_contains($request->url(), '/rest/posts')
@@ -203,7 +203,7 @@ test('linkedin page publisher handles empty content', function () {
     });
 });
 
-test('linkedin page publisher builds correct company url when username present', function () {
+test('linkedin page publisher builds feed url with post id when username present', function () {
     Http::fake([
         config('trypost.platforms.linkedin-page.api').'/rest/posts' => Http::response(null, 201, [
             'x-restli-id' => 'urn:li:share:1234567890',
@@ -212,7 +212,7 @@ test('linkedin page publisher builds correct company url when username present',
 
     $result = $this->publisher->publish($this->postPlatform);
 
-    expect($result['url'])->toContain('linkedin.com/company/testcompany/posts/');
+    expect($result['url'])->toBe('https://www.linkedin.com/feed/update/urn:li:share:1234567890');
 });
 
 test('linkedin page publisher builds feed url when username missing', function () {
@@ -226,7 +226,7 @@ test('linkedin page publisher builds feed url when username missing', function (
 
     $result = $this->publisher->publish($this->postPlatform);
 
-    expect($result['url'])->toContain('linkedin.com/feed/update/urn:li:share:1234567890');
+    expect($result['url'])->toBe('https://www.linkedin.com/feed/update/urn:li:share:1234567890');
 });
 
 test('linkedin page publisher can publish post with image using organization urn', function () {
@@ -385,7 +385,7 @@ test('linkedin page publisher can publish a document (pdf carousel) using organi
     $result = $this->publisher->publish($this->postPlatform);
 
     expect($result['id'])->toBe('urn:li:share:orgdoc999');
-    expect($result['url'])->toContain('linkedin.com/company/testcompany/posts/');
+    expect($result['url'])->toBe('https://www.linkedin.com/feed/update/urn:li:share:orgdoc999');
 
     Http::assertSent(fn ($request) => str_contains($request->url(), '/rest/documents') && str_contains($request->url(), 'initializeUpload'));
     Http::assertSent(function ($request) {


### PR DESCRIPTION
## Summary
- `LinkedInPagePublisher::postUrl()` built `https://www.linkedin.com/company/{username}/posts/` but never interpolated `$postId` into it, so the "view on LinkedIn" link for company page posts always ended at the trailing slash (member posts were unaffected — they use the base class's default).
- Confirmed against LinkedIn's Posts API docs: the correct public URL for any published post (member or organization) is always `https://www.linkedin.com/feed/update/{postId}` — there's no documented `company/{username}/posts/{id}` format. The buggy override is removed so `LinkedInPagePublisher` now inherits the correct implementation from `AbstractLinkedInPublisher`.
- Added `php artisan social:backfill-linkedin-page-post-urls` (`--dry-run` supported) to repair `platform_url` on LinkedIn Page posts that were already published before this fix — those rows had the broken URL persisted and are never recomputed otherwise. **Needs to run once in production after deploy.**
- Fixed a stale docblock on `AbstractLinkedInPublisher::postUrl()` that still claimed company pages override it.

## Test coverage
- `LinkedInPagePublisherTest`: text, document, image, and carousel publish paths now all assert the corrected `result['url']` (previously only the document/text tests checked it, and only via a loose `toContain`). Added a dataset test proving the URL no longer depends on `username`, and a case for a missing `x-restli-id` (null post id → null url).
- `BackfillLinkedInPagePostUrlsTest`: covers the broken-URL row getting corrected, an already-correct row being left untouched (idempotent), a non-LinkedIn-Page row with a similarly-shaped URL being ignored, `--dry-run` not writing, and non-published rows being skipped.

## Test plan
- [x] `php artisan test --compact tests/Feature/Services/Social/LinkedInPagePublisherTest.php tests/Feature/Services/Social/LinkedInPublisherTest.php tests/Feature/Commands/BackfillLinkedInPagePostUrlsTest.php` — 59 passed
- [x] `vendor/bin/pint --dirty --format agent` — passed
- [ ] After deploy: run `php artisan social:backfill-linkedin-page-post-urls --dry-run` in production to preview, then without `--dry-run` to apply.

Closes #271