### PR TITLE
fix: classify Pinterest content-policy rejections (code 1) instead of surfacing raw JSON

### DIFF
--- a/app/Exceptions/Social/PinterestPublishException.php
+++ b/app/Exceptions/Social/PinterestPublishException.php
@@ -41,6 +41,18 @@ class PinterestPublishException extends SocialPublishException
             );
         }
 
+        // Pinterest's own JSON error code 1 ("Sorry! This site doesn't allow
+        // you to save Pins.") is a content-policy rejection reused from their
+        // legacy "nopin" crawler-block message, not an HTTP/technical error.
+        if ($status === 400 && (int) data_get($body, 'code') === 1) {
+            return new static(
+                userMessage: "Pinterest rejected this pin. This usually means the content violates Pinterest's content policies (e.g. adult or sexual content).",
+                category: ErrorCategory::ContentPolicy,
+                platformErrorCode: (string) $status,
+                rawResponse: $rawResponse,
+            );
+        }
+
         if ($status === 400 && str_contains(strtolower($rawResponse), 'board')) {
             return new static(
                 userMessage: 'Invalid board. Please select a valid board.',

--- a/app/Exceptions/Social/PinterestPublishException.php
+++ b/app/Exceptions/Social/PinterestPublishException.php
@@ -41,6 +41,20 @@ class PinterestPublishException extends SocialPublishException
             );
         }
 
+        // Documented for /pins, /media, and /boards alike (Pinterest's public
+        // OpenAPI spec: github.com/pinterest/api-description). In our flows
+        // this means the board (or, when polling media status, the media
+        // upload) referenced by the request no longer exists or isn't
+        // accessible to this account.
+        if ($status === 404) {
+            return new static(
+                userMessage: 'Pinterest could not find the selected board. It may have been deleted or you no longer have access to it.',
+                category: ErrorCategory::ContentPolicy,
+                platformErrorCode: (string) $status,
+                rawResponse: $rawResponse,
+            );
+        }
+
         // Pinterest's own JSON error code 1 ("Sorry! This site doesn't allow
         // you to save Pins.") is a content-policy rejection reused from their
         // legacy "nopin" crawler-block message, not an HTTP/technical error.

--- a/tests/Unit/Exceptions/Social/PinterestPublishExceptionTest.php
+++ b/tests/Unit/Exceptions/Social/PinterestPublishExceptionTest.php
@@ -34,6 +34,16 @@ test('HTTP 403 maps to Permission category', function () {
         ->and($exception->userMessage)->toBe('Not authorized to create pins on this board.');
 });
 
+test('HTTP 404 maps to ContentPolicy category', function () {
+    $response = Http::response(['code' => 2, 'message' => 'Board not found.'], 404);
+    $fakeResponse = Http::fake(['*' => $response])->post('https://api.pinterest.com/test');
+
+    $exception = PinterestPublishException::fromApiResponse($fakeResponse);
+
+    expect($exception->category)->toBe(ErrorCategory::ContentPolicy)
+        ->and($exception->userMessage)->toBe('Pinterest could not find the selected board. It may have been deleted or you no longer have access to it.');
+});
+
 test('HTTP 400 with Pinterest error code 1 maps to ContentPolicy category', function () {
     $response = Http::response(['code' => 1, 'message' => "Sorry! This site doesn't allow you to save Pins."], 400);
     $fakeResponse = Http::fake(['*' => $response])->post('https://api.pinterest.com/test');

--- a/tests/Unit/Exceptions/Social/PinterestPublishExceptionTest.php
+++ b/tests/Unit/Exceptions/Social/PinterestPublishExceptionTest.php
@@ -34,6 +34,16 @@ test('HTTP 403 maps to Permission category', function () {
         ->and($exception->userMessage)->toBe('Not authorized to create pins on this board.');
 });
 
+test('HTTP 400 with Pinterest error code 1 maps to ContentPolicy category', function () {
+    $response = Http::response(['code' => 1, 'message' => "Sorry! This site doesn't allow you to save Pins."], 400);
+    $fakeResponse = Http::fake(['*' => $response])->post('https://api.pinterest.com/test');
+
+    $exception = PinterestPublishException::fromApiResponse($fakeResponse);
+
+    expect($exception->category)->toBe(ErrorCategory::ContentPolicy)
+        ->and($exception->userMessage)->toBe("Pinterest rejected this pin. This usually means the content violates Pinterest's content policies (e.g. adult or sexual content).");
+});
+
 test('HTTP 400 with board in body maps to ContentPolicy category', function () {
     $response = Http::response(['message' => 'Invalid board_id provided.'], 400);
     $fakeResponse = Http::fake(['*' => $response])->post('https://api.pinterest.com/test');


### PR DESCRIPTION
## Summary
- A client's video pin failed with Pinterest's `{"code":1,"message":"Sorry! This site doesn't allow you to save Pins."}` — a content-policy rejection from Pinterest, not a technical/domain issue on our side.
- `PinterestPublishException::fromApiResponse()` only branched on HTTP status, so this fell into the generic `Unknown` category and dumped the raw Pinterest JSON as the user-facing error message.
- Added an explicit branch that detects Pinterest's JSON `code: 1` and classifies it as `ErrorCategory::ContentPolicy` with a clear, friendly message.
- Reviewed Pinterest's official v5 OpenAPI spec (`github.com/pinterest/api-description`) for other unmapped cases: Pinterest doesn't publish a code catalog beyond the generic `{code, message}` error envelope, but `/pins`, `/media`, and `/boards` all document `404` as a possible response, which we didn't handle at all (fell into `Unknown`). Added a `404 -> ContentPolicy` branch (board/media not found or no longer accessible).

## Test plan
- [x] `php artisan test --compact tests/Unit/Exceptions/Social/PinterestPublishExceptionTest.php tests/Feature/Services/Social/PinterestPublisherTest.php` — 48 passed
- [x] `vendor/bin/pint --dirty --format agent` — passed