### PR TITLE
fix: API/MCP returns raw translation key when editing a finalized post

### DIFF
--- a/app/Support/PostStatusRules.php
+++ b/app/Support/PostStatusRules.php
@@ -14,7 +14,7 @@ use Illuminate\Validation\Rule;
  */
 class PostStatusRules
 {
-    private const EDIT_BLOCKED_MESSAGE_KEY = 'posts.cannot_edit_finalized';
+    private const EDIT_BLOCKED_MESSAGE_KEY = 'posts.flash.cannot_edit_finalized';
 
     /**
      * Statuses where the post can no longer be edited.

--- a/tests/Feature/Mcp/PostPublishToolTest.php
+++ b/tests/Feature/Mcp/PostPublishToolTest.php
@@ -116,7 +116,9 @@ test('update post rejects posts in any terminal state', function (PostStatus $st
     $response = TryPostServer::actingAs($this->user)
         ->tool(UpdatePostTool::class, ['post_id' => $post->id, 'content' => 'x']);
 
-    $response->assertHasErrors([__('posts.flash.cannot_edit_finalized')]);
+    $message = __('posts.flash.cannot_edit_finalized');
+    expect($message)->not->toBe('posts.flash.cannot_edit_finalized');
+    $response->assertHasErrors([$message]);
 })->with([
     PostStatus::Published,
     PostStatus::PartiallyPublished,
@@ -280,7 +282,9 @@ test('publish post rejects posts already in a terminal state', function (PostSta
     $response = TryPostServer::actingAs($this->user)
         ->tool(PublishPostTool::class, ['post_id' => $post->id]);
 
-    $response->assertHasErrors([__('posts.flash.cannot_edit_finalized')]);
+    $message = __('posts.flash.cannot_edit_finalized');
+    expect($message)->not->toBe('posts.flash.cannot_edit_finalized');
+    $response->assertHasErrors([$message]);
 })->with([
     PostStatus::Published,
     PostStatus::PartiallyPublished,

--- a/tests/Feature/Mcp/PostPublishToolTest.php
+++ b/tests/Feature/Mcp/PostPublishToolTest.php
@@ -116,7 +116,7 @@ test('update post rejects posts in any terminal state', function (PostStatus $st
     $response = TryPostServer::actingAs($this->user)
         ->tool(UpdatePostTool::class, ['post_id' => $post->id, 'content' => 'x']);
 
-    $response->assertHasErrors([__('posts.cannot_edit_finalized')]);
+    $response->assertHasErrors([__('posts.flash.cannot_edit_finalized')]);
 })->with([
     PostStatus::Published,
     PostStatus::PartiallyPublished,
@@ -280,7 +280,7 @@ test('publish post rejects posts already in a terminal state', function (PostSta
     $response = TryPostServer::actingAs($this->user)
         ->tool(PublishPostTool::class, ['post_id' => $post->id]);
 
-    $response->assertHasErrors([__('posts.cannot_edit_finalized')]);
+    $response->assertHasErrors([__('posts.flash.cannot_edit_finalized')]);
 })->with([
     PostStatus::Published,
     PostStatus::PartiallyPublished,


### PR DESCRIPTION
## Summary

`PostStatusRules::editBlockedMessage()` referenced the translation key
`posts.cannot_edit_finalized`, which does not exist in `lang/*/posts.php`.
The string only exists under `posts.flash.cannot_edit_finalized`, which
the web UI (`PostController`) already uses correctly. The public API and
MCP tools (`UpdatePostTool`, `PublishPostTool`, `AttachExistingAssetTool`,
`AttachExistingAsset` action) went through `editBlockedMessage()` and
returned the raw, untranslated key instead of the human-readable message.

## Changes

- Point `PostStatusRules::EDIT_BLOCKED_MESSAGE_KEY` at
  `posts.flash.cannot_edit_finalized` so it resolves to the same string
  the web UI shows.
- Update the two assertions in `PostPublishToolTest` that hardcoded
  `__('posts.cannot_edit_finalized')` (which was just echoing back the
  same missing key, so they passed without verifying anything) to assert
  the corrected key instead.

## Test plan

- [x] `php artisan test --compact tests/Feature/Mcp/PostPublishToolTest.php tests/Feature/Mcp/AssetToolTest.php tests/Feature/Api/PostMediaApiTest.php` — 84 passed
- [x] `vendor/bin/pint --dirty --format agent` — passed

Closes #244