### PR TITLE
fix: prune orphaned chunked-upload temp files

### DIFF
--- a/app/Console/Commands/Media/PruneAbandonedChunks.php
+++ b/app/Console/Commands/Media/PruneAbandonedChunks.php
@@ -27,8 +27,17 @@ class PruneAbandonedChunks extends Command
         $pruned = 0;
 
         foreach (glob("{$directory}/*") ?: [] as $file) {
-            if (is_file($file) && filemtime($file) < $threshold) {
-                unlink($file);
+            if (! is_file($file)) {
+                continue;
+            }
+
+            $modifiedAt = @filemtime($file);
+
+            if ($modifiedAt === false || $modifiedAt >= $threshold) {
+                continue;
+            }
+
+            if (@unlink($file)) {
                 $pruned++;
             }
         }

--- a/app/Console/Commands/Media/PruneAbandonedChunks.php
+++ b/app/Console/Commands/Media/PruneAbandonedChunks.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands\Media;
+
+use App\Services\Media\ChunkedCloudUploader;
+use Illuminate\Console\Attributes\Description;
+use Illuminate\Console\Attributes\Signature;
+use Illuminate\Console\Command;
+
+#[Signature('chunks:prune')]
+#[Description('Delete orphaned chunked-upload temp files left behind by abandoned attempts')]
+class PruneAbandonedChunks extends Command
+{
+    public function handle(): int
+    {
+        $directory = storage_path('app/private/chunks');
+
+        if (! is_dir($directory)) {
+            $this->info('No chunk directory to prune.');
+
+            return self::SUCCESS;
+        }
+
+        $threshold = now()->subHours(ChunkedCloudUploader::CACHE_TTL_HOURS)->getTimestamp();
+        $pruned = 0;
+
+        foreach (glob("{$directory}/*") ?: [] as $file) {
+            if (is_file($file) && filemtime($file) < $threshold) {
+                unlink($file);
+                $pruned++;
+            }
+        }
+
+        $this->info("Pruned {$pruned} abandoned chunk file(s).");
+
+        return self::SUCCESS;
+    }
+}

--- a/app/Services/Media/ChunkedCloudUploader.php
+++ b/app/Services/Media/ChunkedCloudUploader.php
@@ -19,7 +19,7 @@ class ChunkedCloudUploader
 {
     private const CACHE_PREFIX = 'chunked-cloud-upload:';
 
-    private const CACHE_TTL_HOURS = 6;
+    public const CACHE_TTL_HOURS = 6;
 
     /** S3/R2 require every non-final multipart part to be at least 5 MiB. */
     public const MIN_PART_BYTES = 5 * 1024 * 1024;

--- a/routes/console.php
+++ b/routes/console.php
@@ -8,6 +8,7 @@ use App\Console\Commands\Automation\PruneDryRunAutomationRuns;
 use App\Console\Commands\Automation\RecoverStuckAutomationRuns;
 use App\Console\Commands\CheckSocialConnections;
 use App\Console\Commands\CheckUpcomingPostConnections;
+use App\Console\Commands\Media\PruneAbandonedChunks;
 use App\Console\Commands\ProcessScheduledPosts;
 use App\Console\Commands\RecoverStuckPosts;
 use App\Console\Commands\RefreshExpiringTokens;
@@ -22,3 +23,4 @@ Schedule::command(FireScheduleTriggers::class)->everyMinute()->withoutOverlappin
 Schedule::command(ProcessAutomationDelays::class)->everyMinute()->withoutOverlapping()->onOneServer();
 Schedule::command(RecoverStuckAutomationRuns::class)->everyFiveMinutes()->withoutOverlapping()->onOneServer();
 Schedule::command(PruneDryRunAutomationRuns::class)->everyTenMinutes()->withoutOverlapping()->onOneServer();
+Schedule::command(PruneAbandonedChunks::class)->hourly()->withoutOverlapping()->onOneServer();

--- a/tests/Feature/Media/Command/PruneAbandonedChunksTest.php
+++ b/tests/Feature/Media/Command/PruneAbandonedChunksTest.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Services\Media\ChunkedCloudUploader;
+
+beforeEach(function () {
+    $this->chunksDir = storage_path('app/private/chunks');
+
+    if (! is_dir($this->chunksDir)) {
+        mkdir($this->chunksDir, 0755, true);
+    }
+});
+
+afterEach(function () {
+    foreach (glob("{$this->chunksDir}/*") ?: [] as $file) {
+        @unlink($file);
+    }
+});
+
+test('command deletes chunk files older than the cache TTL', function () {
+    $old = "{$this->chunksDir}/old-attempt";
+    file_put_contents($old, 'partial-bytes');
+    touch($old, now()->subHours(ChunkedCloudUploader::CACHE_TTL_HOURS + 1)->getTimestamp());
+
+    $this->artisan('chunks:prune')->assertExitCode(0);
+
+    expect(file_exists($old))->toBeFalse();
+});
+
+test('command leaves recent chunk files alone', function () {
+    $recent = "{$this->chunksDir}/recent-attempt";
+    file_put_contents($recent, 'partial-bytes');
+    touch($recent, now()->subMinutes(10)->getTimestamp());
+
+    $this->artisan('chunks:prune')->assertExitCode(0);
+
+    expect(file_exists($recent))->toBeTrue();
+});
+
+test('command is a no-op when the chunks directory does not exist', function () {
+    foreach (glob("{$this->chunksDir}/*") ?: [] as $file) {
+        unlink($file);
+    }
+    rmdir($this->chunksDir);
+
+    $this->artisan('chunks:prune')->assertExitCode(0);
+
+    expect(is_dir($this->chunksDir))->toBeFalse();
+});


### PR DESCRIPTION
## Summary

PR #263 gave every chunked-upload attempt a unique server-side
identifier, fixing a collision bug but also meaning a retry no longer
implicitly cleans up an abandoned attempt's session. This PR addresses
the first item in the issue's scope: orphaned local temp files.

## Changes

- Widen `ChunkedCloudUploader::CACHE_TTL_HOURS` from `private` to
  `public` so it can be reused as the single source of truth for the
  abandoned-attempt window.
- Add `chunks:prune` (`App\Console\Commands\Media\PruneAbandonedChunks`)
  which deletes files in `storage/app/private/chunks/` older than
  `CACHE_TTL_HOURS` (6h).
- Schedule it hourly in `routes/console.php`, alongside the other
  scheduled maintenance commands.

## Out of scope (infra, not app code)

The issue's second item - an `AbortIncompleteMultipartUpload` lifecycle
rule on the production R2/S3 bucket(s) for the `medias/` prefix - is
bucket configuration outside this repo. Flagging it back on the issue
so it isn't lost.

## Test plan

- [x] New `tests/Feature/Media/Command/PruneAbandonedChunksTest.php` (3 tests): prunes files older than the TTL, leaves recent files alone, no-ops when the directory doesn't exist
- [x] `php artisan test --compact tests/Feature/Media/Command/PruneAbandonedChunksTest.php tests/Feature/ChunkedAssetReceiverTest.php tests/Feature/ChunkedCloudUploadTest.php tests/Feature/ChunkedUploadFilenameEncodingTest.php` - 48 passed
- [x] `vendor/bin/pint --dirty --format agent` - passed

Addresses #264 (app-code portion; bucket lifecycle rule still needed separately)