### PR TITLE
fix: scheduled prune for hosted social-media derivatives

### DIFF
--- a/app/Console/Commands/Social/PruneSocialMediaDerivatives.php
+++ b/app/Console/Commands/Social/PruneSocialMediaDerivatives.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands\Social;
+
+use App\Support\Social\SocialMediaDerivativeDirectory;
+use Illuminate\Console\Attributes\Description;
+use Illuminate\Console\Attributes\Signature;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Storage;
+
+#[Signature('social:prune-derivatives')]
+#[Description('Delete hosted social-media image derivatives (aspect-ratio crops, TikTok resized photos) once no platform still needs to pull them')]
+class PruneSocialMediaDerivatives extends Command
+{
+    private const MAX_AGE_HOURS = 1;
+
+    /**
+     * Every directory a publisher hosts a pull-from-URL derivative in. Add a
+     * new network's directory here - nowhere else - when it starts hosting
+     * derivatives a platform fetches asynchronously.
+     *
+     * @var list<string>
+     */
+    private const DIRECTORIES = [
+        SocialMediaDerivativeDirectory::CROPS,
+        SocialMediaDerivativeDirectory::TIKTOK_PHOTOS,
+    ];
+
+    public function handle(): int
+    {
+        $threshold = now()->subHours(self::MAX_AGE_HOURS)->getTimestamp();
+        $pruned = 0;
+
+        foreach (self::DIRECTORIES as $directory) {
+            foreach (Storage::files($directory) as $path) {
+                $modifiedAt = Storage::lastModified($path);
+
+                if ($modifiedAt !== false && $modifiedAt < $threshold && Storage::delete($path)) {
+                    $pruned++;
+                }
+            }
+        }
+
+        $this->info("Pruned {$pruned} social media derivative(s).");
+
+        return self::SUCCESS;
+    }
+}

--- a/app/Console/Commands/Social/PruneSocialMediaDerivatives.php
+++ b/app/Console/Commands/Social/PruneSocialMediaDerivatives.php
@@ -10,30 +10,19 @@ use Illuminate\Console\Attributes\Signature;
 use Illuminate\Console\Command;
 use Illuminate\Support\Facades\Storage;
 
-#[Signature('social:prune-derivatives')]
+#[Signature('social:prune-derivatives {--hours=1 : Delete derivatives older than this many hours}')]
 #[Description('Delete hosted social-media image derivatives (aspect-ratio crops, TikTok resized photos) once no platform still needs to pull them')]
 class PruneSocialMediaDerivatives extends Command
 {
-    private const MAX_AGE_HOURS = 1;
-
-    /**
-     * Every directory a publisher hosts a pull-from-URL derivative in. Add a
-     * new network's directory here - nowhere else - when it starts hosting
-     * derivatives a platform fetches asynchronously.
-     *
-     * @var list<string>
-     */
-    private const DIRECTORIES = [
-        SocialMediaDerivativeDirectory::CROPS,
-        SocialMediaDerivativeDirectory::TIKTOK_PHOTOS,
-    ];
+    private const int DEFAULT_MAX_AGE_HOURS = 1;
 
     public function handle(): int
     {
-        $threshold = now()->subHours(self::MAX_AGE_HOURS)->getTimestamp();
+        $hours = max(0, (int) ($this->option('hours') ?? self::DEFAULT_MAX_AGE_HOURS));
+        $threshold = now()->subHours($hours)->getTimestamp();
         $pruned = 0;
 
-        foreach (self::DIRECTORIES as $directory) {
+        foreach (SocialMediaDerivativeDirectory::ALL as $directory) {
             foreach (Storage::files($directory) as $path) {
                 $modifiedAt = Storage::lastModified($path);
 

--- a/app/Services/Social/Concerns/CropsImageForAspectRatio.php
+++ b/app/Services/Social/Concerns/CropsImageForAspectRatio.php
@@ -7,13 +7,14 @@ namespace App\Services\Social\Concerns;
 use App\Enums\PostPlatform\AspectRatio;
 use App\Exceptions\Social\SocialPublishException;
 use App\Services\Media\MediaOptimizer;
+use App\Support\Social\SocialMediaDerivativeDirectory;
 use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Storage;
 use Illuminate\Support\Str;
 
 trait CropsImageForAspectRatio
 {
-    private const CROP_DIRECTORY = 'social-crops';
+    private const string CROP_DIRECTORY = SocialMediaDerivativeDirectory::CROPS;
 
     /**
      * Crop the image to the user-selected aspect ratio and return a public URL

--- a/app/Support/Social/SocialMediaDerivativeDirectory.php
+++ b/app/Support/Social/SocialMediaDerivativeDirectory.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Support\Social;
+
+/**
+ * Directory name a publisher hosts a pull-from-URL derivative in, shared
+ * between each writer (CropsImageForAspectRatio, TikTokPhotoDerivativeCleaner)
+ * and the scheduled prune command (PruneSocialMediaDerivatives) so they
+ * cannot drift. Add a new network's directory here - nowhere else - when it
+ * starts hosting derivatives a platform fetches asynchronously.
+ */
+final class SocialMediaDerivativeDirectory
+{
+    public const string CROPS = 'social-crops';
+
+    public const string TIKTOK_PHOTOS = 'social-tiktok-photos';
+}

--- a/app/Support/Social/SocialMediaDerivativeDirectory.php
+++ b/app/Support/Social/SocialMediaDerivativeDirectory.php
@@ -16,4 +16,14 @@ final class SocialMediaDerivativeDirectory
     public const string CROPS = 'social-crops';
 
     public const string TIKTOK_PHOTOS = 'social-tiktok-photos';
+
+    /**
+     * Every directory a publisher hosts a pull-from-URL derivative in.
+     *
+     * @var list<string>
+     */
+    public const array ALL = [
+        self::CROPS,
+        self::TIKTOK_PHOTOS,
+    ];
 }

--- a/app/Support/Social/TikTokPhotoDerivativeCleaner.php
+++ b/app/Support/Social/TikTokPhotoDerivativeCleaner.php
@@ -11,7 +11,7 @@ use Throwable;
 
 class TikTokPhotoDerivativeCleaner
 {
-    public const string DIRECTORY = 'social-tiktok-photos';
+    public const string DIRECTORY = SocialMediaDerivativeDirectory::TIKTOK_PHOTOS;
 
     /**
      * @param  array<string, mixed>|null  $context

--- a/routes/console.php
+++ b/routes/console.php
@@ -11,6 +11,7 @@ use App\Console\Commands\CheckUpcomingPostConnections;
 use App\Console\Commands\ProcessScheduledPosts;
 use App\Console\Commands\RecoverStuckPosts;
 use App\Console\Commands\RefreshExpiringTokens;
+use App\Console\Commands\Social\PruneSocialMediaDerivatives;
 use Illuminate\Support\Facades\Schedule;
 
 Schedule::command(ProcessScheduledPosts::class)->everyMinute()->withoutOverlapping()->onOneServer();
@@ -22,3 +23,4 @@ Schedule::command(FireScheduleTriggers::class)->everyMinute()->withoutOverlappin
 Schedule::command(ProcessAutomationDelays::class)->everyMinute()->withoutOverlapping()->onOneServer();
 Schedule::command(RecoverStuckAutomationRuns::class)->everyFiveMinutes()->withoutOverlapping()->onOneServer();
 Schedule::command(PruneDryRunAutomationRuns::class)->everyTenMinutes()->withoutOverlapping()->onOneServer();
+Schedule::command(PruneSocialMediaDerivatives::class)->hourly()->withoutOverlapping()->onOneServer();

--- a/tests/Feature/Social/Command/PruneSocialMediaDerivativesTest.php
+++ b/tests/Feature/Social/Command/PruneSocialMediaDerivativesTest.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Support\Social\SocialMediaDerivativeDirectory;
+use Illuminate\Support\Facades\Storage;
+
+beforeEach(function () {
+    Storage::fake();
+});
+
+test('command deletes derivatives older than the pull window from every registered directory', function () {
+    $oldCrop = SocialMediaDerivativeDirectory::CROPS.'/old.jpg';
+    $oldTikTok = SocialMediaDerivativeDirectory::TIKTOK_PHOTOS.'/old.jpg';
+
+    Storage::put($oldCrop, 'fake-bytes');
+    Storage::put($oldTikTok, 'fake-bytes');
+    touch(Storage::path($oldCrop), now()->subHours(2)->getTimestamp());
+    touch(Storage::path($oldTikTok), now()->subHours(2)->getTimestamp());
+
+    $this->artisan('social:prune-derivatives')->assertExitCode(0);
+
+    Storage::assertMissing($oldCrop);
+    Storage::assertMissing($oldTikTok);
+});
+
+test('command leaves recent derivatives alone', function () {
+    $recent = SocialMediaDerivativeDirectory::CROPS.'/recent.jpg';
+
+    Storage::put($recent, 'fake-bytes');
+
+    $this->artisan('social:prune-derivatives')->assertExitCode(0);
+
+    Storage::assertExists($recent);
+});
+
+test('command is a no-op when no derivative directories exist yet', function () {
+    $this->artisan('social:prune-derivatives')->assertExitCode(0);
+});

--- a/tests/Feature/Social/Command/PruneSocialMediaDerivativesTest.php
+++ b/tests/Feature/Social/Command/PruneSocialMediaDerivativesTest.php
@@ -37,3 +37,18 @@ test('command leaves recent derivatives alone', function () {
 test('command is a no-op when no derivative directories exist yet', function () {
     $this->artisan('social:prune-derivatives')->assertExitCode(0);
 });
+
+test('--hours overrides the default retention window', function () {
+    $fortyMinutesOld = SocialMediaDerivativeDirectory::CROPS.'/forty-min.jpg';
+
+    Storage::put($fortyMinutesOld, 'fake-bytes');
+    touch(Storage::path($fortyMinutesOld), now()->subMinutes(40)->getTimestamp());
+
+    // Default 1h window leaves a 40-minute-old file alone.
+    $this->artisan('social:prune-derivatives')->assertExitCode(0);
+    Storage::assertExists($fortyMinutesOld);
+
+    // An explicit 0h window prunes the same file immediately.
+    $this->artisan('social:prune-derivatives', ['--hours' => 0])->assertExitCode(0);
+    Storage::assertMissing($fortyMinutesOld);
+});


### PR DESCRIPTION
## Summary

`social-crops/` (aspect-ratio crops and story-canvas fits, written by
`CropsImageForAspectRatio`) had no cleanup at all - every Instagram/Facebook
post with an aspect ratio leaves a JPEG on disk forever.

`social-tiktok-photos/` already has its own cleanup
(`TikTokPhotoDerivativeCleaner`), but it was added later (to fix a
resume/duplicate-publish issue) and is checkpoint-aware about in-flight
publishes - it's not a scheduled backstop, so a derivative that survives
a crash mid-publish has nothing else cleaning it up either.

## Changes

- New `social:prune-derivatives` command (scheduled hourly in
  `routes/console.php`) deletes files older than 1h - well past any
  platform's pull window - from every directory a publisher hosts a
  pull-from-URL derivative in.
- Directory names now live in one place -
  `App\Support\Social\SocialMediaDerivativeDirectory` - referenced by
  both writers (`CropsImageForAspectRatio`, `TikTokPhotoDerivativeCleaner`)
  and the new command, so a future network's directory is one line to
  add, not a hunt across publishers.

## What I intentionally left alone

The issue's task list said to remove the inline TikTok cleanup, citing
a timing risk if the status poll times out while TikTok is still
pulling the image. That's no longer accurate - since this issue was
filed, `TikTokPhotoDerivativeCleaner` was introduced with
`cleanupUnlessPublishInFlight()`, which checks a resumable publish
checkpoint before deleting anything. That's a real fix for the race,
and it runs immediately after publish (success or failure) rather than
waiting up to an hour, so removing it would be a regression, not a
cleanup. The scheduled prune here is a safety net alongside it (and
the only cleanup `social-crops/` has ever had), not a replacement.

## Test plan

- [x] New `tests/Feature/Social/Command/PruneSocialMediaDerivativesTest.php` (3 tests): prunes derivatives older than the window from both directories, leaves recent ones alone, no-ops when nothing exists yet
- [x] `php artisan test --compact tests/Feature/Social/Command/PruneSocialMediaDerivativesTest.php tests/Feature/Social tests/Unit/Support/Social` - 141 passed, no regressions in Instagram/Facebook (crop trait) or TikTok publisher tests
- [x] `vendor/bin/pint --dirty --format agent` - passed

Closes #121