### PR TITLE
feat: support Instagram collaborators on Reels, images, and carousels

### DIFF
--- a/app/Services/Social/InstagramPublisher.php
+++ b/app/Services/Social/InstagramPublisher.php
@@ -117,19 +117,21 @@ class InstagramPublisher
             $params['alt_text'] = $alt;
         }
 
-        $containerId = $this->createContainer($instagramId, $params, 'container');
+        $containerId = $this->createContainer($instagramId, $this->withCollaborators($params), 'container');
 
         return $this->finishContainer($instagramId, $accessToken, $containerId);
     }
 
     private function publishReel(string $instagramId, string $accessToken, ?string $content, $media): array
     {
-        $containerId = $this->createContainer($instagramId, [
+        $params = [
             'video_url' => $media->url,
             'caption' => $content,
             'media_type' => 'REELS',
             'access_token' => $accessToken,
-        ], 'reel container');
+        ];
+
+        $containerId = $this->createContainer($instagramId, $this->withCollaborators($params), 'reel container');
 
         return $this->finishContainer($instagramId, $accessToken, $containerId);
     }
@@ -233,12 +235,12 @@ class InstagramPublisher
             $this->waitForMediaProcessing($childId, $accessToken, $workflow);
         }
 
-        $carouselId = $this->createContainer($instagramId, [
+        $carouselId = $this->createContainer($instagramId, $this->withCollaborators([
             'media_type' => 'CAROUSEL',
             'caption' => $content,
             'children' => implode(',', $childContainers),
             'access_token' => $accessToken,
-        ], 'carousel container');
+        ]), 'carousel container');
 
         return $this->finishContainer($instagramId, $accessToken, $carouselId);
     }
@@ -475,6 +477,28 @@ class InstagramPublisher
             retryDelaySeconds: self::STATUS_RETRY_DELAY_SECONDS,
             maxRetries: self::STATUS_MAX_RETRIES,
         );
+    }
+
+    /**
+     * Adds the up-to-3 usernames invited as collaborators, when set. Applies
+     * to the container that actually gets published (single image, Reel, or
+     * the carousel's parent container) - Instagram does not accept it on
+     * Stories or on individual carousel child items.
+     *
+     * @param  array<string, mixed>  $parameters
+     * @return array<string, mixed>
+     */
+    private function withCollaborators(array $parameters): array
+    {
+        $collaborators = data_get($this->postPlatform->meta, 'collaborators');
+
+        if (empty($collaborators)) {
+            return $parameters;
+        }
+
+        $parameters['collaborators'] = json_encode(array_values($collaborators));
+
+        return $parameters;
     }
 
     /**

--- a/app/Support/PostPlatformMetaRules.php
+++ b/app/Support/PostPlatformMetaRules.php
@@ -45,6 +45,11 @@ class PostPlatformMetaRules
             // Instagram / Facebook
             'platforms.*.meta.aspect_ratio' => ['sometimes', 'nullable', 'string', Rule::enum(AspectRatio::class)],
 
+            // Instagram — up to 3 usernames invited as collaborators (Reels, single
+            // images, and carousels only; Instagram ignores this on Stories).
+            'platforms.*.meta.collaborators' => ['sometimes', 'nullable', 'array', 'max:3'],
+            'platforms.*.meta.collaborators.*' => ['string', 'max:30'],
+
             // LinkedIn — title shown on a document (PDF carousel) post
             'platforms.*.meta.document_title' => ['sometimes', 'nullable', 'string', 'max:300'],
 

--- a/tests/Feature/Api/PostApiPlatformMetaTest.php
+++ b/tests/Feature/Api/PostApiPlatformMetaTest.php
@@ -192,7 +192,7 @@ it('persists per-platform meta across networks on store', function () {
         ->postJson(route('api.posts.store'), [
             'content' => 'Cross-platform',
             'platforms' => [
-                ['social_account_id' => $instagram->id, 'content_type' => ContentType::InstagramFeed->value, 'meta' => ['aspect_ratio' => '4:5']],
+                ['social_account_id' => $instagram->id, 'content_type' => ContentType::InstagramFeed->value, 'meta' => ['aspect_ratio' => '4:5', 'collaborators' => ['alice', 'bob']]],
                 ['social_account_id' => $pinterest->id, 'content_type' => ContentType::PinterestPin->value, 'meta' => ['board_id' => 'board-99']],
                 ['social_account_id' => $tiktok->id, 'content_type' => ContentType::TikTokVideo->value, 'meta' => ['privacy_level' => 'SELF_ONLY', 'allow_comments' => true]],
             ],
@@ -200,9 +200,26 @@ it('persists per-platform meta across networks on store', function () {
         ->assertCreated();
 
     expect(PostPlatform::where('social_account_id', $instagram->id)->sole()->meta['aspect_ratio'])->toBe('4:5')
+        ->and(PostPlatform::where('social_account_id', $instagram->id)->sole()->meta['collaborators'])->toBe(['alice', 'bob'])
         ->and(PostPlatform::where('social_account_id', $pinterest->id)->sole()->meta['board_id'])->toBe('board-99')
         ->and(PostPlatform::where('social_account_id', $tiktok->id)->sole()->meta['privacy_level'])->toBe('SELF_ONLY')
         ->and(PostPlatform::where('social_account_id', $tiktok->id)->sole()->meta['allow_comments'])->toBeTrue();
+});
+
+it('rejects more than 3 instagram collaborators', function () {
+    $instagram = SocialAccount::factory()->create(['workspace_id' => $this->workspace->id, 'platform' => Platform::Instagram]);
+
+    $this->withHeaders($this->headers)
+        ->postJson(route('api.posts.store'), [
+            'content' => 'Too many collaborators',
+            'platforms' => [
+                ['social_account_id' => $instagram->id, 'content_type' => ContentType::InstagramFeed->value, 'meta' => [
+                    'collaborators' => ['alice', 'bob', 'carol', 'dave'],
+                ]],
+            ],
+        ])
+        ->assertUnprocessable()
+        ->assertJsonValidationErrors(['platforms.0.meta.collaborators']);
 });
 
 it('allows saving a Discord draft without a channel', function () {

--- a/tests/Feature/Mcp/PostPlatformMetaToolTest.php
+++ b/tests/Feature/Mcp/PostPlatformMetaToolTest.php
@@ -72,6 +72,41 @@ test('create post persists LinkedIn document_title meta', function () {
     expect(PostPlatform::where('social_account_id', $linkedin->id)->sole()->meta['document_title'])->toBe('Q2 Report');
 });
 
+test('create post persists Instagram collaborators meta', function () {
+    $instagram = SocialAccount::factory()->create(['workspace_id' => $this->workspace->id, 'platform' => Platform::Instagram]);
+
+    $response = TryPostServer::actingAs($this->user)
+        ->tool(CreatePostTool::class, [
+            'content' => 'On The Ground ep. 42',
+            'platforms' => [[
+                'social_account_id' => $instagram->id,
+                'content_type' => ContentType::InstagramReel->value,
+                'meta' => ['collaborators' => ['cohost_one', 'cohost_two']],
+            ]],
+        ]);
+
+    $response->assertOk();
+
+    expect(PostPlatform::where('social_account_id', $instagram->id)->sole()->meta['collaborators'])
+        ->toBe(['cohost_one', 'cohost_two']);
+});
+
+test('create post rejects more than 3 Instagram collaborators', function () {
+    $instagram = SocialAccount::factory()->create(['workspace_id' => $this->workspace->id, 'platform' => Platform::Instagram]);
+
+    $response = TryPostServer::actingAs($this->user)
+        ->tool(CreatePostTool::class, [
+            'content' => 'Too many collaborators',
+            'platforms' => [[
+                'social_account_id' => $instagram->id,
+                'content_type' => ContentType::InstagramReel->value,
+                'meta' => ['collaborators' => ['a', 'b', 'c', 'd']],
+            ]],
+        ]);
+
+    $response->assertHasErrors(['platforms.0.meta.collaborators']);
+});
+
 test('update post merges per-platform meta', function () {
     $post = Post::factory()->create([
         'workspace_id' => $this->workspace->id,

--- a/tests/Feature/Services/Social/InstagramPublisherTest.php
+++ b/tests/Feature/Services/Social/InstagramPublisherTest.php
@@ -145,6 +145,160 @@ test('instagram publisher can publish reel', function () {
     });
 });
 
+test('instagram publisher includes collaborators on a reel container', function () {
+    $this->postPlatform->update([
+        'content_type' => ContentType::InstagramReel,
+        'meta' => ['collaborators' => ['alice', 'bob']],
+    ]);
+
+    $this->post->update([
+        'media' => [[
+            'id' => 'test-media-video',
+            'path' => 'media/2026-01/test-video.mp4',
+            'url' => 'https://example.com/media/2026-01/test-video.mp4',
+            'mime_type' => 'video/mp4',
+            'original_filename' => 'test.mp4',
+        ]],
+    ]);
+
+    Http::fake([
+        'https://graph.instagram.com/v25.0/ig_123456789/media' => Http::response(['id' => 'container-123'], 200),
+        'https://graph.instagram.com/v25.0/container-123*' => Http::response(['status_code' => 'FINISHED'], 200),
+        'https://graph.instagram.com/v25.0/ig_123456789/media_publish' => Http::response(['id' => 'reel-123456789'], 200),
+        'https://graph.instagram.com/v25.0/reel-123456789*' => Http::response(['permalink' => 'https://www.instagram.com/reel/ABC123/'], 200),
+    ]);
+
+    $this->publisher->publish($this->postPlatform);
+
+    Http::assertSent(function ($request) {
+        return str_contains($request->url(), '/ig_123456789/media')
+            && ! str_contains($request->url(), 'media_publish')
+            && ($request['collaborators'] ?? null) === json_encode(['alice', 'bob']);
+    });
+});
+
+test('instagram publisher includes collaborators on a single-image container', function () {
+    $this->postPlatform->update(['meta' => ['collaborators' => ['alice']]]);
+
+    $this->post->update([
+        'media' => [[
+            'id' => 'test-media-id',
+            'path' => 'media/2026-01/test-image.jpg',
+            'url' => 'https://example.com/media/2026-01/test-image.jpg',
+            'mime_type' => 'image/jpeg',
+            'original_filename' => 'test.jpg',
+        ]],
+    ]);
+
+    Http::fake([
+        'https://graph.instagram.com/v25.0/ig_123456789/media' => Http::response(['id' => 'container-123'], 200),
+        'https://graph.instagram.com/v25.0/container-123*' => Http::response(['status_code' => 'FINISHED'], 200),
+        'https://graph.instagram.com/v25.0/ig_123456789/media_publish' => Http::response(['id' => 'media-123456789'], 200),
+        'https://graph.instagram.com/v25.0/media-123456789*' => Http::response(['permalink' => 'https://www.instagram.com/p/ABC123/'], 200),
+    ]);
+
+    $this->publisher->publish($this->postPlatform);
+
+    Http::assertSent(fn ($request) => ($request['collaborators'] ?? null) === json_encode(['alice']));
+});
+
+test('instagram publisher omits collaborators when none are set', function () {
+    $this->post->update([
+        'media' => [[
+            'id' => 'test-media-id',
+            'path' => 'media/2026-01/test-image.jpg',
+            'url' => 'https://example.com/media/2026-01/test-image.jpg',
+            'mime_type' => 'image/jpeg',
+            'original_filename' => 'test.jpg',
+        ]],
+    ]);
+
+    Http::fake([
+        'https://graph.instagram.com/v25.0/ig_123456789/media' => Http::response(['id' => 'container-123'], 200),
+        'https://graph.instagram.com/v25.0/container-123*' => Http::response(['status_code' => 'FINISHED'], 200),
+        'https://graph.instagram.com/v25.0/ig_123456789/media_publish' => Http::response(['id' => 'media-123456789'], 200),
+        'https://graph.instagram.com/v25.0/media-123456789*' => Http::response(['permalink' => 'https://www.instagram.com/p/ABC123/'], 200),
+    ]);
+
+    $this->publisher->publish($this->postPlatform);
+
+    Http::assertSent(fn ($request) => ! isset($request['collaborators']));
+});
+
+test('instagram publisher does not send collaborators on a story', function () {
+    Storage::fake();
+    $this->postPlatform->update([
+        'content_type' => ContentType::InstagramStory,
+        'meta' => ['collaborators' => ['alice']],
+    ]);
+
+    $this->post->update([
+        'media' => [[
+            'id' => 'test-media-video',
+            'path' => 'media/2026-01/test-video.mp4',
+            'url' => 'https://example.com/media/2026-01/test-video.mp4',
+            'mime_type' => 'video/mp4',
+            'original_filename' => 'test.mp4',
+        ]],
+    ]);
+
+    Http::fake([
+        'https://graph.instagram.com/v25.0/ig_123456789/media' => Http::response(['id' => 'container-123'], 200),
+        'https://graph.instagram.com/v25.0/container-123*' => Http::response(['status_code' => 'FINISHED'], 200),
+        'https://graph.instagram.com/v25.0/ig_123456789/media_publish' => Http::response(['id' => 'story-123456789'], 200),
+        'https://graph.instagram.com/v25.0/story-123456789*' => Http::response(['permalink' => 'https://www.instagram.com/stories/testuser/ABC123/'], 200),
+    ]);
+
+    $this->publisher->publish($this->postPlatform);
+
+    Http::assertSent(function ($request) {
+        return ! str_contains($request->url(), 'media_publish')
+            && ! isset($request['collaborators']);
+    });
+});
+
+test('instagram publisher puts collaborators only on the carousel parent container, not child items', function () {
+    $this->postPlatform->update(['meta' => ['collaborators' => ['alice', 'bob']]]);
+
+    $mediaItems = [];
+    for ($i = 0; $i < 2; $i++) {
+        $mediaItems[] = [
+            'id' => "test-media-{$i}",
+            'path' => "media/2026-01/test-image-{$i}.jpg",
+            'url' => "https://example.com/media/2026-01/test-image-{$i}.jpg",
+            'mime_type' => 'image/jpeg',
+            'original_filename' => "test-{$i}.jpg",
+        ];
+    }
+    $this->post->update(['media' => $mediaItems]);
+
+    Http::fake([
+        'https://graph.instagram.com/v25.0/ig_123456789/media' => Http::sequence()
+            ->push(['id' => 'child-1'], 200)
+            ->push(['id' => 'child-2'], 200)
+            ->push(['id' => 'carousel-container-123'], 200),
+        'https://graph.instagram.com/v25.0/carousel-container-123*' => Http::response(['status_code' => 'FINISHED'], 200),
+        'https://graph.instagram.com/v25.0/ig_123456789/media_publish' => Http::response(['id' => 'carousel-123456789'], 200),
+        'https://graph.instagram.com/v25.0/carousel-123456789*' => Http::response(['permalink' => 'https://www.instagram.com/p/CAROUSEL123/'], 200),
+    ]);
+
+    $this->publisher->publish($this->postPlatform);
+
+    $mediaCreationRequests = collect(Http::recorded())
+        ->map(fn ($pair) => $pair[0])
+        ->filter(fn ($request) => str_contains($request->url(), '/ig_123456789/media')
+            && ! str_contains($request->url(), 'media_publish'));
+
+    $childRequests = $mediaCreationRequests->filter(fn ($request) => isset($request['is_carousel_item']));
+    $parentRequests = $mediaCreationRequests->filter(fn ($request) => isset($request['children']));
+
+    expect($childRequests)->toHaveCount(2)
+        ->and($parentRequests)->toHaveCount(1);
+
+    expect($childRequests->every(fn ($request) => ! isset($request['collaborators'])))->toBeTrue();
+    expect($parentRequests->first()['collaborators'])->toBe(json_encode(['alice', 'bob']));
+});
+
 test('instagram publisher fits an image story to 9:16 and posts the hosted copy', function () {
     Storage::fake();
     $this->postPlatform->update(['content_type' => ContentType::InstagramStory]);

--- a/tests/Feature/Services/Social/InstagramPublisherTest.php
+++ b/tests/Feature/Services/Social/InstagramPublisherTest.php
@@ -222,7 +222,11 @@ test('instagram publisher omits collaborators when none are set', function () {
 
     $this->publisher->publish($this->postPlatform);
 
-    Http::assertSent(fn ($request) => ! isset($request['collaborators']));
+    Http::assertSent(function ($request) {
+        return str_contains($request->url(), '/ig_123456789/media')
+            && ! str_contains($request->url(), 'media_publish')
+            && ! isset($request['collaborators']);
+    });
 });
 
 test('instagram publisher does not send collaborators on a story', function () {
@@ -252,7 +256,8 @@ test('instagram publisher does not send collaborators on a story', function () {
     $this->publisher->publish($this->postPlatform);
 
     Http::assertSent(function ($request) {
-        return ! str_contains($request->url(), 'media_publish')
+        return str_contains($request->url(), '/ig_123456789/media')
+            && ! str_contains($request->url(), 'media_publish')
             && ! isset($request['collaborators']);
     });
 });

--- a/tests/Unit/PostPlatformMetaRulesTest.php
+++ b/tests/Unit/PostPlatformMetaRulesTest.php
@@ -24,6 +24,7 @@ test('shared meta rules still include non-pinterest platform fields', function (
 
     expect($rules)->toHaveKeys([
         'platforms.*.meta.aspect_ratio',
+        'platforms.*.meta.collaborators',
         'platforms.*.meta.privacy_level',
         'platforms.*.meta.board_id',
         'platforms.*.meta.channel_id',


### PR DESCRIPTION
## Summary

Instagram's Content Publishing API accepts a `collaborators` parameter
(up to 3 usernames) on media container creation. Without it, every Reel
published through TryPost needs a manual re-invite in the Instagram app
afterward - this covers the "smallest useful version" from the issue:
accept the field and pass it through to the container creation call.

## Changes

- `PostPlatformMetaRules::rules()`: `platforms.*.meta.collaborators`
  (array, max 3, each entry a string up to 30 chars - Instagram's
  username length cap), following the exact shape suggested in the
  issue.
- `InstagramPublisher`: a `withCollaborators()` helper adds the field
  (JSON-encoded, matching Meta's expected format and the existing
  `attached_media` JSON-encoding pattern in `FacebookPublisher`) to
  whichever container actually gets published - single image, Reel, or
  the carousel's **parent** container (not per-item children, which
  don't accept it). Reads straight from `$this->postPlatform->meta`
  (same as other instance state already on the class) rather than
  threading a new parameter through every method, which also means it
  survives a carousel publish that resumes after an interruption - the
  parent container isn't created until the resume completes.
- `publishStory()` is untouched - Instagram doesn't support collaborators
  on Stories, so it's simply never added there.

## What I intentionally left out

- **Composer UI**: the issue's suggested scope includes surfacing this
  in the web composer next to Pinterest's board picker etc. I didn't
  add it - it would be the first real usage of the `TagsInput` UI
  primitive in this app (everywhere else that needs an array-of-strings
  input, like Discord mentions, uses a server-side autocomplete instead),
  and I don't have a way to verify it renders/behaves correctly in a
  browser in this environment. Shipping an unverified new UI pattern
  felt riskier than leaving it for a follow-up where someone can
  actually click through it. The feature is fully usable today via the
  public API and MCP tools.
- **Error-code mapping**: the issue suggests mapping a specific Instagram
  error (invalid/private collaborator username) to a friendlier message
  in `InstagramPublishException`. I didn't add a guessed `error_subcode`
  entry - the existing fallback already surfaces Meta's own
  `error_user_msg` when present, and I'd rather not fabricate an
  unconfirmed code mapping (this table is built from Meta's official
  error-code docs, not guesses).
- **Status-check endpoint** (invite Accepted/Pending/Declined): explicitly
  called out in the issue as a v2 follow-up, not needed here.
- **Docs site** (docs.trypost.it): out of scope for this repo.

## Test plan

- [x] `tests/Feature/Services/Social/InstagramPublisherTest.php` - 5 new tests: collaborators on a reel container, on a single-image container, omitted when unset, never sent on a story, and present only on the carousel's parent container (not child items)
- [x] `tests/Unit/PostPlatformMetaRulesTest.php`, `tests/Feature/Api/PostApiPlatformMetaTest.php`, `tests/Feature/Mcp/PostPlatformMetaToolTest.php` - rule presence, cross-platform persistence (API), and MCP create-post coverage, plus a max-3 rejection test in each entry point
- [x] `php artisan test --compact tests/Unit/PostPlatformMetaRulesTest.php tests/Feature/Api/PostApiPlatformMetaTest.php tests/Feature/Mcp/PostPlatformMetaToolTest.php tests/Feature/Services/Social/InstagramPublisherTest.php` - 105 passed
- [x] `vendor/bin/pint --dirty --format agent` - passed

Addresses #213 (validation + publisher; composer UI and error-message mapping left as follow-ups per above)