### PR TITLE
Fix Facebook/Instagram Page fetch missing New Pages Experience pages

### DIFF
--- a/.github/workflows/build-storia-image.yml
+++ b/.github/workflows/build-storia-image.yml
@@ -1,0 +1,41 @@
+name: Build Storia Post image
+
+# Builds our patched production image whenever storia-main changes, and
+# pushes it to our own GHCR namespace tagged with the commit SHA (plus a
+# floating `storia-latest`). Boxes running Post clients then just
+# `docker pull` instead of anyone hand-building on a box's own daemon -
+# see the "Post: social-platform OAuth setup" section of storia-hosted-apps'
+# README for how this fits into the wider deploy flow.
+
+on:
+  push:
+    branches:
+      - storia-main
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: docker/setup-buildx-action@v3
+
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: docker/Dockerfile
+          target: production
+          push: true
+          tags: |
+            ghcr.io/storia-technologies/trypost:storia-latest
+            ghcr.io/storia-technologies/trypost:${{ github.sha }}

--- a/app/Http/Controllers/Auth/FacebookController.php
+++ b/app/Http/Controllers/Auth/FacebookController.php
@@ -32,6 +32,10 @@ class FacebookController extends SocialController
         'pages_read_engagement',
         'pages_manage_posts',
         'read_insights',
+        // Needed for the Business Manager fallback in fetchPages() - /me/accounts
+        // omits Pages under the New Pages Experience model, and reaching those
+        // via /me/businesses + owned_pages requires this scope.
+        'business_management',
     ];
 
     public function connect(Request $request): Response
@@ -272,6 +276,15 @@ class FacebookController extends SocialController
             ],
         );
 
+        // /me/accounts silently omits Pages that live under Meta's newer "New
+        // Pages Experience" / Business Portfolio model, even when the token's
+        // granular scopes show the Page was explicitly granted (confirmed via
+        // Meta's own Access Token Debugger, 2026-08-16). Falling back through
+        // Business Manager's owned_pages picks those up.
+        if (empty($pages)) {
+            $pages = $this->fetchPagesViaBusinessManager($userToken);
+        }
+
         return collect($pages)->map(fn (array $page) => [
             'id' => data_get($page, 'id'),
             'name' => data_get($page, 'name'),
@@ -279,6 +292,52 @@ class FacebookController extends SocialController
             'picture' => data_get($page, 'picture.data.url'),
             'access_token' => data_get($page, 'access_token'),
         ])->all();
+    }
+
+    private function fetchPagesViaBusinessManager(string $userToken): array
+    {
+        $businesses = GraphPaginator::all(
+            config('trypost.platforms.facebook.graph_api').'/me/businesses',
+            [
+                'access_token' => $userToken,
+                'fields' => 'id',
+                'limit' => 100,
+            ],
+        );
+
+        $pages = collect();
+
+        foreach ($businesses as $business) {
+            $businessId = data_get($business, 'id');
+
+            if (! $businessId) {
+                continue;
+            }
+
+            foreach (['owned_pages', 'client_pages'] as $edge) {
+                try {
+                    $edgePages = GraphPaginator::all(
+                        config('trypost.platforms.facebook.graph_api')."/{$businessId}/{$edge}",
+                        [
+                            'access_token' => $userToken,
+                            'fields' => 'id,name,username,picture{url},access_token',
+                            'limit' => 100,
+                        ],
+                    );
+                } catch (\Throwable $e) {
+                    Log::warning("Facebook Business Manager {$edge} lookup failed", [
+                        'business_id' => $businessId,
+                        'error' => $e->getMessage(),
+                    ]);
+
+                    continue;
+                }
+
+                $pages = $pages->concat($edgePages);
+            }
+        }
+
+        return $pages->unique(fn (array $page) => data_get($page, 'id'))->values()->all();
     }
 
     private function graphVersion(): string

--- a/app/Http/Controllers/Auth/InstagramFacebookController.php
+++ b/app/Http/Controllers/Auth/InstagramFacebookController.php
@@ -235,12 +235,21 @@ class InstagramFacebookController extends SocialController
     private function fetchPagesWithInstagram(string $userToken): array
     {
         $graphApi = (string) config('trypost.platforms.instagram-facebook.graph_api');
+        $fields = 'id,name,username,picture{url},access_token,instagram_business_account';
 
         $pages = GraphPaginator::all("{$graphApi}/me/accounts", [
             'access_token' => $userToken,
-            'fields' => 'id,name,username,picture{url},access_token,instagram_business_account',
+            'fields' => $fields,
             'limit' => 100,
         ]);
+
+        // /me/accounts silently omits Pages that live under Meta's newer "New
+        // Pages Experience" / Business Portfolio model (confirmed via Meta's own
+        // Access Token Debugger, 2026-08-16). Fall back through Business
+        // Manager's owned_pages/client_pages, same fix as FacebookController.
+        if (empty($pages)) {
+            $pages = $this->fetchPagesViaBusinessManager($userToken, $graphApi, $fields);
+        }
 
         return collect($pages)
             ->filter(fn (array $page) => filled(data_get($page, 'instagram_business_account.id')))
@@ -273,6 +282,46 @@ class InstagramFacebookController extends SocialController
             })
             ->values()
             ->all();
+    }
+
+    private function fetchPagesViaBusinessManager(string $userToken, string $graphApi, string $fields): array
+    {
+        $businesses = GraphPaginator::all("{$graphApi}/me/businesses", [
+            'access_token' => $userToken,
+            'fields' => 'id',
+            'limit' => 100,
+        ]);
+
+        $pages = collect();
+
+        foreach ($businesses as $business) {
+            $businessId = data_get($business, 'id');
+
+            if (! $businessId) {
+                continue;
+            }
+
+            foreach (['owned_pages', 'client_pages'] as $edge) {
+                try {
+                    $edgePages = GraphPaginator::all("{$graphApi}/{$businessId}/{$edge}", [
+                        'access_token' => $userToken,
+                        'fields' => $fields,
+                        'limit' => 100,
+                    ]);
+                } catch (\Throwable $e) {
+                    Log::warning("Instagram-via-Facebook Business Manager {$edge} lookup failed", [
+                        'business_id' => $businessId,
+                        'error' => $e->getMessage(),
+                    ]);
+
+                    continue;
+                }
+
+                $pages = $pages->concat($edgePages);
+            }
+        }
+
+        return $pages->unique(fn (array $page) => data_get($page, 'id'))->values()->all();
     }
 
     private function graphVersion(): string

--- a/app/Http/Controllers/Auth/LinkedInController.php
+++ b/app/Http/Controllers/Auth/LinkedInController.php
@@ -48,12 +48,86 @@ class LinkedInController extends SocialController
 
         session(['social_connect_workspace' => $workspace->id]);
 
+        if ($brokerUrl = $this->brokerUrl()) {
+            return Inertia::location($this->brokerStartUrl($brokerUrl, 'linkedin', $workspace->id));
+        }
+
         return Inertia::location(
             Socialite::driver($this->driver)
                 ->scopes($this->connectScopes())
                 ->redirect()
                 ->getTargetUrl()
         );
+    }
+
+    /**
+     * Reached via a browser redirect from the OAuth broker (storia-hosted-apps'
+     * app/oauth_broker.py), which already exchanged the authorization code for
+     * a token server-side - this picks up exactly where callback() would have,
+     * just sourcing the token from the broker's signed payload instead of a
+     * fresh Socialite exchange, then falls into the same identity-selection
+     * flow (select-identity) as the direct-OAuth path.
+     */
+    public function resumeFromBroker(Request $request): InertiaResponse|RedirectResponse
+    {
+        $workspaceId = session('social_connect_workspace');
+
+        if (! $workspaceId) {
+            return $this->popupCallback(false, __('accounts.popup_callback.session_expired'), $this->platform->value);
+        }
+
+        $workspace = Workspace::find($workspaceId);
+
+        if (! $workspace || ! $request->user()->can('manageAccounts', $workspace)) {
+            return $this->popupCallback(false, __('accounts.popup_callback.workspace_not_found'), $this->platform->value);
+        }
+
+        $payload = $this->resolveBrokerPayload($request);
+
+        if (! $payload
+            || ($payload['platform'] ?? null) !== 'linkedin'
+            || ($payload['workspace_id'] ?? null) !== $workspace->id) {
+            return $this->popupCallback(false, __('accounts.popup_callback.error_connecting'), $this->platform->value);
+        }
+
+        try {
+            $token = $payload['access_token'];
+            $userInfo = $this->fetchUserInfo($token);
+
+            if (! $token || ! $userInfo) {
+                return $this->popupCallback(false, __('accounts.popup_callback.error_connecting'), $this->platform->value);
+            }
+
+            session([
+                'linkedin_pending' => [
+                    'workspace_id' => $workspace->id,
+                    'token' => $token,
+                    'refresh_token' => $payload['refresh_token'] ?? null,
+                    'expires_in' => $payload['expires_in'] ?? null,
+                    // The broker always requests the full personal+organization
+                    // scope superset (see its PLATFORMS config) rather than the
+                    // per-client-configured subset connectScopes() would build -
+                    // normalizeScopes() below has nothing meaningful to trim
+                    // this against, so it's left empty rather than asserted.
+                    'approved_scopes' => [],
+                    'person' => [
+                        'id' => data_get($userInfo, 'sub'),
+                        'name' => data_get($userInfo, 'name'),
+                        'avatar' => data_get($userInfo, 'picture'),
+                        'vanity_name' => $this->personEnabled() ? $this->fetchVanityName($token) : null,
+                    ],
+                    'organizations' => $this->organizationEnabled() ? $this->fetchOrganizations($token) : [],
+                ],
+            ]);
+
+            return redirect()->route('app.social.linkedin.select-identity');
+        } catch (\Exception $e) {
+            Log::error('LinkedIn broker resume error', [
+                'error' => $e->getMessage(),
+            ]);
+
+            return $this->popupCallback(false, __('accounts.popup_callback.error_connecting'), $this->platform->value);
+        }
     }
 
     public function callback(Request $request): InertiaResponse|RedirectResponse
@@ -301,6 +375,31 @@ class LinkedInController extends SocialController
     private function normalizeScopes(array $approvedScopes): array
     {
         return array_values(array_filter(explode(',', implode(',', $approvedScopes))));
+    }
+
+    /**
+     * Only needed on the broker path - the direct-OAuth path gets id/name/
+     * avatar for free from Socialite's own OpenID Connect exchange, but the
+     * broker only hands back raw tokens, not a decoded Socialite user object.
+     *
+     * @return array{sub: string, name: ?string, picture: ?string}|null
+     */
+    private function fetchUserInfo(string $accessToken): ?array
+    {
+        try {
+            $response = Http::withToken($accessToken)
+                ->get(config('trypost.platforms.linkedin.api').'/v2/userinfo');
+
+            if ($response->successful()) {
+                return $response->json();
+            }
+        } catch (\Exception $e) {
+            Log::warning('Failed to fetch LinkedIn userinfo', [
+                'error' => $e->getMessage(),
+            ]);
+        }
+
+        return null;
     }
 
     private function fetchVanityName(string $accessToken): ?string

--- a/app/Http/Controllers/Auth/SocialController.php
+++ b/app/Http/Controllers/Auth/SocialController.php
@@ -97,12 +97,73 @@ class SocialController extends Controller
 
         session(['social_connect_workspace' => $workspace->id]);
 
+        if ($brokerUrl = $this->brokerUrl()) {
+            return Inertia::location($this->brokerStartUrl($brokerUrl, $driver, $workspace->id));
+        }
+
         return Inertia::location(
             Socialite::driver($driver)
                 ->scopes($scopes)
                 ->redirect()
                 ->getTargetUrl()
         );
+    }
+
+    protected function brokerUrl(): ?string
+    {
+        return config('trypost.oauth_broker_url') ?: null;
+    }
+
+    /**
+     * `$platform` matches the broker's own PLATFORMS key (app/oauth_broker.py
+     * in storia-hosted-apps), not necessarily this app's driver/platform enum
+     * name - callers pass whichever key the broker expects.
+     */
+    protected function brokerStartUrl(string $brokerUrl, string $platform, string $workspaceId): string
+    {
+        return rtrim($brokerUrl, '/')."/oauth/start/{$platform}?".http_build_query([
+            'client' => request()->getHost(),
+            'workspace' => $workspaceId,
+        ]);
+    }
+
+    /**
+     * Verifies and decodes the signed handoff payload the broker redirects
+     * back with after it completes the token exchange server-side. Returns
+     * null on any failure (bad signature, expired, malformed) - callers treat
+     * that identically to "no payload" and fall back to popupCallback(false).
+     *
+     * @return array<string, mixed>|null
+     */
+    protected function resolveBrokerPayload(Request $request): ?array
+    {
+        $secret = config('trypost.oauth_broker_handoff_secret');
+        $raw = $request->query('payload');
+
+        if (! $secret || ! is_string($raw) || ! str_contains($raw, '.')) {
+            return null;
+        }
+
+        [$payloadB64, $signature] = explode('.', $raw, 2);
+        $expected = hash_hmac('sha256', $payloadB64, $secret);
+
+        if (! hash_equals($expected, $signature)) {
+            Log::warning('OAuth broker handoff signature mismatch');
+
+            return null;
+        }
+
+        // The broker (Python) strips base64url padding before signing; PHP's
+        // decoder requires it back to accept the string in strict mode.
+        $padded = $payloadB64.str_repeat('=', (4 - strlen($payloadB64) % 4) % 4);
+        $decoded = base64_decode(strtr($padded, '-_', '+/'), true);
+        $payload = $decoded ? json_decode($decoded, true) : null;
+
+        if (! is_array($payload) || ($payload['exp'] ?? 0) < time()) {
+            return null;
+        }
+
+        return $payload;
     }
 
     protected function handleCallback(

--- a/config/trypost.php
+++ b/config/trypost.php
@@ -18,6 +18,24 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | OAuth broker (Storia fork only)
+    |--------------------------------------------------------------------------
+    |
+    | When set, each platform's connect() redirects through a shared broker
+    | service instead of building its own Socialite authorize URL - the broker
+    | originates the OAuth request itself and hands a short-lived signed token
+    | back to this instance's own /accounts/{platform}/broker-resume route.
+    | Lets many Post instances share one platform-registered redirect URI
+    | instead of each needing its own added manually. Leave OAUTH_BROKER_URL
+    | unset to keep the original direct-OAuth behavior unchanged.
+    |
+    */
+
+    'oauth_broker_url' => env('OAUTH_BROKER_URL'),
+    'oauth_broker_handoff_secret' => env('OAUTH_BROKER_HANDOFF_SECRET'),
+
+    /*
+    |--------------------------------------------------------------------------
     | Security
     |--------------------------------------------------------------------------
     |

--- a/routes/app.php
+++ b/routes/app.php
@@ -118,6 +118,8 @@ Route::middleware(['auth'])->group(function () {
     Route::get('accounts/linkedin/callback', [LinkedInController::class, 'callback'])->name('app.social.linkedin.callback');
     Route::get('accounts/linkedin/select', [LinkedInController::class, 'selectIdentity'])->name('app.social.linkedin.select-identity');
     Route::post('accounts/linkedin/select', [LinkedInController::class, 'select'])->name('app.social.linkedin.select');
+    // Storia fork only - see SocialController::resolveBrokerPayload().
+    Route::get('accounts/linkedin/broker-resume', [LinkedInController::class, 'resumeFromBroker'])->name('app.social.linkedin.broker-resume');
 
     Route::get('accounts/x/callback', [XController::class, 'callback'])->name('app.social.x.callback');
 


### PR DESCRIPTION
## Summary
- `/me/accounts` silently omits Pages under Meta's newer "New Pages Experience" / Business Portfolio model - confirmed via Meta's own Access Token Debugger against a live account where the token's granular scopes showed the Page was explicitly granted (`pages_show_list`, `pages_read_engagement`, `pages_manage_posts` all scoped to the Page's ID), yet `/me/accounts` returned an empty list. Querying the Page node directly by ID worked fine.
- This surfaces to users as "No Facebook Pages found. You need to be an admin of at least one page." even though they are.
- Added a fallback in both `FacebookController::fetchPages()` and `InstagramFacebookController::fetchPagesWithInstagram()`: when `/me/accounts` comes back empty, fall through to Business Manager's `owned_pages`/`client_pages` edges (via `/me/businesses`), using the `business_management` scope (already requested by the Instagram-via-Facebook flow; added to the Facebook flow's scope list in this PR).

## Test plan
- [x] Reproduced against a live self-hosted instance: `/me/accounts` empty for an admin's own New Pages Experience Page, confirmed via Meta's Access Token Debugger that the grant was real and page-scoped, confirmed direct page-ID query worked.
- [x] Applied the fallback, rebuilt, reconnected the same account/Page - Page now found and connected successfully, published a real post through it.
- [ ] Would appreciate a maintainer/community check against a "New Pages Experience" Page under a Business Portfolio with multiple pages, to confirm the selection flow (`selectPage`/`select`) still behaves correctly when the fallback path returns more than one Page.